### PR TITLE
fix: match exclude pattern on the fullpath

### DIFF
--- a/pkg/utils/testdata/findfiles/node_modules/file.js
+++ b/pkg/utils/testdata/findfiles/node_modules/file.js
@@ -1,0 +1,1 @@
+console.log('foo bar');

--- a/pkg/utils/testdata/findfiles/node_modules/yamllint-invalid.yml
+++ b/pkg/utils/testdata/findfiles/node_modules/yamllint-invalid.yml
@@ -1,0 +1,2 @@
+this: is invalid
+this: yaml

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -29,7 +29,7 @@ func FindFiles(root, pattern string, excludePattern string) ([]string, error) {
 			return e
 		}
 		if excludePattern != "" {
-			if excluded, err := regexp.MatchString(excludePattern, d.Name()); err != nil {
+			if excluded, err := regexp.MatchString(excludePattern, fullpath); err != nil {
 				return err
 			} else if excluded {
 				return nil


### PR DESCRIPTION
The exclude pattern was only matching against the file and not the full path, which is why files inside the `node_modules` directory were being scanned.