### PR TITLE
[DEVOPS-123] Added optional ability to perform supported image versions checks.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/uuid v1.3.0 // indirect
+	github.com/hashicorp/go-version v1.6.0 // indirect
 	github.com/kennygrant/sanitize v1.2.4 // indirect
 	github.com/klauspost/compress v1.16.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,8 @@ github.com/graph-gophers/graphql-go v1.5.0 h1:fDqblo50TEpD0LY7RXk/LFVYEVqo3+tXMN
 github.com/graph-gophers/graphql-go v1.5.0/go.mod h1:YtmJZDLbF1YYNrlNAuiO5zAStUWc3XZT07iGsVqe1Os=
 github.com/graph-gophers/graphql-transport-ws v0.0.2 h1:DbmSkbIGzj8SvHei6n8Mh9eLQin8PtA8xY9eCzjRpvo=
 github.com/graph-gophers/graphql-transport-ws v0.0.2/go.mod h1:5BVKvFzOd2BalVIBFfnfmHjpJi/MZ5rOj8G55mXvZ8g=
+github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
+github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hasura/go-graphql-client v0.9.2 h1:4FyAeVOu+GcS1BaoELWNyxzaLY7s+g72LLH+qYItdEY=
 github.com/hasura/go-graphql-client v0.9.2/go.mod h1:AarJlxO1I59MPqU/TC7gQP0BMFgPEqUTt5LYPvykasw=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=

--- a/pkg/checks/docker/baseimagecheck.go
+++ b/pkg/checks/docker/baseimagecheck.go
@@ -86,7 +86,7 @@ func (c *BaseImageCheck) RunCheck() {
 						continue
 					}
 
-					if len(c.Allowed) > 0 && !utils.SliceCheckString(c.Allowed, match[1], match[2]) {
+					if len(c.Allowed) > 0 && !utils.PackageCheckString(c.Allowed, match[1], match[2]) {
 						c.AddFail(name + " is using invalid base image " + match[1])
 						c.AddBreach(result.KeyValueBreach{
 							Key:        name,
@@ -108,7 +108,7 @@ func (c *BaseImageCheck) RunCheck() {
 					continue
 				}
 
-				if !utils.SliceCheckString(c.Allowed, match[1], match[2]) {
+				if !utils.PackageCheckString(c.Allowed, match[1], match[2]) {
 					c.AddFail(name + " is using invalid base image " + match[1])
 					c.AddBreach(result.KeyValueBreach{
 						Key:        name,

--- a/pkg/checks/docker/baseimagecheck_test.go
+++ b/pkg/checks/docker/baseimagecheck_test.go
@@ -63,7 +63,7 @@ func TestInvalidDockerfileCheck(t *testing.T) {
 func TestValidDockerfileImageVersion(t *testing.T) {
 	assert := assert.New(t)
 	c := docker.BaseImageCheck{
-		Allowed: []string{"bitnami/kubectl@latest"},
+		Allowed: []string{"bitnami/kubectl@1.24"},
 		Paths:   []string{"./fixtures/compose-dockerfile"},
 	}
 	c.RunCheck()
@@ -77,7 +77,7 @@ func TestValidDockerfileImageVersion(t *testing.T) {
 func TestInvalidDockerfileImageVersion(t *testing.T) {
 	assert := assert.New(t)
 	c := docker.BaseImageCheck{
-		Allowed: []string{"bitnami/kubectl:1.24"},
+		Allowed: []string{"bitnami/kubectl:1.26"},
 		Paths:   []string{"./fixtures/compose-dockerfile"},
 	}
 	c.RunCheck()
@@ -117,7 +117,7 @@ func TestValidImageVersions(t *testing.T) {
 	c := docker.BaseImageCheck{
 		Allowed: []string{
 			"bitnami/kubectl@1.25.12-debian-11-r6",
-			"bitnami/postgresql:16",
+			"bitnami/postgresql:15",
 			"bitnami/redis",
 			"bitnami/mongodb@latest",
 		},
@@ -159,7 +159,7 @@ func TestInvalidImageVersions(t *testing.T) {
 	c := docker.BaseImageCheck{
 		Allowed: []string{
 			"bitnami/kubectl@latest",
-			"bitnami/postgresql:16",
+			"bitnami/postgresql:17",
 			"bitnami/redis",
 		},
 		Paths: []string{"./fixtures/compose-image"},
@@ -167,7 +167,10 @@ func TestInvalidImageVersions(t *testing.T) {
 	c.RunCheck()
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(
-		[]string{"service4 is using invalid base image bitnami/mongodb"},
+		[]string{
+		  "service2 is using invalid base image bitnami/postgresql",
+		  "service4 is using invalid base image bitnami/mongodb",
+		},
 		c.Result.Failures,
 	)
 }

--- a/pkg/checks/docker/fixtures/compose-dockerfile/Dockerfile
+++ b/pkg/checks/docker/fixtures/compose-dockerfile/Dockerfile
@@ -1,1 +1,1 @@
-FROM bitnami/kubectl
+FROM bitnami/kubectl:1.25.12-debian-11-r6

--- a/pkg/checks/docker/fixtures/compose-image/docker-compose.yml
+++ b/pkg/checks/docker/fixtures/compose-image/docker-compose.yml
@@ -3,13 +3,13 @@ version: "3.8"
 services:
 
   service1:
-    image: bitnami/kubectl
+    image: bitnami/kubectl:1.25.12-debian-11-r5
 
   service2:
-    image: bitnami/postgresql
+    image: bitnami/postgresql@16
 
   service3:
-    image: bitnami/redis
+    image: bitnami/redis:{MY_VERSION}
 
   service4:
-    image: bitnami/mongodb
+    image: bitnami/mongodb:5.0.19-debian-11-r11

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -220,7 +220,7 @@ func StringSliceMatch(slice []string, item string) bool {
 
 // Sift through a slice to determine if it contains eligible package
 // with optional version constrains.
-func SliceCheckString(slice []string, item string, item_version string) bool {
+func PackageCheckString(slice []string, item string, item_version string) bool {
   for _, s := range slice {
     // Parse slice with regex to:
     // 1 - package name (e.g. "bitnami/kubectl")

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -237,10 +237,10 @@ func SliceCheckString(slice []string, item string, item_version string) bool {
           return true
         } else if len(item_version) > 0 {
           // Ensure that item version is not less than slice version.
-          v1, err := version.NewVersion(service_match[2])
-          v2, err := version.NewVersion(item_version)
+          allowedVersion, err := version.NewVersion(service_match[2])
+          imageVersion, err := version.NewVersion(item_version)
           // Run version comparison.
-          if err == nil && v1.GreaterThanOrEqual(v2) {
+          if err == nil && allowedVersion.LessThanOrEqual(imageVersion) {
             return true
           }
         }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -366,3 +366,12 @@ func TestHasComposerDependency(t *testing.T) {
 		t.Errorf("expected file not found got %s", err)
 	}
 }
+
+func TestSliceCheckString(t *testing.T) {
+	assert := assert.New(t)
+	assert.False(SliceCheckString([]string{}, "bitnami/kubectl", ""))
+	assert.False(SliceCheckString([]string{"bitnami/postgresql@16"}, "bitnami/kubectl", "1.24"))
+	assert.False(SliceCheckString([]string{"bitnami/postgresql@16", "bitnami/kubectl@1.24-beta"}, "bitnami/kubectl", "1.23-alpha"))
+	assert.True(SliceCheckString([]string{"bitnami/postgresql@16", "bitnami/kubectl"}, "bitnami/kubectl", "1.24"))
+	assert.True(SliceCheckString([]string{"bitnami/postgresql@16", "bitnami/kubectl:1.24"}, "bitnami/kubectl", "1.25"))
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -367,11 +367,11 @@ func TestHasComposerDependency(t *testing.T) {
 	}
 }
 
-func TestSliceCheckString(t *testing.T) {
+func TestPackageCheckString(t *testing.T) {
 	assert := assert.New(t)
-	assert.False(SliceCheckString([]string{}, "bitnami/kubectl", ""))
-	assert.False(SliceCheckString([]string{"bitnami/postgresql@16"}, "bitnami/kubectl", "1.24"))
-	assert.False(SliceCheckString([]string{"bitnami/postgresql@16", "bitnami/kubectl@1.24-beta"}, "bitnami/kubectl", "1.23-alpha"))
-	assert.True(SliceCheckString([]string{"bitnami/postgresql@16", "bitnami/kubectl"}, "bitnami/kubectl", "1.24"))
-	assert.True(SliceCheckString([]string{"bitnami/postgresql@16", "bitnami/kubectl:1.24"}, "bitnami/kubectl", "1.25"))
+	assert.False(PackageCheckString([]string{}, "bitnami/kubectl", ""))
+	assert.False(PackageCheckString([]string{"bitnami/postgresql@16"}, "bitnami/kubectl", "1.24"))
+	assert.False(PackageCheckString([]string{"bitnami/postgresql@16", "bitnami/kubectl@1.24-beta"}, "bitnami/kubectl", "1.23-alpha"))
+	assert.True(PackageCheckString([]string{"bitnami/postgresql@16", "bitnami/kubectl"}, "bitnami/kubectl", "1.24"))
+	assert.True(PackageCheckString([]string{"bitnami/postgresql@16", "bitnami/kubectl:1.24"}, "bitnami/kubectl", "1.25"))
 }


### PR DESCRIPTION
# Description
Currently, PaaS customers have the ability to use unsupported image versions. This can introduce issues when an unsupported version of an image is being used (eg. PHP 7, when the last supported version is 8).

# Proposed solution
Extend `docker-base-image` check to allow optional version constrain within the `allowed` list, which will reject builds that do not adhere to the specified image version constraint.

If the version constraint is added to the image, then that version will be considered the last supported version, meaning that images with lower version will not pass validation.

For version comparison it is proposed to use https://github.com/hashicorp/go-version that follows [SemVer](http://semver.org/)

# Usage

The version constraint can be added either with `:` or `@` suffix tag. When no version suffix is specified then any version will pass the validation (current behaviour)

```
docker-base-image:
    - name: '[FILE] Allowed image lookup'
      paths:
        - ./
      allowed:
        - govcms/nginx-drupal:9.5.3
        - uselagoon/varnish-drupal@latest

```