### PR TITLE
Add Allowed and Optional options.

### DIFF
--- a/pkg/shipshape/types.go
+++ b/pkg/shipshape/types.go
@@ -88,14 +88,16 @@ const (
 )
 
 // KeyValue represents a check to be made against Yaml data.
-// It can be a simple Key=Value check, or it can be a Key in DisallowedList
-// check, in which case IsList needs to be true, and a Disallowed list of values
-// is required.
+// It can be a simple Key=Value check, or it check Keys in Disallowed or
+// Allowed lists accordingly. If the source is a list then IsList must be true.
+// If Optional is set then the validation will not fail if the key is not present.
 type KeyValue struct {
 	Key        string   `yaml:"key"`
 	Value      string   `yaml:"value"`
 	IsList     bool     `yaml:"is-list"`
+	Optional   bool     `yaml:"optional"`
 	Disallowed []string `yaml:"disallowed"`
+	Allowed    []string `yaml:"allowed"`
 }
 
 // KeyValueResult represents the different outcomes of the KeyValue check.

--- a/pkg/shipshape/yaml_test.go
+++ b/pkg/shipshape/yaml_test.go
@@ -133,6 +133,19 @@ foo:
 	if kvr != shipshape.KeyValueEqual {
 		t.Errorf("result should be KeyValueEqual(1), got %d", kvr)
 	}
+
+	// Optional value not present.
+	kvr, _, err = c.CheckKeyValue(shipshape.KeyValue{
+		Key:   "foo.bar[0].bazzle",
+		Value: "zoom",
+		Optional: true,
+	}, "data")
+	if err != nil {
+		t.Error("missing optional value should not fail")
+	}
+	if kvr != shipshape.KeyValueEqual {
+		t.Errorf("result should be KeyValueEqual(1), got %d", kvr)
+	}
 }
 
 func TestYamlCheckKeyValueList(t *testing.T) {
@@ -191,6 +204,33 @@ foo:
 	}
 	if len(fails) > 0 {
 		t.Errorf("There should be no Failures, got %+v", fails)
+	}
+
+	// Allowed values in yaml all match.
+	kvr, fails, _ = c.CheckKeyValue(shipshape.KeyValue{
+		Key:        "foo.bar",
+		IsList:     true,
+		Allowed: []string{"baz", "zoo", "zoom"},
+	}, "data")
+	if kvr != shipshape.KeyValueEqual {
+		t.Errorf("result should be KeyValueEqual(1), got %d", kvr)
+	}
+	if len(fails) > 0 {
+		t.Errorf("There should be no Failures, got %+v", fails)
+	}
+
+	// Value not in Allowed list.
+	kvr, fails, _ = c.CheckKeyValue(shipshape.KeyValue{
+		Key:        "foo.bar",
+		IsList:     true,
+		Allowed: []string{"baz", "zoo"},
+	}, "data")
+	if kvr != shipshape.KeyValueDisallowedFound {
+		t.Errorf("result should be KeyValueDisallowedFound(-2), got %d", kvr)
+	}
+	expectedAllowedFails := []string{"zoom"}
+	if len(fails) != 1 || !reflect.DeepEqual(fails, expectedAllowedFails) {
+		t.Errorf("There should be exactly 1 Failure, with values %+v, got %+v", expectedAllowedFails, fails)
 	}
 
 }


### PR DESCRIPTION
Small change but provides a large amount of flexibility, e.g allows for the following use cases:

1. Check `docker-compose.yml` for expected, mandatory services & lagoon types
```
    - name: '[FILE] Validate services have expected lagoon type'
      file: docker-compose.yml
      ignore-missing: false
      path: .
      values:
        - key: services.cli.labels['lagoon.type']
          value: cli-persistent
        - key: services.test.labels['lagoon.type']
          value: none
        - key: services.nginx.labels['lagoon.type']
          value: nginx-php-persistent
        - key: services.php.labels['lagoon.type']
          value: nginx-php-persistent
        - key: services.mariadb.labels['lagoon.type']
          value: mariadb
```

2. Check `docker-compose.yml` if optional service (solr) has the expected lagoon.type. Ignore if the key is not present.
```
    - name: '[FILE] Validate optional services have expected lagoon type'
      file: docker-compose.yml
      ignore-missing: false
      path: .
      values:
        - key: services.solr.labels['lagoon.type']
          value: solr
          optional: true
```
3. Validate all services in `docker-compose.yml ` are present in the Allow list
```
    - name: '[FILE] Validate services are all of an allowed type'
      file: docker-compose.yml
      ignore-missing: false
      path: .
      values:
        - key: services.*.labels['lagoon.type']
          allowed:
            - none
            - cli-persistent
            - nginx-php-persistent
            - mariadb
            - solr
```

4. Validate no additional services are defined in `docker-compose.yml` outside the expected allow list
```
    - name: '[FILE] Validate service names are all expected'
      file: docker-compose.yml
      ignore-missing: false
      path: .
      values:
        - key: services
          is-list: true
          allowed:
            - cli
            - test
            - nginx
            - php
            - mariadb
            - solr
            - chrome
```

The first option is already possible, the rest require this change. No tests yet.