### PR TITLE
[WIP] Add support for globbing with multiple sub-directories

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/golang/protobuf v1.3.1 // indirect
 	github.com/kennygrant/sanitize v1.2.4 // indirect
+	github.com/mattn/go-zglob v0.0.3 // indirect
 	github.com/minio/selfupdate v0.4.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/saintfish/chardet v0.0.0-20120816061221-3af4cd4741ca // indirect

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/kennygrant/sanitize v1.2.4/go.mod h1:LGsjYYtgxbetdg5owWB2mpgUL6e2nfw2
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/mattn/go-zglob v0.0.3 h1:6Ry4EYsScDyt5di4OI6xw1bYhOqfE5S33Z1OPy+d+To=
+github.com/mattn/go-zglob v0.0.3/go.mod h1:9fxibJccNxU2cnpIKLRRFA7zX7qhkJIQWBb449FYHOo=
 github.com/minio/selfupdate v0.4.0 h1:A7t07pN4Ch1tBTIRStW0KhUVyykz+2muCqFsITQeEW8=
 github.com/minio/selfupdate v0.4.0/go.mod h1:mcDkzMgq8PRcpCRJo/NlPY7U45O5dfYl2Y0Rg7IustY=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/pkg/shipshape/testdata/yaml/dir/foo.bar.yml
+++ b/pkg/shipshape/testdata/yaml/dir/foo.bar.yml
@@ -1,0 +1,2 @@
+check:
+  interval_days: 7

--- a/pkg/shipshape/testdata/yaml/dir/subdir/foo.bar.yml
+++ b/pkg/shipshape/testdata/yaml/dir/subdir/foo.bar.yml
@@ -1,0 +1,2 @@
+check:
+  interval_days: 7

--- a/pkg/shipshape/testdata/yaml/dir/subdir/zoom.bar.yml
+++ b/pkg/shipshape/testdata/yaml/dir/subdir/zoom.bar.yml
@@ -1,0 +1,2 @@
+check:
+  interval_days: 5

--- a/pkg/shipshape/testdata/yaml/dir/zoom.bar.yml
+++ b/pkg/shipshape/testdata/yaml/dir/zoom.bar.yml
@@ -1,0 +1,2 @@
+check:
+  interval_days: 5

--- a/pkg/shipshape/yaml.go
+++ b/pkg/shipshape/yaml.go
@@ -190,7 +190,7 @@ func (c *YamlCheck) FetchData() {
 			c.readFile(filepath.Join(c.Path, f), filepath.Join(ProjectDir, c.Path, f))
 		}
 	} else if c.Pattern != "" {
-		configPath := filepath.Join(c.Pattern, c.Path)
+		configPath := filepath.Join(c.Path, c.Pattern)
 		files, err := zglob.Glob(configPath)
 		if err != nil {
 			// No failure if missing path and ignoring missing.
@@ -229,8 +229,7 @@ func (c *YamlCheck) FetchData() {
 
 		c.DataMap = map[string][]byte{}
 		for _, fname := range files {
-			_, file := filepath.Split(fname)
-			c.readFile(filepath.Join(c.Path, file), fname)
+			c.readFile(fname, fname)
 		}
 	} else {
 		c.AddFail("no file provided")

--- a/pkg/shipshape/yaml_test.go
+++ b/pkg/shipshape/yaml_test.go
@@ -516,18 +516,23 @@ func TestYamlCheck(t *testing.T) {
 		t.Error(msg)
 	}
 
-	// Bad File pattern.
+	// File pattern with recursive depth.
 	c = mockCheck()
-	c.Pattern = "*.bar.yml"
+	c.Pattern = "**/*.bar.yml"
 	c.Path = ""
 	c.FetchData()
-	if _, ok := internal.EnsureFail(t, &c.CheckBase); !ok {
-		t.Error("Check with bad file pattern should fail")
+	if c.Result.Status == shipshape.Fail {
+		t.Error("Check should not Fail yet")
 	}
-	if msg, ok := internal.EnsurePasses(t, &c.CheckBase, []string(nil)); !ok {
+	if len(c.Result.Failures) > 0 {
+		t.Errorf("there should be no Failure, got: %#v", c.Result.Failures)
+	}
+	c.UnmarshalDataMap()
+	c.RunCheck()
+	if msg, ok := internal.EnsurePasses(t, &c.CheckBase, []string{"[testdata/yaml/foo.bar.yml] 'check.interval_days' equals '7'", "[testdata/yaml/dir/foo.bar.yml] 'check.interval_days' equals '7'", "[testdata/yaml/dir/subdir/foo.bar.yml] 'check.interval_days' equals '7'"}); !ok {
 		t.Error(msg)
 	}
-	if msg, ok := internal.EnsureFailures(t, &c.CheckBase, []string{"error parsing regexp: missing argument to repetition operator: `*`"}); !ok {
+	if msg, ok := internal.EnsureFailures(t, &c.CheckBase, []string{"[testdata/yaml/zoom.bar.yml] 'check.interval_days' equals '5'", "[testdata/yaml/dir/zoom.bar.yml] 'check.interval_days' equals '5'", "[testdata/yaml/dir/subdir/zoom.bar.yml] 'check.interval_days' equals '5'"}); !ok {
 		t.Error(msg)
 	}
 
@@ -541,7 +546,7 @@ func TestYamlCheck(t *testing.T) {
 	if msg, ok := internal.EnsurePasses(t, &c.CheckBase, []string(nil)); !ok {
 		t.Error(msg)
 	}
-	if msg, ok := internal.EnsureFailures(t, &c.CheckBase, []string{"no matching config files found"}); !ok {
+	if msg, ok := internal.EnsureFailures(t, &c.CheckBase, []string{"no matching files found"}); !ok {
 		t.Error(msg)
 	}
 
@@ -556,13 +561,14 @@ func TestYamlCheck(t *testing.T) {
 	if msg, ok := internal.EnsureFailures(t, &c.CheckBase, []string(nil)); !ok {
 		t.Error(msg)
 	}
-	if msg, ok := internal.EnsurePasses(t, &c.CheckBase, []string{"no matching config files found"}); !ok {
+	if msg, ok := internal.EnsurePasses(t, &c.CheckBase, []string{"no matching files found"}); !ok {
 		t.Error(msg)
 	}
 
 	// Correct file pattern.
 	c = mockCheck()
-	c.Pattern = ".*.bar.yml"
+	c.Pattern = "*.bar.yml"
+	c.Path = "testdata/yaml"
 	c.FetchData()
 	if c.Result.Status == shipshape.Fail {
 		t.Error("Check should not Fail yet")
@@ -575,10 +581,10 @@ func TestYamlCheck(t *testing.T) {
 	if msg, ok := internal.EnsureFail(t, &c.CheckBase); !ok {
 		t.Error(msg)
 	}
-	if msg, ok := internal.EnsurePasses(t, &c.CheckBase, []string{"[yaml/foo.bar.yml] 'check.interval_days' equals '7'"}); !ok {
+	if msg, ok := internal.EnsurePasses(t, &c.CheckBase, []string{"[testdata/yaml/foo.bar.yml] 'check.interval_days' equals '7'"}); !ok {
 		t.Error(msg)
 	}
-	if msg, ok := internal.EnsureFailures(t, &c.CheckBase, []string{"[yaml/zoom.bar.yml] 'check.interval_days' equals '5'"}); !ok {
+	if msg, ok := internal.EnsureFailures(t, &c.CheckBase, []string{"[testdata/yaml/zoom.bar.yml] 'check.interval_days' equals '5'"}); !ok {
 		t.Error(msg)
 	}
 }


### PR DESCRIPTION
This adds support for more advanced globbing via `pattern`.

Namely it allows us to use `**` wildcard for finding within deep subdirectories.

Example use case to find any `*.info.yml` file in all sub-directories and validate a key/value pair:
```
    - name: '[FILE] Detect module files in theme folder'
      pattern: 'themes/**/*.info.yml'
      ignore-missing: true
      path: .
      values:
        - key: type
          value: theme
```