### PR TITLE
Split tests by single & recursive file lookup.

### DIFF
--- a/internal/test_utils.go
+++ b/internal/test_utils.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"strconv"
 	"testing"
+	"sort"
 
 	"github.com/salsadigitalauorg/shipshape/pkg/shipshape"
 )
@@ -75,6 +76,8 @@ func EnsurePass(t *testing.T, c *shipshape.CheckBase) (msg string, ok bool) {
 
 func EnsureFailures(t *testing.T, c *shipshape.CheckBase, expectedFailures []string) (msg string, ok bool) {
 	numExpectedFailures := len(expectedFailures)
+	sort.Strings(expectedFailures)
+	sort.Strings(c.Result.Failures)
 	if len(c.Result.Failures) != numExpectedFailures || !reflect.DeepEqual(expectedFailures, c.Result.Failures) {
 		return fmt.Sprintf("there should be exactly %d Failure(s), got %#v", numExpectedFailures, c.Result.Failures), false
 	}
@@ -83,6 +86,8 @@ func EnsureFailures(t *testing.T, c *shipshape.CheckBase, expectedFailures []str
 
 func EnsurePasses(t *testing.T, c *shipshape.CheckBase, expectedPasses []string) (msg string, ok bool) {
 	numExpectedPasses := len(expectedPasses)
+	sort.Strings(expectedPasses)
+	sort.Strings(c.Result.Passes)
 	if len(c.Result.Passes) != numExpectedPasses || !reflect.DeepEqual(expectedPasses, c.Result.Passes) {
 		return fmt.Sprintf("there should be exactly %d Pass(es), got %#v", numExpectedPasses, c.Result.Passes), false
 	}

--- a/pkg/shipshape/testdata/yaml/dir/foo.bar.yml
+++ b/pkg/shipshape/testdata/yaml/dir/foo.bar.yml
@@ -1,0 +1,2 @@
+check:
+  interval_days: 7

--- a/pkg/shipshape/testdata/yaml/dir/subdir/foo.bar.yml
+++ b/pkg/shipshape/testdata/yaml/dir/subdir/foo.bar.yml
@@ -1,0 +1,2 @@
+check:
+  interval_days: 7

--- a/pkg/shipshape/testdata/yaml/dir/subdir/zoom.bar.yml
+++ b/pkg/shipshape/testdata/yaml/dir/subdir/zoom.bar.yml
@@ -1,0 +1,2 @@
+check:
+  interval_days: 5

--- a/pkg/shipshape/testdata/yaml/dir/zoom.bar.yml
+++ b/pkg/shipshape/testdata/yaml/dir/zoom.bar.yml
@@ -1,0 +1,2 @@
+check:
+  interval_days: 5

--- a/pkg/shipshape/yaml.go
+++ b/pkg/shipshape/yaml.go
@@ -212,8 +212,7 @@ func (c *YamlCheck) FetchData() {
 
 		c.DataMap = map[string][]byte{}
 		for _, fname := range files {
-			_, file := filepath.Split(fname)
-			c.readFile(filepath.Join(c.Path, file), fname)
+			c.readFile(fname, fname)
 		}
 	} else {
 		c.AddFail("no file provided")


### PR DESCRIPTION
This PR adds explicit tests for individual files versus a recursive walk through subfolders.

The key in FetchData has also been changed to the full path on disk. This is important, otherwise you can have one file that passes a check and another that fails with the same name which is not caught.

Closing #9 - not relevant with the ability to do `.*` pattern matching.

Related: https://github.com/govCMS/scaffold-tooling/pull/208