### PR TITLE
feat: add truthy comparison for keyvalue

### DIFF
--- a/pkg/shipshape/keyvalue.go
+++ b/pkg/shipshape/keyvalue.go
@@ -1,6 +1,36 @@
 package shipshape
 
-import "github.com/salsadigitalauorg/shipshape/pkg/utils"
+import (
+	"github.com/salsadigitalauorg/shipshape/pkg/utils"
+)
+
+// KeyValue represents a check to be made against Yaml data.
+// It can be a simple Key=Value check, or match against a list of Disallowed or
+// Allowed values. If the source is a list then IsList must be true.
+// If Optional is set then the validation will not fail if the key is not present.
+type KeyValue struct {
+	Key        string   `yaml:"key"`
+	Value      string   `yaml:"value"`
+	Truthy     bool     `yaml:"truthy"`
+	IsList     bool     `yaml:"is-list"`
+	Optional   bool     `yaml:"optional"`
+	Disallowed []string `yaml:"disallowed"`
+	Allowed    []string `yaml:"allowed"`
+}
+
+// KeyValueResult represents the different outcomes of the KeyValue check.
+type KeyValueResult int8
+
+const (
+	KeyValueError           KeyValueResult = -2
+	KeyValueNotFound        KeyValueResult = -1
+	KeyValueNotEqual        KeyValueResult = 0
+	KeyValueEqual           KeyValueResult = 1
+	KeyValueDisallowedFound KeyValueResult = 2
+)
+
+var truthyValues = []string{"1", "true"}
+var falsyValues = []string{"0", "false", "null"}
 
 // MergeIntSlice replaces the values of a KeyValue slice with those of another.
 func MergeKeyValueSlice(slcA *[]KeyValue, slcB []KeyValue) {
@@ -29,9 +59,29 @@ func getKeyValueFromSlice(kvSlc *[]KeyValue, key string) (*KeyValue, int) {
 	return nil, -1
 }
 
-// CheckAllowDisallowList validates against allow/disallow lists and returns
+// Equals simply returns whether the given value matches the keyvalue.
+func (kv KeyValue) Equals(value string) bool {
+	if kv.Truthy {
+		return kv.EqualsTruthy(value)
+	}
+	return kv.Value == value
+}
+
+func (kv KeyValue) EqualsTruthy(value string) bool {
+	// Check if true.
+	if utils.StringSliceContains(truthyValues, kv.Value) {
+		return utils.StringSliceContains(truthyValues, value)
+	}
+	// Check if false.
+	if utils.StringSliceContains(falsyValues, kv.Value) {
+		return utils.StringSliceContains(falsyValues, value)
+	}
+	return false
+}
+
+// IsDisallowed validates against the allow/disallow lists and returns
 // true if a disallowed value is present.
-func (kv KeyValue) CheckAllowDisallowList(value string) bool {
+func (kv KeyValue) IsDisallowed(value string) bool {
 
 	// Ignore blank and null values.
 	if len(value) == 0 {

--- a/pkg/shipshape/keyvalue_test.go
+++ b/pkg/shipshape/keyvalue_test.go
@@ -43,3 +43,63 @@ func TestMergeKeyValueSlice(t *testing.T) {
 		assert.Equal([]shipshape.KeyValue{{Key: "k2", Value: "v2"}}, slcA)
 	})
 }
+
+func TestEquals(t *testing.T) {
+	assert := assert.New(t)
+
+	t.Run("stringEquals", func(t *testing.T) {
+		kv := shipshape.KeyValue{Key: "k", Value: "foo"}
+		assert.True(kv.Equals("foo"))
+		assert.False(kv.Equals("bar"))
+	})
+
+	t.Run("stringEqualsTruthyTrue", func(t *testing.T) {
+		kv := shipshape.KeyValue{Key: "k", Value: "true", Truthy: true}
+		assert.False(kv.Equals("foo"))
+		assert.False(kv.Equals("false"))
+		assert.False(kv.Equals("0"))
+		assert.False(kv.Equals("null"))
+		assert.True(kv.Equals("true"))
+		assert.True(kv.Equals("1"))
+	})
+
+	t.Run("stringEqualsTruthyOne", func(t *testing.T) {
+		kv := shipshape.KeyValue{Key: "k", Value: "1", Truthy: true}
+		assert.False(kv.Equals("foo"))
+		assert.False(kv.Equals("false"))
+		assert.False(kv.Equals("0"))
+		assert.False(kv.Equals("null"))
+		assert.True(kv.Equals("true"))
+		assert.True(kv.Equals("1"))
+	})
+
+	t.Run("stringEqualsTruthyFalse", func(t *testing.T) {
+		kv := shipshape.KeyValue{Key: "k", Value: "false", Truthy: true}
+		assert.False(kv.Equals("foo"))
+		assert.False(kv.Equals("true"))
+		assert.False(kv.Equals("1"))
+		assert.True(kv.Equals("null"))
+		assert.True(kv.Equals("false"))
+		assert.True(kv.Equals("0"))
+	})
+
+	t.Run("stringEqualsTruthyZero", func(t *testing.T) {
+		kv := shipshape.KeyValue{Key: "k", Value: "0", Truthy: true}
+		assert.False(kv.Equals("foo"))
+		assert.False(kv.Equals("true"))
+		assert.False(kv.Equals("1"))
+		assert.True(kv.Equals("null"))
+		assert.True(kv.Equals("false"))
+		assert.True(kv.Equals("0"))
+	})
+
+	t.Run("stringEqualsTruthyNull", func(t *testing.T) {
+		kv := shipshape.KeyValue{Key: "k", Value: "null", Truthy: true}
+		assert.False(kv.Equals("foo"))
+		assert.False(kv.Equals("true"))
+		assert.False(kv.Equals("1"))
+		assert.True(kv.Equals("null"))
+		assert.True(kv.Equals("false"))
+		assert.True(kv.Equals("0"))
+	})
+}

--- a/pkg/shipshape/types.go
+++ b/pkg/shipshape/types.go
@@ -95,30 +95,6 @@ const (
 	Fail CheckStatus = "Fail"
 )
 
-// KeyValue represents a check to be made against Yaml data.
-// It can be a simple Key=Value check, or it check Keys in Disallowed or
-// Allowed lists accordingly. If the source is a list then IsList must be true.
-// If Optional is set then the validation will not fail if the key is not present.
-type KeyValue struct {
-	Key        string   `yaml:"key"`
-	Value      string   `yaml:"value"`
-	IsList     bool     `yaml:"is-list"`
-	Optional   bool     `yaml:"optional"`
-	Disallowed []string `yaml:"disallowed"`
-	Allowed    []string `yaml:"allowed"`
-}
-
-// KeyValueResult represents the different outcomes of the KeyValue check.
-type KeyValueResult int8
-
-const (
-	KeyValueError           KeyValueResult = -2
-	KeyValueNotFound        KeyValueResult = -1
-	KeyValueNotEqual        KeyValueResult = 0
-	KeyValueEqual           KeyValueResult = 1
-	KeyValueDisallowedFound KeyValueResult = 2
-)
-
 const (
 	File     CheckType = "file"     // Represents a FileCheck.
 	Yaml     CheckType = "yaml"     // Represents a YamlCheck.

--- a/pkg/shipshape/yaml_test.go
+++ b/pkg/shipshape/yaml_test.go
@@ -279,7 +279,7 @@ notification:
 	c.RunCheck()
 	assert.Equal(shipshape.Fail, c.Result.Status)
 	assert.EqualValues(0, len(c.Result.Passes))
-	assert.EqualValues([]string{"[data] 'check.interval_days' equals '7'"}, c.Result.Failures)
+	assert.EqualValues([]string{"[data] 'check.interval_days' equals '7', expected '8'"}, c.Result.Failures)
 
 	// Multiple config values - all correct.
 	c = mockCheck()

--- a/pkg/shipshape/yamlcheck_test.go
+++ b/pkg/shipshape/yamlcheck_test.go
@@ -142,8 +142,8 @@ func TestYamlCheck(t *testing.T) {
 		c.Result.Passes)
 	assert.ElementsMatch(
 		[]string{
-			"[testdata/yaml/dir/subdir/zoom.bar.yml] 'check.interval_days' equals '5'",
-			"[testdata/yaml/dir/zoom.bar.yml] 'check.interval_days' equals '5'",
-			"[testdata/yaml/zoom.bar.yml] 'check.interval_days' equals '5'"},
+			"[testdata/yaml/dir/subdir/zoom.bar.yml] 'check.interval_days' equals '5', expected '7'",
+			"[testdata/yaml/dir/zoom.bar.yml] 'check.interval_days' equals '5', expected '7'",
+			"[testdata/yaml/zoom.bar.yml] 'check.interval_days' equals '5', expected '7'"},
 		c.Result.Failures)
 }


### PR DESCRIPTION
- moved keyvalue check types to own file

on-behalf-of: @govCMS <govcms@govcms.gov.au>