### PR TITLE
[DEVOPS-121] Added AdminUser DB check.

### DIFF
--- a/pkg/drupal/dbadmincheck.go
+++ b/pkg/drupal/dbadmincheck.go
@@ -1,0 +1,139 @@
+package drupal
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os/exec"
+	"strings"
+
+	"github.com/salsadigitalauorg/shipshape/pkg/shipshape"
+	"github.com/salsadigitalauorg/shipshape/pkg/utils"
+)
+
+const AdminUser shipshape.CheckType = "drupal-admin-user"
+
+// AdminUserCheck fetches all role configurations from the database and verifies
+// they do not have is_admin set to true.
+type AdminUserCheck struct {
+	shipshape.CheckBase `yaml:",inline"`
+	DrushCommand        `yaml:",inline"`
+	// List of role names allowed to have is_admin set to true.
+	AllowedRoles []string `yaml:"allowed-roles"`
+	userRoles    []string
+	roleConfigs  map[string]bool
+}
+
+type roleConf struct {
+	IsAdmin bool `json:"is_admin"`
+	Name string `json:"id"`
+}
+
+// Init implementation for the drush-based user role config check.
+func (c *AdminUserCheck) Init(ct shipshape.CheckType) {
+	c.CheckBase.Init(ct)
+	c.RequiresDb = true
+}
+
+// Merge implementation for AdminUserCheck check.
+func (c *AdminUserCheck) Merge(mergeCheck shipshape.Check) error {
+	adminUserMergeCheck := mergeCheck.(*AdminUserCheck)
+	if err := c.CheckBase.Merge(&adminUserMergeCheck.CheckBase); err != nil {
+		return err
+	}
+
+	c.DrushCommand.Merge(adminUserMergeCheck.DrushCommand)
+	utils.MergeStringSlice(&c.AllowedRoles, adminUserMergeCheck.AllowedRoles)
+	return nil
+}
+
+// getActiveRoles runs the drush command to populate data for the roles config check.
+func (c *AdminUserCheck) getActiveRoles() map[string]string {
+  var err error
+
+	activeRoles := map[string][]byte{}
+	rolesListMap := map[string]string{}
+
+  cmd := []string{"role:list", "--fields=.", "--format=json"}
+  activeRoles["user-roles"], err = Drush(c.DrushPath, c.Alias, cmd).Exec()
+  var pathErr *fs.PathError
+  if err != nil && errors.As(err, &pathErr) {
+    c.AddFail(pathErr.Path + ": " + pathErr.Err.Error())
+  } else if err != nil {
+  		msg := string(err.(*exec.ExitError).Stderr)
+  		c.AddFail(strings.ReplaceAll(strings.TrimSpace(msg), "  \n  ", ""))
+  } else {
+    // Unmarshal roles JSON.
+    err = json.Unmarshal(activeRoles["user-roles"], &rolesListMap)
+    var synErr *json.SyntaxError
+    if err != nil && errors.As(err, &synErr) {
+      c.AddFail(err.Error())
+    }
+  }
+
+  return rolesListMap
+}
+
+// FetchData runs the drush command for each active role to extract its config.
+func (c *AdminUserCheck) FetchData() {
+	var err error
+
+	activeRoles := c.getActiveRoles()
+	if c.Result.Status == shipshape.Fail {
+		return
+	}
+
+	// Loop through active roles and pull active config with drush.
+	rolesMap := map[string][]byte{}
+	for i := range activeRoles {
+	  cmd := []string{"cget", "user.role." + i, "--format=json"}
+  	rolesMap[i], err = Drush(c.DrushPath, c.Alias, cmd).Exec()
+  	c.DataMap = rolesMap
+  }
+
+	if err != nil {
+		msg := string(err.(*exec.ExitError).Stderr)
+		c.AddFail(strings.ReplaceAll(strings.TrimSpace(msg), "  \n  ", ""))
+	}
+}
+
+// UnmarshalDataMap parses the data map json entries
+// into the roleConfigs for further processing.
+func (c *AdminUserCheck) UnmarshalDataMap() {
+  if len(c.DataMap) == 0 {
+		c.AddFail("no data provided")
+		return
+	}
+
+	c.roleConfigs = map[string]bool{}
+  for _, element := range c.DataMap {
+    var role roleConf
+    err := json.Unmarshal([]byte(element), &role)
+    var synErr *json.SyntaxError
+    if err != nil && errors.As(err, &synErr) {
+      c.AddFail(err.Error())
+      return
+    }
+    // Collect role config.
+    c.roleConfigs[role.Name] = role.IsAdmin
+  }
+}
+
+// RunCheck implements the Check logic for all active roles.
+func (c *AdminUserCheck) RunCheck() {
+  for roleName, isAdmin := range c.roleConfigs {
+    allowedRole := utils.StringSliceContains(c.AllowedRoles, roleName)
+		if allowedRole {
+			continue
+		}
+
+		if (isAdmin) {
+			c.AddFail(fmt.Sprintf("Role [%s] has `is_admin: true`", roleName))
+		}
+	}
+
+	if len(c.Result.Failures) == 0 {
+		c.Result.Status = shipshape.Pass
+	}
+}

--- a/pkg/drupal/dbadmincheck.go
+++ b/pkg/drupal/dbadmincheck.go
@@ -52,11 +52,11 @@ func (c *AdminUserCheck) Merge(mergeCheck shipshape.Check) error {
 func (c *AdminUserCheck) getActiveRoles() map[string]string {
   var err error
 
-	activeRoles := map[string][]byte{}
+	activeRoles := []byte{}
 	rolesListMap := map[string]string{}
 
   cmd := []string{"role:list", "--fields=.", "--format=json"}
-  activeRoles["user-roles"], err = Drush(c.DrushPath, c.Alias, cmd).Exec()
+  activeRoles, err = Drush(c.DrushPath, c.Alias, cmd).Exec()
   var pathErr *fs.PathError
   if err != nil && errors.As(err, &pathErr) {
     c.AddFail(pathErr.Path + ": " + pathErr.Err.Error())
@@ -65,7 +65,7 @@ func (c *AdminUserCheck) getActiveRoles() map[string]string {
   		c.AddFail(strings.ReplaceAll(strings.TrimSpace(msg), "  \n  ", ""))
   } else {
     // Unmarshal roles JSON.
-    err = json.Unmarshal(activeRoles["user-roles"], &rolesListMap)
+    err = json.Unmarshal(activeRoles, &rolesListMap)
     var synErr *json.SyntaxError
     if err != nil && errors.As(err, &synErr) {
       c.AddFail(err.Error())

--- a/pkg/drupal/dbadmincheck_test.go
+++ b/pkg/drupal/dbadmincheck_test.go
@@ -1,0 +1,178 @@
+package drupal_test
+
+import (
+  "fmt"
+	"os/exec"
+	"testing"
+	"reflect"
+
+	"github.com/salsadigitalauorg/shipshape/pkg/command"
+	"github.com/salsadigitalauorg/shipshape/pkg/drupal"
+	"github.com/salsadigitalauorg/shipshape/pkg/internal"
+	"github.com/salsadigitalauorg/shipshape/pkg/shipshape"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAdminUserInit(t *testing.T) {
+	c := drupal.AdminUserCheck{}
+	c.Init(drupal.AdminUser)
+	assert.True(t, c.RequiresDb)
+}
+
+func TestAdminUserMerge(t *testing.T) {
+	assert := assert.New(t)
+
+	c := drupal.AdminUserCheck{
+		DrushCommand: drupal.DrushCommand{
+			DrushPath: "/path/to/drush",
+		},
+		AllowedRoles:        []string{"role1"},
+	}
+	c.Merge(&drupal.AdminUserCheck{
+		DrushCommand: drupal.DrushCommand{
+			DrushPath: "/new/path/to/drush",
+		},
+		AllowedRoles:        []string{"role2", "role3"},
+	})
+	assert.EqualValues(drupal.AdminUserCheck{
+		DrushCommand: drupal.DrushCommand{
+			DrushPath: "/new/path/to/drush",
+		},
+		AllowedRoles:        []string{"role2", "role3"},
+	}, c)
+}
+
+func TestAdminUserFetchData(t *testing.T) {
+	assert := assert.New(t)
+
+	t.Run("drushNotFound", func(t *testing.T) {
+		c := drupal.AdminUserCheck{}
+		c.FetchData()
+		assert.Equal(shipshape.Fail, c.Result.Status)
+		assert.EqualValues([]string{"vendor/drush/drush/drush: no such file or directory"}, c.Result.Failures)
+
+	})
+
+	curShellCommander := command.ShellCommander
+	defer func() { command.ShellCommander = curShellCommander }()
+	t.Run("drushError", func(t *testing.T) {
+		command.ShellCommander = internal.ShellCommanderMaker(
+			nil,
+			&exec.ExitError{Stderr: []byte("unable to run drush command")},
+			nil,
+		)
+		c := drupal.AdminUserCheck{}
+		c.FetchData()
+		assert.Equal(shipshape.Fail, c.Result.Status)
+		assert.EqualValues([]string{"unable to run drush command"}, c.Result.Failures)
+	})
+
+	// correct data.
+	t.Run("correctData", func(t *testing.T) {
+	  expectedStdout := `{"anonymous":{"is_admin": false}}`
+
+    curShellCommander := command.ShellCommander
+    defer func() { command.ShellCommander = curShellCommander }()
+    command.ShellCommander = internal.ShellCommanderMaker(&expectedStdout, nil, nil)
+
+		c := drupal.AdminUserCheck{}
+		c.FetchData()
+		assert.NotEqual(shipshape.Fail, c.Result.Status)
+		assert.NotEqual(shipshape.Pass, c.Result.Status)
+		assert.Equal([]byte(`{"anonymous":{"is_admin": false}}`), c.DataMap["anonymous"])
+	})
+}
+
+func TestAdminUserUnmarshalData(t *testing.T) {
+	assert := assert.New(t)
+	c := drupal.AdminUserCheck{}
+
+	// Empty datamap.
+	t.Run("emptyDataMap", func(t *testing.T) {
+    c.UnmarshalDataMap()
+    assert.Equal(shipshape.Fail, c.Result.Status)
+    assert.EqualValues([]string{"no data provided"}, c.Result.Failures)
+	})
+
+	// Incorrect json.
+	t.Run("incorrectJSON", func(t *testing.T) {
+  	c = drupal.AdminUserCheck{
+  		CheckBase: shipshape.CheckBase{
+  			DataMap: map[string][]byte{
+          "anonymous": []byte(`{"is_admin":false, "id": "anonymous"]}`)},
+  		},
+  	}
+  	c.UnmarshalDataMap()
+  	assert.Equal(shipshape.Fail, c.Result.Status)
+  	assert.EqualValues([]string{"invalid character ']' after object key:value pair"}, c.Result.Failures)
+  })
+
+  // Correct json.
+  t.Run("correctJSON", func(t *testing.T) {
+    c = drupal.AdminUserCheck{
+      CheckBase: shipshape.CheckBase{
+    	  DataMap: map[string][]byte{
+          "anonymous": []byte(`{"is_admin":false, "id": "anonymous"}`)},
+      },
+    }
+
+    c.UnmarshalDataMap()
+    assert.NotEqual(shipshape.Fail, c.Result.Status)
+    assert.NotEqual(shipshape.Pass, c.Result.Status)
+    roleConfigsVal := reflect.ValueOf(c).FieldByName("roleConfigs")
+    assert.Equal("map[string]bool{\"anonymous\":false}", fmt.Sprintf("%#v", roleConfigsVal))
+  })
+}
+
+func TestAdminUserRunCheck(t *testing.T) {
+	assert := assert.New(t)
+  c := drupal.AdminUserCheck{}
+
+	// Role does not have is_admin:true.
+	t.Run("roleNotAdmin", func(t *testing.T) {
+    c = drupal.AdminUserCheck{
+  		CheckBase: shipshape.CheckBase{
+  			DataMap: map[string][]byte{
+          "anonymous": []byte(`{"is_admin":false, "id": "anonymous"}`)},
+  		},
+  		AllowedRoles: []string{"authenticated", "content-admin"},
+  	}
+  	c.UnmarshalDataMap()
+  	c.RunCheck()
+  	assert.Equal(shipshape.Pass, c.Result.Status)
+	})
+
+  // Role has is_admin:true.
+  t.Run("roleAdmin", func(t *testing.T) {
+    c = drupal.AdminUserCheck{
+  		CheckBase: shipshape.CheckBase{
+  			DataMap: map[string][]byte{
+          "anonymous": []byte(`{"is_admin":true, "id": "anonymous"}`)},
+  		},
+  		AllowedRoles: []string{"content-admin"},
+  	}
+  	c.UnmarshalDataMap()
+  	c.RunCheck()
+  	assert.Equal(shipshape.Fail, c.Result.Status)
+  	assert.EqualValues([]string{"Role [anonymous] has `is_admin: true`"}, c.Result.Failures)
+  })
+
+  // Role has is_admin:true but is allowed.
+  t.Run("roleAdminAllowed", func(t *testing.T) {
+    c = drupal.AdminUserCheck{
+  		CheckBase: shipshape.CheckBase{
+  			DataMap: map[string][]byte{
+          "anonymous": []byte(`{"is_admin":true, "id": "anonymous"}`)},
+  		},
+  		AllowedRoles: []string{"anonymous", "content-admin"},
+  	}
+  	c.UnmarshalDataMap()
+  	c.RunCheck()
+  	assert.Equal(shipshape.Pass, c.Result.Status)
+  })
+
+	c.UnmarshalDataMap()
+	c.RunCheck()
+	assert.Equal(shipshape.Pass, c.Result.Status)
+}
+

--- a/pkg/drupal/dbadmincheck_test.go
+++ b/pkg/drupal/dbadmincheck_test.go
@@ -1,10 +1,10 @@
 package drupal_test
 
 import (
-  "fmt"
+	"fmt"
 	"os/exec"
-	"testing"
 	"reflect"
+	"testing"
 
 	"github.com/salsadigitalauorg/shipshape/pkg/command"
 	"github.com/salsadigitalauorg/shipshape/pkg/drupal"
@@ -26,19 +26,19 @@ func TestAdminUserMerge(t *testing.T) {
 		DrushCommand: drupal.DrushCommand{
 			DrushPath: "/path/to/drush",
 		},
-		AllowedRoles:        []string{"role1"},
+		AllowedRoles: []string{"role1"},
 	}
 	c.Merge(&drupal.AdminUserCheck{
 		DrushCommand: drupal.DrushCommand{
 			DrushPath: "/new/path/to/drush",
 		},
-		AllowedRoles:        []string{"role2", "role3"},
+		AllowedRoles: []string{"role2", "role3"},
 	})
 	assert.EqualValues(drupal.AdminUserCheck{
 		DrushCommand: drupal.DrushCommand{
 			DrushPath: "/new/path/to/drush",
 		},
-		AllowedRoles:        []string{"role2", "role3"},
+		AllowedRoles: []string{"role2", "role3"},
 	}, c)
 }
 
@@ -69,11 +69,11 @@ func TestAdminUserFetchData(t *testing.T) {
 
 	// correct data.
 	t.Run("correctData", func(t *testing.T) {
-	  expectedStdout := `{"anonymous":{"is_admin": false}}`
+		expectedStdout := `{"anonymous":{"is_admin": false}}`
 
-    curShellCommander := command.ShellCommander
-    defer func() { command.ShellCommander = curShellCommander }()
-    command.ShellCommander = internal.ShellCommanderMaker(&expectedStdout, nil, nil)
+		curShellCommander := command.ShellCommander
+		defer func() { command.ShellCommander = curShellCommander }()
+		command.ShellCommander = internal.ShellCommanderMaker(&expectedStdout, nil, nil)
 
 		c := drupal.AdminUserCheck{}
 		c.FetchData()
@@ -89,90 +89,89 @@ func TestAdminUserUnmarshalData(t *testing.T) {
 
 	// Empty datamap.
 	t.Run("emptyDataMap", func(t *testing.T) {
-    c.UnmarshalDataMap()
-    assert.Equal(shipshape.Fail, c.Result.Status)
-    assert.EqualValues([]string{"no data provided"}, c.Result.Failures)
+		c.UnmarshalDataMap()
+		assert.Equal(shipshape.Fail, c.Result.Status)
+		assert.EqualValues([]string{"no data provided"}, c.Result.Failures)
 	})
 
 	// Incorrect json.
 	t.Run("incorrectJSON", func(t *testing.T) {
-  	c = drupal.AdminUserCheck{
-  		CheckBase: shipshape.CheckBase{
-  			DataMap: map[string][]byte{
-          "anonymous": []byte(`{"is_admin":false, "id": "anonymous"]}`)},
-  		},
-  	}
-  	c.UnmarshalDataMap()
-  	assert.Equal(shipshape.Fail, c.Result.Status)
-  	assert.EqualValues([]string{"invalid character ']' after object key:value pair"}, c.Result.Failures)
-  })
+		c = drupal.AdminUserCheck{
+			CheckBase: shipshape.CheckBase{
+				DataMap: map[string][]byte{
+					"anonymous": []byte(`{"is_admin":false, "id": "anonymous"]}`)},
+			},
+		}
+		c.UnmarshalDataMap()
+		assert.Equal(shipshape.Fail, c.Result.Status)
+		assert.EqualValues([]string{"invalid character ']' after object key:value pair"}, c.Result.Failures)
+	})
 
-  // Correct json.
-  t.Run("correctJSON", func(t *testing.T) {
-    c = drupal.AdminUserCheck{
-      CheckBase: shipshape.CheckBase{
-    	  DataMap: map[string][]byte{
-          "anonymous": []byte(`{"is_admin":false, "id": "anonymous"}`)},
-      },
-    }
+	// Correct json.
+	t.Run("correctJSON", func(t *testing.T) {
+		c = drupal.AdminUserCheck{
+			CheckBase: shipshape.CheckBase{
+				DataMap: map[string][]byte{
+					"anonymous": []byte(`{"is_admin":false, "id": "anonymous"}`)},
+			},
+		}
 
-    c.UnmarshalDataMap()
-    assert.NotEqual(shipshape.Fail, c.Result.Status)
-    assert.NotEqual(shipshape.Pass, c.Result.Status)
-    roleConfigsVal := reflect.ValueOf(c).FieldByName("roleConfigs")
-    assert.Equal("map[string]bool{\"anonymous\":false}", fmt.Sprintf("%#v", roleConfigsVal))
-  })
+		c.UnmarshalDataMap()
+		assert.NotEqual(shipshape.Fail, c.Result.Status)
+		assert.NotEqual(shipshape.Pass, c.Result.Status)
+		roleConfigsVal := reflect.ValueOf(c).FieldByName("roleConfigs")
+		assert.Equal("map[string]bool{\"anonymous\":false}", fmt.Sprintf("%#v", roleConfigsVal))
+	})
 }
 
 func TestAdminUserRunCheck(t *testing.T) {
 	assert := assert.New(t)
-  c := drupal.AdminUserCheck{}
+	c := drupal.AdminUserCheck{}
 
 	// Role does not have is_admin:true.
 	t.Run("roleNotAdmin", func(t *testing.T) {
-    c = drupal.AdminUserCheck{
-  		CheckBase: shipshape.CheckBase{
-  			DataMap: map[string][]byte{
-          "anonymous": []byte(`{"is_admin":false, "id": "anonymous"}`)},
-  		},
-  		AllowedRoles: []string{"authenticated", "content-admin"},
-  	}
-  	c.UnmarshalDataMap()
-  	c.RunCheck()
-  	assert.Equal(shipshape.Pass, c.Result.Status)
+		c = drupal.AdminUserCheck{
+			CheckBase: shipshape.CheckBase{
+				DataMap: map[string][]byte{
+					"anonymous": []byte(`{"is_admin":false, "id": "anonymous"}`)},
+			},
+			AllowedRoles: []string{"authenticated", "content-admin"},
+		}
+		c.UnmarshalDataMap()
+		c.RunCheck()
+		assert.Equal(shipshape.Pass, c.Result.Status)
 	})
 
-  // Role has is_admin:true.
-  t.Run("roleAdmin", func(t *testing.T) {
-    c = drupal.AdminUserCheck{
-  		CheckBase: shipshape.CheckBase{
-  			DataMap: map[string][]byte{
-          "anonymous": []byte(`{"is_admin":true, "id": "anonymous"}`)},
-  		},
-  		AllowedRoles: []string{"content-admin"},
-  	}
-  	c.UnmarshalDataMap()
-  	c.RunCheck()
-  	assert.Equal(shipshape.Fail, c.Result.Status)
-  	assert.EqualValues([]string{"Role [anonymous] has `is_admin: true`"}, c.Result.Failures)
-  })
+	// Role has is_admin:true.
+	t.Run("roleAdmin", func(t *testing.T) {
+		c = drupal.AdminUserCheck{
+			CheckBase: shipshape.CheckBase{
+				DataMap: map[string][]byte{
+					"anonymous": []byte(`{"is_admin":true, "id": "anonymous"}`)},
+			},
+			AllowedRoles: []string{"content-admin"},
+		}
+		c.UnmarshalDataMap()
+		c.RunCheck()
+		assert.Equal(shipshape.Fail, c.Result.Status)
+		assert.EqualValues([]string{"Role [anonymous] has `is_admin: true`"}, c.Result.Failures)
+	})
 
-  // Role has is_admin:true but is allowed.
-  t.Run("roleAdminAllowed", func(t *testing.T) {
-    c = drupal.AdminUserCheck{
-  		CheckBase: shipshape.CheckBase{
-  			DataMap: map[string][]byte{
-          "anonymous": []byte(`{"is_admin":true, "id": "anonymous"}`)},
-  		},
-  		AllowedRoles: []string{"anonymous", "content-admin"},
-  	}
-  	c.UnmarshalDataMap()
-  	c.RunCheck()
-  	assert.Equal(shipshape.Pass, c.Result.Status)
-  })
+	// Role has is_admin:true but is allowed.
+	t.Run("roleAdminAllowed", func(t *testing.T) {
+		c = drupal.AdminUserCheck{
+			CheckBase: shipshape.CheckBase{
+				DataMap: map[string][]byte{
+					"anonymous": []byte(`{"is_admin":true, "id": "anonymous"}`)},
+			},
+			AllowedRoles: []string{"anonymous", "content-admin"},
+		}
+		c.UnmarshalDataMap()
+		c.RunCheck()
+		assert.Equal(shipshape.Pass, c.Result.Status)
+	})
 
 	c.UnmarshalDataMap()
 	c.RunCheck()
 	assert.Equal(shipshape.Pass, c.Result.Status)
 }
-

--- a/pkg/drupal/drupal.go
+++ b/pkg/drupal/drupal.go
@@ -15,6 +15,7 @@ func RegisterChecks() {
 	shipshape.ChecksRegistry[DbPermissions] = func() shipshape.Check { return &DbPermissionsCheck{} }
 	shipshape.ChecksRegistry[TrackingCode] = func() shipshape.Check { return &TrackingCodeCheck{} }
 	shipshape.ChecksRegistry[UserRole] = func() shipshape.Check { return &UserRoleCheck{} }
+	shipshape.ChecksRegistry[AdminUser] = func() shipshape.Check { return &AdminUserCheck{} }
 }
 
 func init() {


### PR DESCRIPTION
# Description
The current shipshape configuration provided by scaffold tooling does not currently validate/remediate the active configuration for the `is_admin` property on user roles. 

# Proposed solution
Introduce a new check `drupal-admin-user` that will sift through all active user roles in the DB and flag those that have `is_admin` set to `true`. 

The check configuration should also allow specific roles to pass the check, if needed.

```
drupal-admin-user:
    - name: '[DATABASE] Active user roles admin check '
      severity: high
      allowed-roles:
         - site_admin
         - superuser
```