### PR TITLE
feat: optimise image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.20 AS builder
 
 ARG VERSION
 ARG COMMIT
@@ -9,7 +9,10 @@ WORKDIR $GOPATH/src/github.com/salsadigitalauorg/shipshape
 
 ENV CGO_ENABLED 0
 
-RUN go mod tidy && \
+ARG TARGETOS TARGETARCH
+
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} && \
+    go mod tidy && \
     go generate ./... && \
     go build -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT}" -o build/shipshape
 


### PR DESCRIPTION
Cross-compiling using Golang's native method rather than docker multi-arch. Followed the instructions here: https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/

Result - build times are halved:
<img width="1161" alt="image" src="https://github.com/salsadigitalauorg/shipshape/assets/1160048/98e09797-d111-475b-84d5-d0ea5330b98b">
