### PR TITLE
[DEVOPS-212] Add Drupal TFA check

### DIFF
--- a/pkg/checks/drupal/dbtfausercheck.go
+++ b/pkg/checks/drupal/dbtfausercheck.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/salsadigitalauorg/shipshape/pkg/config"
-	"github.com/salsadigitalauorg/shipshape/pkg/utils"
 )
 
 // DbUserTfaCheck fetches a list of users and checks that they
@@ -25,16 +24,19 @@ func (c *DbUserTfaCheck) Init(ct config.CheckType) {
 	c.RequiresDb = true
 }
 
+// FetchData runs the Drush command to extract user information from the Drupal database.
 func (c *DbUserTfaCheck) FetchData() {
-	cmd := []string{"ev", "return \\Drupal::database()->query(\"SELECT users.uid, users_field_data.name FROM users LEFT JOIN users_field_data ON users.uid = users_field_data.uid WHERE users.uid != '0' AND NOT EXISTS (SELECT 1 FROM users_data WHERE users.uid = users_data.uid AND users_data.module = 'tfa');\")->fetchAll()", "--format=json"}
+	cmd := []string{"ev", "return \\Drupal::database()->query(\"SELECT users.uid, users_field_data.name FROM users LEFT JOIN users_field_data ON users.uid = users_field_data.uid WHERE users.uid != '0' AND users_field_data.status = '1' AND NOT EXISTS (SELECT 1 FROM users_data WHERE users.uid = users_data.uid AND users_data.module = 'tfa');\")->fetchAll()", "--format=json"}
 	result, err := Drush(c.DrushPath, c.Alias, cmd).Exec()
 	if err != nil {
-		c.AddFail(err.Error())
+		c.Result.Status = config.Fail
+		c.Result.Failures = append(c.Result.Failures, "Error calling drush ev.")
 	}
 	c.DataMap = map[string][]byte{}
 	c.DataMap["db-tfa-check"] = result
 }
 
+// RunCheck checks to see if any results were returned from the Drupal database query.
 func (c *DbUserTfaCheck) RunCheck() {
 	var users []User
 	err := json.Unmarshal(c.DataMap["db-tfa-check"], &users)
@@ -43,19 +45,18 @@ func (c *DbUserTfaCheck) RunCheck() {
 	}
 
 	if len(users) == 0 {
-		c.AddPass("All users have TFA enabled.")
+		c.AddPass("All active users have two-factor authentication enabled.")
 		c.Result.Status = config.Pass
 	} else {
 		for _, user := range users {
-			c.AddFail(fmt.Sprintf("Found UID %s with name %s without TFA.", user.UID, user.Name))
+			c.AddFail(fmt.Sprintf("Two-factor authentication not enabled for active user %s, with UID %s.", user.Name, user.UID))
 		}
 		c.Result.Status = config.Fail
 	}
 }
 
 
+// Merge implmentation for DbUserTfaCheck check.
 func (c *DbUserTfaCheck) Merge(mergeCheck config.Check) error {
-	DbUserTfaMergeCheck := mergeCheck.(*DbUserTfaCheck)
-	utils.MergeString(&c.CheckBase.Name, DbUserTfaMergeCheck.CheckBase.Name)
 	return nil
 }

--- a/pkg/checks/drupal/dbtfausercheck.go
+++ b/pkg/checks/drupal/dbtfausercheck.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/salsadigitalauorg/shipshape/pkg/config"
-//	"github.com/salsadigitalauorg/shipshape/pkg/utils"
+	"github.com/salsadigitalauorg/shipshape/pkg/utils"
 )
 
 // DbUserTfaCheck fetches a list of users and checks that they
@@ -55,6 +55,7 @@ func (c *DbUserTfaCheck) RunCheck() {
 
 
 func (c *DbUserTfaCheck) Merge(mergeCheck config.Check) error {
-	// not implemented yet
+	DbUserTfaMergeCheck := mergeCheck.(*DbUserTfaCheck)
+	utils.MergeString(&c.CheckBase.Name, DbUserTfaMergeCheck.CheckBase.Name)
 	return nil
 }

--- a/pkg/checks/drupal/dbtfausercheck.go
+++ b/pkg/checks/drupal/dbtfausercheck.go
@@ -1,0 +1,35 @@
+package drupal
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os/exec"
+	"strings"
+
+	"github.com/salsadigitalauorg/shipshape/pkg/config"
+	"github.com/salsadigitalauorg/shipshape/pkg/utils"
+)
+
+const DbUserTfa config.CheckType = "drupal-tfa-user"
+
+// DbUserTfaCheck fetches a list of users and checks that they
+// have TFA configured.
+type DbUserTfaCheck struct {
+	config.CheckBase `yaml:",inline"`
+	DrushCommand     `yaml:",inline"`
+}
+
+// Init implementation for the drush-based check.
+func (c *AdminUserCheck) Init(ct config.CheckType) {
+	c.CheckBase.Init(ct)
+	c.RequiresDb = true
+}
+
+func (c *AdminUserCheck) FetchData() {
+
+	var err error
+	
+	cmd := []string{"ev", "return \\Drupal::database()->query(\"SELECT users.uid FROM users WHERE users.uid != '0' AND NOT EXISTS (SELECT 1 FROM users_data WHERE users.uid = users_data.uid AND users_data.module = 'tfa');\")->fetchAll()", "--format=json"}
+}

--- a/pkg/checks/drupal/dbtfausercheck.go
+++ b/pkg/checks/drupal/dbtfausercheck.go
@@ -2,17 +2,10 @@ package drupal
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
-	"io/fs"
-	"os/exec"
-	"strings"
-
 	"github.com/salsadigitalauorg/shipshape/pkg/config"
-	"github.com/salsadigitalauorg/shipshape/pkg/utils"
+//	"github.com/salsadigitalauorg/shipshape/pkg/utils"
 )
-
-const DbUserTfa config.CheckType = "drupal-tfa-user"
 
 // DbUserTfaCheck fetches a list of users and checks that they
 // have TFA configured.
@@ -21,15 +14,47 @@ type DbUserTfaCheck struct {
 	DrushCommand     `yaml:",inline"`
 }
 
+type User struct {
+	UID string `json:"uid"`
+	Name string `json:"name"`
+}
+
 // Init implementation for the drush-based check.
-func (c *AdminUserCheck) Init(ct config.CheckType) {
+func (c *DbUserTfaCheck) Init(ct config.CheckType) {
 	c.CheckBase.Init(ct)
 	c.RequiresDb = true
 }
 
-func (c *AdminUserCheck) FetchData() {
+func (c *DbUserTfaCheck) FetchData() {
+	cmd := []string{"ev", "return \\Drupal::database()->query(\"SELECT users.uid, users_field_data.name FROM users LEFT JOIN users_field_data ON users.uid = users_field_data.uid WHERE users.uid != '0' AND NOT EXISTS (SELECT 1 FROM users_data WHERE users.uid = users_data.uid AND users_data.module = 'tfa');\")->fetchAll()", "--format=json"}
+	result, err := Drush(c.DrushPath, c.Alias, cmd).Exec()
+	if err != nil {
+		c.AddFail(err.Error())
+	}
+	c.DataMap = map[string][]byte{}
+	c.DataMap["db-tfa-check"] = result
+}
 
-	var err error
-	
-	cmd := []string{"ev", "return \\Drupal::database()->query(\"SELECT users.uid FROM users WHERE users.uid != '0' AND NOT EXISTS (SELECT 1 FROM users_data WHERE users.uid = users_data.uid AND users_data.module = 'tfa');\")->fetchAll()", "--format=json"}
+func (c *DbUserTfaCheck) RunCheck() {
+	var users []User
+	err := json.Unmarshal(c.DataMap["db-tfa-check"], &users)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	if len(users) == 0 {
+		c.AddPass("All users have TFA enabled.")
+		c.Result.Status = config.Pass
+	} else {
+		for _, user := range users {
+			c.AddFail(fmt.Sprintf("Found UID %s with name %s without TFA.", user.UID, user.Name))
+		}
+		c.Result.Status = config.Fail
+	}
+}
+
+
+func (c *DbUserTfaCheck) Merge(mergeCheck config.Check) error {
+	// not implemented yet
+	return nil
 }

--- a/pkg/checks/drupal/dbtfausercheck_test.go
+++ b/pkg/checks/drupal/dbtfausercheck_test.go
@@ -1,0 +1,115 @@
+package drupal_test
+
+import (
+	"os/exec"
+	"testing"
+
+	. "github.com/salsadigitalauorg/shipshape/pkg/checks/drupal"
+	"github.com/stretchr/testify/assert"
+	"github.com/salsadigitalauorg/shipshape/pkg/command"
+	"github.com/salsadigitalauorg/shipshape/pkg/config"
+	"github.com/salsadigitalauorg/shipshape/pkg/internal"
+)
+
+func TestDbTfaUserCheck(t *testing.T) {
+	assert := assert.New(t)
+	curShellCommander := command.ShellCommander
+	defer func() { command.ShellCommander = curShellCommander }()
+	t.Run("drushError", func(t *testing.T) {
+		c := DbUserTfaCheck{}
+		c.Init(DbUserTfa)
+		assert.True(c.RequiresDb)
+		
+		command.ShellCommander = internal.ShellCommanderMaker(
+			nil,
+			&exec.ExitError{Stderr: []byte("unable to run drush command")},
+			nil,
+		)
+		c.FetchData()
+		assert.Equal(config.Fail, c.Result.Status)
+		assert.Empty(c.Result.Passes)
+		assert.ElementsMatch(
+			[]string{"Error calling drush ev."},
+			c.Result.Failures,
+		)
+	})
+	
+	t.Run("failOnSingleUserWithoutTFA", func(t *testing.T) {
+		c := DbUserTfaCheck{}
+		c.Init(DbUserTfa)
+		
+		stdout := `
+[
+  {
+    "uid": "1",
+    "name": "shipshape-1"
+  }
+]
+`
+		command.ShellCommander = internal.ShellCommanderMaker(
+			&stdout,
+			nil,
+			nil,
+		)
+		c.FetchData()
+		c.RunCheck()
+		assert.Equal(config.Fail, c.Result.Status)
+		assert.Empty(c.Result.Passes)
+		assert.ElementsMatch(
+			[]string{"Two-factor authentication not enabled for active user shipshape-1, with UID 1."},
+			c.Result.Failures,
+		)
+	})
+	
+	t.Run("failOnMultipleUserWithoutTFA", func(t *testing.T) {
+		c := DbUserTfaCheck{}
+		c.Init(DbUserTfa)
+
+		stdout := `
+[
+  {
+    "uid": "1",
+    "name": "shipshape-1"
+  },
+  {
+    "uid": "2",
+    "name": "shipshape-2"
+  }
+]
+`
+		command.ShellCommander = internal.ShellCommanderMaker(
+			&stdout,
+			nil,
+			nil,
+		)
+		c.FetchData()
+		c.RunCheck()
+		assert.Equal(config.Fail, c.Result.Status)
+		assert.Empty(c.Result.Passes)
+		assert.ElementsMatch(
+			[]string{"Two-factor authentication not enabled for active user shipshape-1, with UID 1.", "Two-factor authentication not enabled for active user shipshape-2, with UID 2."},
+			c.Result.Failures,
+			)
+	})
+	t.Run("passOnEmptyQueryResult", func(t *testing.T) {
+		c := DbUserTfaCheck{}
+		c.Init(DbUserTfa)
+
+		stdout := `
+[]
+`
+		command.ShellCommander = internal.ShellCommanderMaker(
+			&stdout,
+			nil,
+			nil,
+			)
+		c.FetchData()
+		c.RunCheck()
+		assert.Equal(config.Pass, c.Result.Status)
+		assert.Empty(c.Result.Failures)
+		assert.ElementsMatch(
+			[]string{"All active users have two-factor authentication enabled."},
+			c.Result.Passes,
+			)
+	})
+}

--- a/pkg/checks/drupal/drupal.go
+++ b/pkg/checks/drupal/drupal.go
@@ -17,6 +17,7 @@ func RegisterChecks() {
 	config.ChecksRegistry[TrackingCode] = func() config.Check { return &TrackingCodeCheck{} }
 	config.ChecksRegistry[UserRole] = func() config.Check { return &UserRoleCheck{} }
 	config.ChecksRegistry[AdminUser] = func() config.Check { return &AdminUserCheck{} }
+	config.ChecksRegistry[DbUserTfa] = func() config.Check { return &DbUserTfaCheck{} }
 }
 
 func init() {

--- a/pkg/checks/drupal/types.go
+++ b/pkg/checks/drupal/types.go
@@ -10,7 +10,9 @@ const (
 	FileModule    config.CheckType = "drupal-file-module"
 	DbModule      config.CheckType = "drupal-db-module"
 	DbPermissions config.CheckType = "drupal-db-permissions"
-	TrackingCode  config.CheckType = "drupal-tracking-code"
+
+	DbUserTfa    config.CheckType = "drupal-db-user-tfa"
+	TrackingCode config.CheckType = "drupal-tracking-code"
 )
 
 type DrushCommand struct {


### PR DESCRIPTION
1) Add a `drupal-db-user-tfa` check that raises warnings when an active user account is missing TFA configuration:
```
cli-drupal:/app$ ./shipshape 
# Breaches were detected

  ### [DATABASE] Users found without TFA enabled.
     -- Two-factor authentication not enabled for active user test_user, with UID 9.
     -- Two-factor authentication not enabled for active user test_user_2, with UID 10.
```

2) Add corresponding tests.