### PR TITLE
fix: lagoon push facts duplication

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,10 +15,10 @@ jobs:
     - uses: actions/checkout@main
 
     - name: Build & start containers
-      run: cd tests/e2e && docker compose up --detach --build
+      run: docker compose up --detach --build
 
     - name: Run tests
-      run: cd tests/e2e && docker compose exec drupal venom run
+      run: docker compose exec drupal venom run
       env:
         # Allow proper output.
         IS_TTY: true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,24 @@
+name: e2e
+
+on:
+  # schedule:
+  #   - cron: '17 4 * * *'
+  workflow_call: {}
+  workflow_dispatch:
+
+jobs:
+
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+    - uses: actions/checkout@main
+
+    - name: Build & start containers
+      run: cd tests/e2e && docker compose up --detach --build
+
+    - name: Run tests
+      run: cd tests/e2e && docker compose exec drupal venom run
+      env:
+        # Allow proper output.
+        IS_TTY: true

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -79,5 +79,7 @@ jobs:
       if: startsWith(github.ref_name, 'v')
 
   publish-docker:
-    needs: test-build
+    needs:
+      - test-build
+      - publish-binary
     uses: ./.github/workflows/docker-publish.yml

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 build
-node_modules
-
 dist/
-
+docker-compose.override.yml
+node_modules
 registry_gen.go

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     image: shipshape-e2e-drupal
     build:
       context: .
-      dockerfile: Dockerfile
+      dockerfile: tests/e2e/Dockerfile
     volumes:
-      - ./suites:/suites
+      - ./tests/e2e/suites:/suites
     working_dir: /suites

--- a/pkg/checks/drupal/dbmodulecheck_test.go
+++ b/pkg/checks/drupal/dbmodulecheck_test.go
@@ -88,10 +88,8 @@ node:
 	assert.Equal(result.Pass, c.Result.Status)
 	assert.Empty(c.Result.Failures)
 	assert.ElementsMatch(c.Result.Passes, []string{
-		"'block' is enabled",
-		"'node' is enabled",
-		"'views_ui' is not enabled",
-		"'field_ui' is not enabled",
+		"all required modules are enabled",
+		"all disallowed modules are disabled",
 	})
 
 	c = mockCheck(map[string][]byte{
@@ -106,11 +104,11 @@ views_ui:
 
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.ElementsMatch(c.Result.Passes, []string{
-		"'node' is enabled",
-		"'field_ui' is not enabled",
+		"some required modules are enabled: node",
+		"some disallowed modules are disabled: field_ui",
 	})
 	assert.ElementsMatch(c.Result.Failures, []string{
-		"'block' is not enabled",
-		"'views_ui' is enabled",
+		"required modules are not enabled: block",
+		"disallowed modules are enabled: views_ui",
 	})
 }

--- a/pkg/checks/drupal/dbmodulecheck_test.go
+++ b/pkg/checks/drupal/dbmodulecheck_test.go
@@ -61,9 +61,9 @@ func TestDbModuleCheck(t *testing.T) {
 			dataMap = map[string][]byte{
 				"modules": []byte(`
 block:
-  status: enabled
+  status: Enabled
 node:
-  status: enabled
+  status: Enabled
 
 `),
 			}
@@ -95,9 +95,9 @@ node:
 	c = mockCheck(map[string][]byte{
 		"modules": []byte(`
 node:
-  status: enabled
+  status: Enabled
 views_ui:
-  status: enabled
+  status: Enabled
 
 `),
 	})

--- a/pkg/checks/drupal/drupal.go
+++ b/pkg/checks/drupal/drupal.go
@@ -2,6 +2,7 @@ package drupal
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/salsadigitalauorg/shipshape/pkg/checks/yaml"
 	"github.com/salsadigitalauorg/shipshape/pkg/config"
@@ -42,37 +43,66 @@ var CheckModulesInYaml = func(c *yaml.YamlBase, ct config.CheckType, configName 
 		}
 	}
 
-	for _, m := range required {
-		kvr, _, err := c.CheckKeyValue(moduleKey(m), configName)
-		// It could be a value different from 0, which still means it's enabled.
-		if kvr == yaml.KeyValueEqual || kvr == yaml.KeyValueNotEqual {
-			c.AddPass(fmt.Sprintf("'%s' is enabled", m))
-		} else if kvr == yaml.KeyValueError {
-			c.AddFail(err.Error())
-			c.AddBreach(result.ValueBreach{Value: err.Error()})
-		} else {
-			c.AddFail(fmt.Sprintf("'%s' is not enabled", m))
-			c.AddBreach(result.KeyValueBreach{
-				Key:   "required module is disabled",
-				Value: m,
-			})
+	determineModuleStatus := func(modules []string) ([]string, []string, []string) {
+		enabled := []string{}
+		errored := []string{}
+		disabled := []string{}
+
+		for _, m := range modules {
+			kvr, _, err := c.CheckKeyValue(moduleKey(m), configName)
+			// It could be a value different from 0, which still means it's enabled.
+			if kvr == yaml.KeyValueEqual || kvr == yaml.KeyValueNotEqual {
+				enabled = append(enabled, m)
+			} else if kvr == yaml.KeyValueError {
+				errored = append(errored, err.Error())
+			} else {
+				disabled = append(disabled, m)
+			}
 		}
+
+		return enabled, errored, disabled
 	}
-	for _, m := range disallowed {
-		kvr, _, err := c.CheckKeyValue(moduleKey(m), configName)
-		// It could be a value different from 0, which still means it's enabled.
-		if kvr == yaml.KeyValueEqual || kvr == yaml.KeyValueNotEqual {
-			c.AddFail(fmt.Sprintf("'%s' is enabled", m))
-			c.AddBreach(result.KeyValueBreach{
-				Key:   "disallowed module is enabled",
-				Value: m,
-			})
-		} else if kvr == yaml.KeyValueError {
-			c.AddFail(err.Error())
-			c.AddBreach(result.ValueBreach{Value: err.Error()})
-		} else {
-			c.AddPass(fmt.Sprintf("'%s' is not enabled", m))
-		}
+
+	required_enabled, required_errored, required_disabled := determineModuleStatus(required)
+	if len(required_errored) > 0 {
+		c.AddFail(fmt.Sprintf(
+			"error verifying status for required modules: %s",
+			strings.Join(required_errored, ",")))
+		c.AddBreach(result.KeyValuesBreach{
+			Key:    "error verifying status for required modules",
+			Values: required_errored})
+	}
+	if len(required_disabled) > 0 {
+		c.AddFail(fmt.Sprintf(
+			"required modules are not enabled: %s",
+			strings.Join(required_disabled, ",")))
+		c.AddBreach(result.KeyValuesBreach{
+			Key:    "required modules are not enabled",
+			Values: required_disabled})
+	}
+	if len(required_enabled) == len(required) {
+		c.AddPass("all required modules are enabled")
+	}
+
+	disallowed_enabled, disallowed_errored, disallowed_disabled := determineModuleStatus(disallowed)
+	if len(disallowed_errored) > 0 {
+		c.AddFail(fmt.Sprintf(
+			"error verifying status for disallowed modules: %s",
+			strings.Join(disallowed_errored, ",")))
+		c.AddBreach(result.KeyValuesBreach{
+			Key:    "error verifying status for disallowed modules",
+			Values: disallowed_errored})
+	}
+	if len(disallowed_enabled) > 0 {
+		c.AddFail(fmt.Sprintf(
+			"disallowed modules are enabled: %s",
+			strings.Join(disallowed_enabled, ",")))
+		c.AddBreach(result.KeyValuesBreach{
+			Key:    "disallowed modules are enabled",
+			Values: disallowed_enabled})
+	}
+	if len(disallowed_disabled) == len(required) {
+		c.AddPass("all disallowed modules are disabled")
 	}
 
 	if len(c.Result.Failures) == 0 {

--- a/pkg/checks/drupal/drupal.go
+++ b/pkg/checks/drupal/drupal.go
@@ -82,6 +82,10 @@ var CheckModulesInYaml = func(c *yaml.YamlBase, ct config.CheckType, configName 
 	}
 	if len(required_enabled) == len(required) {
 		c.AddPass("all required modules are enabled")
+	} else if len(required_enabled) > 0 {
+		c.AddPass(fmt.Sprint(
+			"some required modules are enabled: ",
+			strings.Join(required_enabled, ",")))
 	}
 
 	disallowed_enabled, disallowed_errored, disallowed_disabled := determineModuleStatus(disallowed)
@@ -103,6 +107,10 @@ var CheckModulesInYaml = func(c *yaml.YamlBase, ct config.CheckType, configName 
 	}
 	if len(disallowed_disabled) == len(required) {
 		c.AddPass("all disallowed modules are disabled")
+	} else if len(disallowed_disabled) > 0 {
+		c.AddPass(fmt.Sprint(
+			"some disallowed modules are disabled: ",
+			strings.Join(disallowed_disabled, ",")))
 	}
 
 	if len(c.Result.Failures) == 0 {

--- a/pkg/checks/drupal/drupal_test.go
+++ b/pkg/checks/drupal/drupal_test.go
@@ -70,12 +70,10 @@ module:
 
 	CheckModulesInYaml(&c, FileModule, "shipshape.extension.yml", required, disallowed)
 	assert.ElementsMatch(c.Result.Passes, []string{
-		"'clamav' is enabled",
-		"'tfa' is enabled",
-		"'module_permissions_ui' is not enabled",
-		"'update' is not enabled",
+		"all required modules are enabled",
+		"all disallowed modules are disabled",
 	})
-	assert.ElementsMatch(c.Result.Failures, []string{"'dblog' is enabled"})
+	assert.ElementsMatch(c.Result.Failures, []string{"disallowed modules are enabled: dblog"})
 }
 
 func TestCheckModulesInYaml(t *testing.T) {
@@ -95,12 +93,12 @@ func TestCheckModulesInYaml(t *testing.T) {
 	CheckModulesInYaml(&c, FileModule, "shipshape.extension.yml", required, disallowed)
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.ElementsMatch(c.Result.Passes, []string{
-		"'block' is enabled",
-		"'views_ui' is not enabled",
+		"some required modules are enabled: block",
+		"some disallowed modules are disabled: views_ui",
 	})
 	assert.ElementsMatch(c.Result.Failures, []string{
-		"invalid character '&' at position 11, following \".node\"",
-		"invalid character '&' at position 15, following \".field_ui\"",
+		"error verifying status for required modules: invalid character '&' at position 11, following \".node\"",
+		"error verifying status for disallowed modules: invalid character '&' at position 15, following \".field_ui\"",
 	})
 
 	// Required is not enabled & disallowed is enabled.
@@ -125,12 +123,12 @@ module:
 	CheckModulesInYaml(&c, FileModule, "shipshape.extension.yml", required, disallowed)
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.ElementsMatch(c.Result.Passes, []string{
-		"'block' is enabled",
-		"'field_ui' is not enabled",
+		"some required modules are enabled: block",
+		"some disallowed modules are disabled: field_ui",
 	})
 	assert.ElementsMatch(c.Result.Failures, []string{
-		"'node' is not enabled",
-		"'views_ui' is enabled",
+		"required modules are not enabled: node",
+		"disallowed modules are enabled: views_ui",
 	})
 
 	c = mockCheck("shipshape.extension.yml")
@@ -147,9 +145,7 @@ module:
 	assert.Equal(result.Pass, c.Result.Status)
 	assert.Empty(c.Result.Failures)
 	assert.ElementsMatch(c.Result.Passes, []string{
-		"'node' is enabled",
-		"'block' is enabled",
-		"'views_ui' is not enabled",
-		"'field_ui' is not enabled",
+		"all required modules are enabled",
+		"all disallowed modules are disabled",
 	})
 }

--- a/pkg/checks/drupal/drupal_test.go
+++ b/pkg/checks/drupal/drupal_test.go
@@ -81,6 +81,20 @@ tfa:
 			expectedDisabled: []string{},
 		},
 		{
+			name: "all enabled - db - lowercase",
+			yaml: `
+clamav:
+  status: enabled
+tfa:
+  status: enabled
+`,
+			modules:          []string{"clamav", "tfa"},
+			ct:               DbModule,
+			expectedEnabled:  []string{"clamav", "tfa"},
+			expectedErrored:  []string{},
+			expectedDisabled: []string{},
+		},
+		{
 			name: "all disabled - file",
 			yaml: `
 module:

--- a/pkg/checks/drupal/drushyamlcheck.go
+++ b/pkg/checks/drupal/drushyamlcheck.go
@@ -46,7 +46,8 @@ func (c *DrushYamlCheck) FetchData() {
 			msg := string(err.(*exec.ExitError).Stderr)
 			c.AddFail(strings.ReplaceAll(strings.TrimSpace(msg), "  \n  ", ""))
 			c.AddBreach(result.ValueBreach{
-				Value: strings.ReplaceAll(strings.TrimSpace(msg), "  \n  ", "")})
+				ValueLabel: c.ConfigName,
+				Value:      strings.ReplaceAll(strings.TrimSpace(msg), "  \n  ", "")})
 		}
 	}
 }

--- a/pkg/checks/drupal/filemodulecheck_test.go
+++ b/pkg/checks/drupal/filemodulecheck_test.go
@@ -5,7 +5,6 @@ import (
 
 	. "github.com/salsadigitalauorg/shipshape/pkg/checks/drupal"
 	"github.com/salsadigitalauorg/shipshape/pkg/checks/yaml"
-	"github.com/salsadigitalauorg/shipshape/pkg/config"
 	"github.com/salsadigitalauorg/shipshape/pkg/result"
 	"github.com/stretchr/testify/assert"
 )
@@ -42,52 +41,6 @@ func TestFileModuleMerge(t *testing.T) {
 		Required:   []string{"req2"},
 		Disallowed: []string{"disallowed2"},
 	}, c)
-}
-
-func TestFileModuleConfigName(t *testing.T) {
-	assert := assert.New(t)
-
-	configNameVal := ""
-	origCheckModulesInYaml := CheckModulesInYaml
-	mockCheckModulesInYaml := func(c *yaml.YamlBase, ct config.CheckType, configName string, required, disallowed []string) {
-		configNameVal = configName
-	}
-
-	t.Run("noPath", func(t *testing.T) {
-		c := FileModuleCheck{YamlCheck: yaml.YamlCheck{File: "foo.bar"}}
-		CheckModulesInYaml = mockCheckModulesInYaml
-		defer func() {
-			CheckModulesInYaml = origCheckModulesInYaml
-		}()
-		c.RunCheck()
-		assert.Equal("foo.bar", configNameVal)
-	})
-
-	t.Run("pathWithoutSlash", func(t *testing.T) {
-		c := FileModuleCheck{YamlCheck: yaml.YamlCheck{
-			File: "foo.bar",
-			Path: "/some/path",
-		}}
-		CheckModulesInYaml = mockCheckModulesInYaml
-		defer func() {
-			CheckModulesInYaml = origCheckModulesInYaml
-		}()
-		c.RunCheck()
-		assert.Equal("/some/path/foo.bar", configNameVal)
-	})
-
-	t.Run("pathWithSlash", func(t *testing.T) {
-		c := FileModuleCheck{YamlCheck: yaml.YamlCheck{
-			File: "foo.bar",
-			Path: "/some/path/",
-		}}
-		CheckModulesInYaml = mockCheckModulesInYaml
-		defer func() {
-			CheckModulesInYaml = origCheckModulesInYaml
-		}()
-		c.RunCheck()
-		assert.Equal("/some/path/foo.bar", configNameVal)
-	})
 }
 
 func TestFileModuleCheck(t *testing.T) {

--- a/pkg/checks/drupal/filemodulecheck_test.go
+++ b/pkg/checks/drupal/filemodulecheck_test.go
@@ -109,9 +109,7 @@ func TestFileModuleCheck(t *testing.T) {
 	assert.Equal(result.Pass, c.Result.Status)
 	assert.Empty(c.Result.Failures)
 	assert.ElementsMatch(c.Result.Passes, []string{
-		"'node' is enabled",
-		"'block' is enabled",
-		"'views_ui' is not enabled",
-		"'field_ui' is not enabled",
+		"all required modules are enabled",
+		"all disallowed modules are disabled",
 	})
 }

--- a/pkg/checks/file/filecheck.go
+++ b/pkg/checks/file/filecheck.go
@@ -55,7 +55,9 @@ func (c *FileCheck) RunCheck() {
 	files, err := utils.FindFiles(filepath.Join(config.ProjectDir, c.Path), c.DisallowedPattern, c.ExcludePattern, c.SkipDir)
 	if err != nil {
 		c.AddFail(err.Error())
-		c.AddBreach(result.ValueBreach{Value: err.Error()})
+		c.AddBreach(result.ValueBreach{
+			ValueLabel: "error finding files",
+			Value:      err.Error()})
 		return
 	}
 	if len(files) == 0 {
@@ -65,9 +67,9 @@ func (c *FileCheck) RunCheck() {
 	}
 	for _, f := range files {
 		c.AddFail(fmt.Sprintf("Illegal file found: %s", f))
-		c.AddBreach(result.ValueBreach{
-			ValueLabel: "illegal file",
-			Value:      f,
-		})
 	}
+	c.AddBreach(result.KeyValuesBreach{
+		Key:    fmt.Sprintf("%s - illegal files found", c.Name),
+		Values: files,
+	})
 }

--- a/pkg/checks/phpstan/phpstan.go
+++ b/pkg/checks/phpstan/phpstan.go
@@ -110,7 +110,8 @@ func (c *PhpStanCheck) FetchData() {
 	}
 
 	if !foundPath {
-		c.AddPass("no paths found to run phpstan on.")
+		c.Result.Status = result.Pass
+		c.AddPass("no paths found to run phpstan on")
 		return
 	}
 
@@ -146,8 +147,7 @@ func (c *PhpStanCheck) HasData(failCheck bool) bool {
 // UnmarshalDataMap parses the phpstan json into the PhpStan
 // type for further processing.
 func (c *PhpStanCheck) UnmarshalDataMap() {
-	// Success if there's a pass at this point as it means no directory was found.
-	if len(c.Result.Passes) > 0 {
+	if c.Result.Status == result.Pass {
 		return
 	}
 

--- a/pkg/checks/phpstan/phpstan.go
+++ b/pkg/checks/phpstan/phpstan.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/salsadigitalauorg/shipshape/pkg/command"
 	"github.com/salsadigitalauorg/shipshape/pkg/config"
@@ -92,18 +93,25 @@ func (c *PhpStanCheck) FetchData() {
 
 	args := []string{
 		"analyse",
-		fmt.Sprintf("--configuration=%s", configPath),
+		"--configuration=" + configPath,
 		"--no-progress",
 		"--error-format=json",
 	}
+	foundPath := false
 	for _, p := range c.Paths {
 		path := p
 		if !filepath.IsAbs(path) {
 			path = filepath.Join(config.ProjectDir, p)
 		}
 		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			foundPath = true
 			args = append(args, path)
 		}
+	}
+
+	if !foundPath {
+		c.AddPass("no paths found to run phpstan on.")
+		return
 	}
 
 	c.DataMap = map[string][]byte{}
@@ -112,18 +120,37 @@ func (c *PhpStanCheck) FetchData() {
 		if pathErr, ok := err.(*fs.PathError); ok {
 			c.AddFail(pathErr.Path + ": " + pathErr.Err.Error())
 			c.AddBreach(result.ValueBreach{
-				Value: pathErr.Path + ": " + pathErr.Err.Error()})
+				ValueLabel: pathErr.Path,
+				Value:      pathErr.Err.Error()})
 		} else if len(c.DataMap["phpstan"]) == 0 { // If errors were found, exit code will be 1.
 			c.AddFail("Phpstan failed to run: " + string(err.(*exec.ExitError).Stderr))
 			c.AddBreach(result.ValueBreach{
-				Value: "Phpstan failed to run: " + string(err.(*exec.ExitError).Stderr)})
+				ValueLabel: "Phpstan failed to run",
+				Value:      string(err.(*exec.ExitError).Stderr)})
 		}
 	}
+}
+
+// HasData is overridden here to prevent the check from failing if there is no
+// directory for phpstan to scan.
+func (c *PhpStanCheck) HasData(failCheck bool) bool {
+	if c.DataMap == nil && len(c.Result.Passes) == 0 {
+		if failCheck {
+			c.AddFail("no data available")
+		}
+		return false
+	}
+	return true
 }
 
 // UnmarshalDataMap parses the phpstan json into the PhpStan
 // type for further processing.
 func (c *PhpStanCheck) UnmarshalDataMap() {
+	// Success if there's a pass at this point as it means no directory was found.
+	if len(c.Result.Passes) > 0 {
+		return
+	}
+
 	if len(c.DataMap["phpstan"]) == 0 {
 		c.Result.Status = result.Pass
 		c.AddWarning("Unhandled PHPStan response, unable to determine status.")
@@ -134,7 +161,9 @@ func (c *PhpStanCheck) UnmarshalDataMap() {
 	err := json.Unmarshal(c.DataMap["phpstan"], &c.phpstanResult)
 	if err != nil {
 		c.AddFail(err.Error())
-		c.AddBreach(result.ValueBreach{Value: err.Error()})
+		c.AddBreach(result.ValueBreach{
+			ValueLabel: "unable to parse phpstan result",
+			Value:      err.Error()})
 		return
 	}
 
@@ -147,7 +176,9 @@ func (c *PhpStanCheck) UnmarshalDataMap() {
 	err = json.Unmarshal(c.phpstanResult.FilesRaw, &c.phpstanResult.Files)
 	if err != nil {
 		c.AddFail(err.Error())
-		c.AddBreach(result.ValueBreach{Value: err.Error()})
+		c.AddBreach(result.ValueBreach{
+			ValueLabel: "unable to parse phpstan file errors",
+			Value:      err.Error()})
 		return
 	}
 }
@@ -161,17 +192,24 @@ func (c *PhpStanCheck) RunCheck() {
 	}
 
 	for file, errors := range c.phpstanResult.Files {
+		errLines := []string{}
 		for _, er := range errors.Messages {
 			c.AddFail(fmt.Sprintf("[%s] Line %d: %s", file, er.Line, er.Message))
-			c.AddBreach(result.KeyValueBreach{
-				Key:   fmt.Sprintf("%s:%d", file, er.Line),
-				Value: er.Message,
-			})
+			errLines = append(errLines, fmt.Sprintf("line %d: %s", er.Line, er.Message))
+
 		}
+		c.AddBreach(result.KeyValueBreach{
+			Key:   fmt.Sprintf("file contains banned functions: %s", file),
+			Value: strings.Join(errLines, "\n"),
+		})
 	}
 
 	for _, er := range c.phpstanResult.Errors {
 		c.AddFail(er)
-		c.AddBreach(result.ValueBreach{Value: er})
+	}
+	if len(c.phpstanResult.Errors) > 0 {
+		c.AddBreach(result.ValueBreach{
+			ValueLabel: "errors encountered when running phpstan",
+			Value:      strings.Join(c.phpstanResult.Errors, "\n")})
 	}
 }

--- a/pkg/checks/yaml/keyvalue.go
+++ b/pkg/checks/yaml/keyvalue.go
@@ -1,6 +1,8 @@
 package yaml
 
 import (
+	"strings"
+
 	"github.com/salsadigitalauorg/shipshape/pkg/utils"
 )
 
@@ -64,7 +66,7 @@ func (kv KeyValue) Equals(value string) bool {
 	if kv.Truthy {
 		return kv.EqualsTruthy(value)
 	}
-	return kv.Value == value
+	return strings.EqualFold(kv.Value, value)
 }
 
 func (kv KeyValue) EqualsTruthy(value string) bool {

--- a/pkg/checks/yaml/keyvalue_test.go
+++ b/pkg/checks/yaml/keyvalue_test.go
@@ -50,6 +50,7 @@ func TestEquals(t *testing.T) {
 	t.Run("stringEquals", func(t *testing.T) {
 		kv := KeyValue{Key: "k", Value: "foo"}
 		assert.True(kv.Equals("foo"))
+		assert.True(kv.Equals("FoO"))
 		assert.False(kv.Equals("bar"))
 	})
 

--- a/pkg/checks/yaml/yaml.go
+++ b/pkg/checks/yaml/yaml.go
@@ -63,7 +63,7 @@ func (c *YamlBase) UnmarshalDataMap() {
 // Fail messages of the Check Result.
 func (c *YamlBase) processData(configName string) {
 	for _, kv := range c.Values {
-		kvr, fails, err := c.CheckKeyValue(kv, configName)
+		kvr, fails, err := CheckKeyValue(c.NodeMap[configName], kv)
 		switch kvr {
 		case KeyValueError:
 			c.AddFail(err.Error())
@@ -112,8 +112,7 @@ func (c *YamlBase) processData(configName string) {
 
 // CheckKeyValue lookups the Yaml data for a specific KeyValue and returns the
 // result, actual values and errors.
-func (c *YamlBase) CheckKeyValue(kv KeyValue, mapKey string) (KeyValueResult, []string, error) {
-	node := c.NodeMap[mapKey]
+func CheckKeyValue(node yaml.Node, kv KeyValue) (KeyValueResult, []string, error) {
 	foundNodes, err := utils.LookupYamlPath(&node, kv.Key)
 	if err != nil {
 		return KeyValueError, nil, err

--- a/pkg/checks/yaml/yaml.go
+++ b/pkg/checks/yaml/yaml.go
@@ -80,7 +80,7 @@ func (c *YamlBase) processData(configName string) {
 			c.AddFail(fmt.Sprintf("[%s] '%s' equals '%s', expected '%s'",
 				configName, kv.Key, fails[0], kv.Value))
 			c.AddBreach(result.KeyValueBreach{
-				KeyLabel:      "config:" + configName,
+				KeyLabel:      configName,
 				Key:           kv.Key,
 				ValueLabel:    "actual",
 				ExpectedValue: kv.Value,

--- a/pkg/checks/yaml/yaml_test.go
+++ b/pkg/checks/yaml/yaml_test.go
@@ -103,6 +103,7 @@ func TestYamlCheckKeyValue(t *testing.T) {
 foo:
   bar:
     - baz: zoo
+    - zap: Bam
 `), &singleValueNode)
 
 	multiValueNode := yamlv3.Node{}
@@ -161,6 +162,17 @@ foo:
 			keyValue: KeyValue{
 				Key:   "foo.bar[0].baz",
 				Value: "zoo",
+			},
+			expectedResult: KeyValueEqual,
+			expectedValues: nil,
+			expectedError:  nil,
+		},
+		{
+			name: "correct value - case sensitivity",
+			node: singleValueNode,
+			keyValue: KeyValue{
+				Key:   "foo.bar[1].zap",
+				Value: "bam",
 			},
 			expectedResult: KeyValueEqual,
 			expectedValues: nil,
@@ -244,9 +256,9 @@ foo:
 
 			assert := assert.New(t)
 			kvr, values, err := CheckKeyValue(tt.node, tt.keyValue)
-			assert.Equal(tt.expectedResult, kvr)
-			assert.EqualValues(tt.expectedValues, values)
-			assert.Equal(err, tt.expectedError)
+			assert.Equal(tt.expectedResult, kvr, "expected result to match")
+			assert.EqualValues(tt.expectedValues, values, "expected values to match")
+			assert.Equal(err, tt.expectedError, "expected error to match")
 		})
 	}
 }

--- a/pkg/checks/yaml/yaml_test.go
+++ b/pkg/checks/yaml/yaml_test.go
@@ -1,7 +1,10 @@
 package yaml_test
 
 import (
+	"errors"
 	"testing"
+
+	yamlv3 "gopkg.in/yaml.v3"
 
 	. "github.com/salsadigitalauorg/shipshape/pkg/checks/yaml"
 	"github.com/salsadigitalauorg/shipshape/pkg/config"
@@ -95,128 +98,157 @@ foo:
 }
 
 func TestYamlCheckKeyValue(t *testing.T) {
-	assert := assert.New(t)
-
-	c := YamlBase{
-		CheckBase: config.CheckBase{
-			DataMap: map[string][]byte{
-				"data": []byte(`
+	singleValueNode := yamlv3.Node{}
+	yamlv3.Unmarshal([]byte(`
 foo:
   bar:
     - baz: zoo
+`), &singleValueNode)
 
-`),
-			},
-		},
-	}
-	c.UnmarshalDataMap()
-
-	// Invalid path.
-	_, _, err := c.CheckKeyValue(KeyValue{
-		Key:   "&*&^);",
-		Value: "foo",
-	}, "data")
-	assert.Equal("child name missing at position 0, following \"\"", err.Error())
-
-	// Non-existent path.
-	kvr, _, err := c.CheckKeyValue(KeyValue{
-		Key:   "foo.baz",
-		Value: "foo",
-	}, "data")
-	assert.Equal(nil, err)
-	assert.Equal(KeyValueNotFound, kvr)
-
-	// Wrong value.
-	kvr, _, err = c.CheckKeyValue(KeyValue{
-		Key:   "foo.bar[0].baz",
-		Value: "zoom",
-	}, "data")
-	assert.Equal(nil, err)
-	assert.Equal(KeyValueNotEqual, kvr)
-
-	// Correct value.
-	kvr, _, err = c.CheckKeyValue(KeyValue{
-		Key:   "foo.bar[0].baz",
-		Value: "zoo",
-	}, "data")
-	assert.Equal(nil, err)
-	assert.Equal(KeyValueEqual, kvr)
-
-	// Optional value not present.
-	kvr, _, err = c.CheckKeyValue(KeyValue{
-		Key:      "foo.bar[0].bazzle",
-		Value:    "zoom",
-		Optional: true,
-	}, "data")
-	assert.Equal(nil, err)
-	assert.Equal(KeyValueEqual, kvr)
-}
-
-func TestYamlCheckKeyValueList(t *testing.T) {
-	assert := assert.New(t)
-
-	c := YamlBase{
-		CheckBase: config.CheckBase{
-			DataMap: map[string][]byte{
-				"data": []byte(`
+	multiValueNode := yamlv3.Node{}
+	yamlv3.Unmarshal([]byte(`
 foo:
   bar:
     - baz
     - zoo
     - zoom
+`), &multiValueNode)
 
-`),
+	tests := []struct {
+		name           string
+		node           yamlv3.Node
+		keyValue       KeyValue
+		expectedResult KeyValueResult
+		expectedValues []string
+		expectedError  error
+	}{
+		{
+			name: "invalid path",
+			node: singleValueNode,
+			keyValue: KeyValue{
+				Key:   "&*&^);",
+				Value: "foo",
 			},
+			expectedResult: KeyValueError,
+			expectedValues: nil,
+			expectedError:  errors.New("child name missing at position 0, following \"\""),
+		},
+		{
+			name: "non-existent path",
+			node: singleValueNode,
+			keyValue: KeyValue{
+				Key:   "foo.baz",
+				Value: "foo",
+			},
+			expectedResult: KeyValueNotFound,
+			expectedValues: nil,
+			expectedError:  nil,
+		},
+		{
+			name: "wrong value",
+			node: singleValueNode,
+			keyValue: KeyValue{
+				Key:   "foo.bar[0].baz",
+				Value: "zoom",
+			},
+			expectedResult: KeyValueNotEqual,
+			expectedValues: []string{"zoo"},
+			expectedError:  nil,
+		},
+		{
+			name: "correct value",
+			node: singleValueNode,
+			keyValue: KeyValue{
+				Key:   "foo.bar[0].baz",
+				Value: "zoo",
+			},
+			expectedResult: KeyValueEqual,
+			expectedValues: nil,
+			expectedError:  nil,
+		},
+		{
+			name: "optional value not present",
+			node: singleValueNode,
+			keyValue: KeyValue{
+				Key:      "foo.bar[0].bazzle",
+				Value:    "zoom",
+				Optional: true,
+			},
+			expectedResult: KeyValueEqual,
+			expectedValues: nil,
+			expectedError:  nil,
+		},
+		{
+			name: "multivalue - disallowed list not provided",
+			node: multiValueNode,
+			keyValue: KeyValue{
+				Key:    "foo.bar",
+				IsList: true,
+			},
+			expectedResult: KeyValueError,
+			expectedValues: nil,
+			expectedError:  errors.New("list of allowed or disallowed values not provided"),
+		},
+		{
+			name: "multivalue - disallowed values in yaml",
+			node: multiValueNode,
+			keyValue: KeyValue{
+				Key:        "foo.bar",
+				IsList:     true,
+				Disallowed: []string{"baz", "zoo"},
+			},
+			expectedResult: KeyValueDisallowedFound,
+			expectedValues: []string{"baz", "zoo"},
+			expectedError:  nil,
+		},
+		{
+			name: "multivalue - no disallowed values in yaml",
+			node: multiValueNode,
+			keyValue: KeyValue{
+				Key:        "foo.bar",
+				IsList:     true,
+				Disallowed: []string{"this should", "be a success"},
+			},
+			expectedResult: KeyValueEqual,
+			expectedValues: nil,
+			expectedError:  nil,
+		},
+		{
+			name: "multivalue - allowed values in yaml all match",
+			node: multiValueNode,
+			keyValue: KeyValue{
+				Key:     "foo.bar",
+				IsList:  true,
+				Allowed: []string{"baz", "zoo", "zoom"},
+			},
+			expectedResult: KeyValueEqual,
+			expectedValues: nil,
+			expectedError:  nil,
+		},
+		{
+			name: "multivalue - value not in allowed list",
+			node: multiValueNode,
+			keyValue: KeyValue{
+				Key:     "foo.bar",
+				IsList:  true,
+				Allowed: []string{"baz", "zoo"},
+			},
+			expectedResult: KeyValueDisallowedFound,
+			expectedValues: []string{"zoom"},
+			expectedError:  nil,
 		},
 	}
-	c.UnmarshalDataMap()
 
-	// Disallowed list not provided.
-	_, _, err := c.CheckKeyValue(KeyValue{
-		Key:    "foo.bar",
-		IsList: true,
-	}, "data")
-	assert.Equal("list of allowed or disallowed values not provided", err.Error())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 
-	var kvr KeyValueResult
-	var fails []string
-	// Disallowed values in yaml.
-	kvr, fails, err = c.CheckKeyValue(KeyValue{
-		Key:        "foo.bar",
-		IsList:     true,
-		Disallowed: []string{"baz", "zoo"},
-	}, "data")
-	assert.Equal(nil, err)
-	assert.Equal(KeyValueDisallowedFound, kvr)
-	assert.EqualValues([]string{"baz", "zoo"}, fails)
-
-	// No disallowed values in yaml.
-	kvr, fails, _ = c.CheckKeyValue(KeyValue{
-		Key:        "foo.bar",
-		IsList:     true,
-		Disallowed: []string{"this should", "be a success"},
-	}, "data")
-	assert.Equal(KeyValueEqual, kvr)
-	assert.EqualValues(0, len(fails))
-
-	// Allowed values in yaml all match.
-	kvr, fails, _ = c.CheckKeyValue(KeyValue{
-		Key:     "foo.bar",
-		IsList:  true,
-		Allowed: []string{"baz", "zoo", "zoom"},
-	}, "data")
-	assert.Equal(KeyValueEqual, kvr)
-	assert.EqualValues(0, len(fails))
-
-	// Value not in Allowed list.
-	kvr, fails, _ = c.CheckKeyValue(KeyValue{
-		Key:     "foo.bar",
-		IsList:  true,
-		Allowed: []string{"baz", "zoo"},
-	}, "data")
-	assert.Equal(KeyValueDisallowedFound, kvr)
-	assert.EqualValues([]string{"zoom"}, fails)
-
+			assert := assert.New(t)
+			kvr, values, err := CheckKeyValue(tt.node, tt.keyValue)
+			assert.Equal(tt.expectedResult, kvr)
+			assert.EqualValues(tt.expectedValues, values)
+			assert.Equal(err, tt.expectedError)
+		})
+	}
 }
 
 func TestYamlBase(t *testing.T) {

--- a/pkg/checks/yaml/yamlcheck.go
+++ b/pkg/checks/yaml/yamlcheck.go
@@ -39,7 +39,9 @@ func (c *YamlCheck) readFile(fkey string, fname string) {
 			c.Result.Status = result.Pass
 		} else {
 			c.AddFail(err.Error())
-			c.AddBreach(result.ValueBreach{Value: err.Error()})
+			c.AddBreach(result.ValueBreach{
+				ValueLabel: "error reading file: " + fname,
+				Value:      err.Error()})
 		}
 	}
 }
@@ -65,7 +67,9 @@ func (c *YamlCheck) FetchData() {
 				c.Result.Status = result.Pass
 			} else {
 				c.AddFail(err.Error())
-				c.AddBreach(result.ValueBreach{Value: err.Error()})
+				c.AddBreach(result.ValueBreach{
+					ValueLabel: "error finding files in path: " + configPath,
+					Value:      err.Error()})
 			}
 			return
 		}
@@ -76,7 +80,9 @@ func (c *YamlCheck) FetchData() {
 			return
 		} else if len(files) == 0 {
 			c.AddFail("no matching config files found")
-			c.AddBreach(result.ValueBreach{Value: "no matching config files found"})
+			c.AddBreach(result.ValueBreach{
+				ValueLabel: c.Name + "- no file",
+				Value:      "no matching yaml files found"})
 			return
 		}
 
@@ -86,6 +92,8 @@ func (c *YamlCheck) FetchData() {
 		}
 	} else {
 		c.AddFail("no file provided")
-		c.AddBreach(result.ValueBreach{Value: "no file provided"})
+		c.AddBreach(result.ValueBreach{
+			ValueLabel: c.Name + "- no file",
+			Value:      "no file provided"})
 	}
 }

--- a/pkg/lagoon/lagoon.go
+++ b/pkg/lagoon/lagoon.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/hasura/go-graphql-client"
+	"github.com/salsadigitalauorg/shipshape/pkg/result"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
 )
@@ -125,4 +127,42 @@ func ReplaceFacts(facts []Fact) error {
 	}
 	log.Debug("adding new facts")
 	return AddFacts(facts)
+}
+
+func BreachFactName(b result.Breach) string {
+	var name string
+	if result.BreachGetKeyLabel(b) != "" {
+		name = fmt.Sprintf("%s: %s", result.BreachGetKeyLabel(b),
+			result.BreachGetKey(b))
+	} else if result.BreachGetKey(b) != "" {
+		name = result.BreachGetKey(b)
+	} else if result.BreachGetValueLabel(b) != "" {
+		name = result.BreachGetValueLabel(b)
+	} else {
+		name = result.BreachGetCheckName(b) + " - " +
+			string(result.BreachGetCheckType(b))
+	}
+	return name
+}
+
+func BreachFactValue(b result.Breach) string {
+	value := result.BreachGetValue(b)
+	if value == "" {
+		value = strings.Join(result.BreachGetValues(b), ", ")
+	}
+
+	label := result.BreachGetValueLabel(b)
+	if label == "" || BreachFactName(b) == label {
+		return value
+	} else {
+		value = fmt.Sprintf("%s: %s", label, value)
+	}
+
+	expected := result.BreachGetExpectedValue(b)
+	if expected == "" {
+		return value
+	} else {
+		value = fmt.Sprintf("expected: %s, %s", expected, value)
+	}
+	return value
 }

--- a/pkg/lagoon/lagoon_test.go
+++ b/pkg/lagoon/lagoon_test.go
@@ -270,6 +270,19 @@ func TestBreachFactNameAndValue(t *testing.T) {
 			expectedValue: "illegal file: /an/illegal/file",
 		},
 		{
+			name: "value breach - with value and key labels and expected value",
+			breach: result.KeyValueBreach{
+				CheckName:     "update module status",
+				CheckType:     "module-status",
+				KeyLabel:      "disallowed module found",
+				ValueLabel:    "actual",
+				Value:         "enabled",
+				ExpectedValue: "disabled",
+			},
+			expectedName:  "disallowed module found: ",
+			expectedValue: "expected: disabled, actual: enabled",
+		},
+		{
 			name: "key-values breach - no label",
 			breach: result.KeyValuesBreach{
 				CheckName: "illegal files",

--- a/pkg/lagoon/lagoon_test.go
+++ b/pkg/lagoon/lagoon_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/salsadigitalauorg/shipshape/pkg/internal"
 	"github.com/salsadigitalauorg/shipshape/pkg/lagoon"
+	"github.com/salsadigitalauorg/shipshape/pkg/result"
 
 	"github.com/hasura/go-graphql-client"
 	"github.com/sirupsen/logrus"
@@ -213,4 +214,77 @@ func TestReplaceFacts(t *testing.T) {
 		"\"cat1\"},{\"name\":\"fact2\",\"value\":\"value2\",\"source\":"+
 		"\"source1\",\"description\":\"\",\"category\":\"cat2\"}],\"project\""+
 		":\"foo\"}}}\n", internal.MockLagoonRequestBodies[2])
+}
+
+func TestBreachFactNameAndValue(t *testing.T) {
+	tests := []struct {
+		name          string
+		breach        result.Breach
+		expectedName  string
+		expectedValue string
+	}{
+		{
+			name: "value breach - no label",
+			breach: result.ValueBreach{
+				CheckName: "illegal file",
+				CheckType: "file",
+				Value:     "/an/illegal/file",
+			},
+			expectedName:  "illegal file - file",
+			expectedValue: "/an/illegal/file",
+		},
+		{
+			name: "value breach - label",
+			breach: result.ValueBreach{
+				CheckName:  "illegal file",
+				CheckType:  "file",
+				ValueLabel: "the illegal file exists",
+				Value:      "/an/illegal/file",
+			},
+			expectedName:  "the illegal file exists",
+			expectedValue: "/an/illegal/file",
+		},
+		{
+			name: "key-value breach - with value label",
+			breach: result.KeyValueBreach{
+				CheckName:  "illegal file",
+				CheckType:  "file",
+				Key:        "illegal file found",
+				ValueLabel: "the illegal file exists",
+				Value:      "/an/illegal/file",
+			},
+			expectedName:  "illegal file found",
+			expectedValue: "the illegal file exists: /an/illegal/file",
+		},
+		{
+			name: "key-value breach - with value and key labels",
+			breach: result.KeyValueBreach{
+				CheckName:  "illegal file",
+				CheckType:  "file",
+				KeyLabel:   "illegal file found in",
+				Key:        "/path/to/dir",
+				ValueLabel: "illegal file",
+				Value:      "/an/illegal/file",
+			},
+			expectedName:  "illegal file found in: /path/to/dir",
+			expectedValue: "illegal file: /an/illegal/file",
+		},
+		{
+			name: "key-values breach - no label",
+			breach: result.KeyValuesBreach{
+				CheckName: "illegal files",
+				CheckType: "file",
+				Values:    []string{"/an/illegal/file", "/another/illegal/file"},
+			},
+			expectedName:  "illegal files - file",
+			expectedValue: "/an/illegal/file, /another/illegal/file",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expectedName, lagoon.BreachFactName(tt.breach))
+			assert.Equal(t, tt.expectedValue, lagoon.BreachFactValue(tt.breach))
+		})
+	}
 }

--- a/pkg/result/breach.go
+++ b/pkg/result/breach.go
@@ -69,16 +69,19 @@ type KeyValuesBreach struct {
 
 func BreachSetCommonValues(bIfc *Breach, checkType string, checkName string, severity string) {
 	if b, ok := (*bIfc).(ValueBreach); ok {
+		b.BreachType = BreachTypeValue
 		b.CheckType = checkType
 		b.CheckName = checkName
 		b.Severity = severity
 		*bIfc = b
 	} else if b, ok := (*bIfc).(KeyValueBreach); ok {
+		b.BreachType = BreachTypeKeyValue
 		b.CheckType = checkType
 		b.CheckName = checkName
 		b.Severity = severity
 		*bIfc = b
 	} else if b, ok := (*bIfc).(KeyValuesBreach); ok {
+		b.BreachType = BreachTypeKeyValues
 		b.CheckType = checkType
 		b.CheckName = checkName
 		b.Severity = severity

--- a/pkg/result/breach.go
+++ b/pkg/result/breach.go
@@ -174,3 +174,12 @@ func BreachGetValues(bIfc Breach) []string {
 	}
 	return []string(nil)
 }
+
+func BreachGetExpectedValue(bIfc Breach) string {
+	if b, ok := bIfc.(ValueBreach); ok {
+		return b.ExpectedValue
+	} else if b, ok := bIfc.(KeyValueBreach); ok {
+		return b.ExpectedValue
+	}
+	return ""
+}

--- a/pkg/result/breach.go
+++ b/pkg/result/breach.go
@@ -3,11 +3,23 @@ package result
 // Breach provides a representation for different breach types.
 type Breach interface{}
 
+type BreachType string
+
+const (
+	// BreachTypeValue is a breach with a value.
+	BreachTypeValue BreachType = "value"
+	// BreachTypeKeyValue is a breach with a key and a value.
+	BreachTypeKeyValue BreachType = "key-value"
+	// BreachTypeKeyValues is a breach with a key and a list of values.
+	BreachTypeKeyValues BreachType = "key-values"
+)
+
 // Simple breach with no key.
 // Example:
 //
 //	"file foo.ext not found": file is the ValueLabel, foo.ext is the Value
 type ValueBreach struct {
+	BreachType
 	CheckType     string
 	CheckName     string
 	Severity      string
@@ -25,6 +37,7 @@ type ValueBreach struct {
 //	  - app could be the ValueLabel
 //	  - wordpress is the Value
 type KeyValueBreach struct {
+	BreachType
 	CheckType     string
 	CheckName     string
 	Severity      string
@@ -44,6 +57,7 @@ type KeyValueBreach struct {
 //	  - permissions could be the ValueLabel
 //	  - [administer site configuration, import configuration] are the Values
 type KeyValuesBreach struct {
+	BreachType
 	CheckType  string
 	CheckName  string
 	Severity   string
@@ -70,6 +84,17 @@ func BreachSetCommonValues(bIfc *Breach, checkType string, checkName string, sev
 		b.Severity = severity
 		*bIfc = b
 	}
+}
+
+func BreachGetBreachType(bIfc Breach) BreachType {
+	if _, ok := bIfc.(ValueBreach); ok {
+		return BreachTypeValue
+	} else if _, ok := bIfc.(KeyValueBreach); ok {
+		return BreachTypeKeyValue
+	} else if _, ok := bIfc.(KeyValuesBreach); ok {
+		return BreachTypeKeyValues
+	}
+	return ""
 }
 
 func BreachGetCheckType(bIfc Breach) string {

--- a/pkg/result/breach_test.go
+++ b/pkg/result/breach_test.go
@@ -14,53 +14,60 @@ func TestBreachSetCommonValues(t *testing.T) {
 	type bogusBreach struct{}
 
 	tests := []struct {
-		name      string
-		breach    Breach
-		checkType string
-		checkName string
-		severity  string
-		empty     bool
+		name               string
+		breach             Breach
+		expectedBreachType BreachType
+		expectedCheckType  string
+		expectedCheckName  string
+		expectedSeverity   string
+		empty              bool
 	}{
 		{
-			name:      "ValueBreach",
-			breach:    ValueBreach{},
-			checkType: "ctvb",
-			checkName: "valuebreachcheck",
-			severity:  "low",
+			name:               "ValueBreach",
+			breach:             ValueBreach{},
+			expectedBreachType: BreachTypeValue,
+			expectedCheckType:  "ctvb",
+			expectedCheckName:  "valuebreachcheck",
+			expectedSeverity:   "low",
 		},
 		{
-			name:      "KeyValueBreach",
-			breach:    KeyValueBreach{},
-			checkType: "ctkvb",
-			checkName: "keyvaluebreachcheck",
-			severity:  "normal",
+			name:               "KeyValueBreach",
+			breach:             KeyValueBreach{},
+			expectedBreachType: BreachTypeKeyValue,
+			expectedCheckType:  "ctkvb",
+			expectedCheckName:  "keyvaluebreachcheck",
+			expectedSeverity:   "normal",
 		},
 		{
-			name:      "KeyValuesBreach",
-			breach:    KeyValuesBreach{},
-			checkType: "ctkvsb",
-			checkName: "keyvaluesbreachcheck",
-			severity:  "high",
+			name:               "KeyValuesBreach",
+			breach:             KeyValuesBreach{},
+			expectedBreachType: BreachTypeKeyValues,
+			expectedCheckType:  "ctkvsb",
+			expectedCheckName:  "keyvaluesbreachcheck",
+			expectedSeverity:   "high",
 		},
 		{
-			name:      "BogusBreach",
-			breach:    bogusBreach{},
-			checkType: "ctbb",
-			checkName: "bogusbreachcheck",
-			severity:  "critical",
-			empty:     true,
+			name:               "BogusBreach",
+			breach:             bogusBreach{},
+			expectedBreachType: "",
+			expectedCheckType:  "ctbb",
+			expectedCheckName:  "bogusbreachcheck",
+			expectedSeverity:   "critical",
+			empty:              true,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			BreachSetCommonValues(&test.breach, test.checkType, test.checkName,
-				test.severity)
+			BreachSetCommonValues(&test.breach, test.expectedCheckType, test.expectedCheckName,
+				test.expectedSeverity)
 			if !test.empty {
-				assert.Equal(test.checkName, BreachGetCheckName(test.breach))
-				assert.Equal(test.checkType, BreachGetCheckType(test.breach))
-				assert.Equal(test.severity, BreachGetSeverity(test.breach))
+				assert.Equal(test.expectedBreachType, BreachGetBreachType(test.breach))
+				assert.Equal(test.expectedCheckName, BreachGetCheckName(test.breach))
+				assert.Equal(test.expectedCheckType, BreachGetCheckType(test.breach))
+				assert.Equal(test.expectedSeverity, BreachGetSeverity(test.breach))
 			} else {
+				assert.Equal(BreachType(""), BreachGetBreachType(test.breach))
 				assert.Equal("", BreachGetCheckName(test.breach))
 				assert.Equal("", BreachGetCheckType(test.breach))
 				assert.Equal("", BreachGetSeverity(test.breach))
@@ -75,39 +82,44 @@ func TestBreachGetters(t *testing.T) {
 	type bogusBreach struct{}
 
 	tests := []struct {
-		name               string
-		breach             Breach
-		expectedKeyLabel   string
-		expectedKey        string
-		expectedValueLabel string
-		expectedValue      string
-		expectedValues     []string
+		name                  string
+		breach                Breach
+		expectedKeyLabel      string
+		expectedKey           string
+		expectedValueLabel    string
+		expectedValue         string
+		expectedValues        []string
+		expectedExpectedValue string
 	}{
 		{
 			name: "ValueBreach",
 			breach: ValueBreach{
-				ValueLabel: "vbvl",
-				Value:      "vbv",
+				ValueLabel:    "vbvl",
+				Value:         "vbv",
+				ExpectedValue: "vbve",
 			},
-			expectedKeyLabel:   "",
-			expectedKey:        "",
-			expectedValueLabel: "vbvl",
-			expectedValue:      "vbv",
-			expectedValues:     []string(nil),
+			expectedKeyLabel:      "",
+			expectedKey:           "",
+			expectedValueLabel:    "vbvl",
+			expectedValue:         "vbv",
+			expectedValues:        []string(nil),
+			expectedExpectedValue: "vbve",
 		},
 		{
 			name: "KeyValueBreach",
 			breach: KeyValueBreach{
-				KeyLabel:   "kvbklbl",
-				Key:        "kvbk",
-				ValueLabel: "kvbvl",
-				Value:      "kvbv",
+				KeyLabel:      "kvbklbl",
+				Key:           "kvbk",
+				ValueLabel:    "kvbvl",
+				Value:         "kvbv",
+				ExpectedValue: "kvbve",
 			},
-			expectedKeyLabel:   "kvbklbl",
-			expectedKey:        "kvbk",
-			expectedValueLabel: "kvbvl",
-			expectedValue:      "kvbv",
-			expectedValues:     []string(nil),
+			expectedKeyLabel:      "kvbklbl",
+			expectedKey:           "kvbk",
+			expectedValueLabel:    "kvbvl",
+			expectedValue:         "kvbv",
+			expectedValues:        []string(nil),
+			expectedExpectedValue: "kvbve",
 		},
 		{
 			name: "KeyValuesBreach",
@@ -140,6 +152,7 @@ func TestBreachGetters(t *testing.T) {
 			assert.Equal(test.expectedKey, BreachGetKey(test.breach))
 			assert.Equal(test.expectedValueLabel, BreachGetValueLabel(test.breach))
 			assert.Equal(test.expectedValue, BreachGetValue(test.breach))
+			assert.Equal(test.expectedExpectedValue, BreachGetExpectedValue(test.breach))
 			assert.EqualValues(test.expectedValues, BreachGetValues(test.breach))
 		})
 	}

--- a/pkg/shipshape/output.go
+++ b/pkg/shipshape/output.go
@@ -194,12 +194,16 @@ func LagoonFacts(w *bufio.Writer) {
 
 	factName := func(b result.Breach) string {
 		var name string
-		if result.BreachGetKeyLabel(b) == "" {
-			name = result.BreachGetCheckName(b) + " - " +
-				string(result.BreachGetCheckType(b))
-		} else {
+		if result.BreachGetKeyLabel(b) != "" {
 			name = fmt.Sprintf("%s: %s", result.BreachGetKeyLabel(b),
 				result.BreachGetKey(b))
+		} else if result.BreachGetKey(b) != "" {
+			name = result.BreachGetKey(b)
+		} else if result.BreachGetValueLabel(b) != "" {
+			name = result.BreachGetValueLabel(b)
+		} else {
+			name = result.BreachGetCheckName(b) + " - " +
+				string(result.BreachGetCheckType(b))
 		}
 		return name
 	}
@@ -212,7 +216,7 @@ func LagoonFacts(w *bufio.Writer) {
 
 		var withLabel string
 		label := result.BreachGetValueLabel(b)
-		if label == "" {
+		if label == "" || factName(b) == label {
 			withLabel = value
 		} else {
 			withLabel = fmt.Sprintf("%s: %s", label, value)

--- a/pkg/shipshape/output.go
+++ b/pkg/shipshape/output.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
-	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -192,50 +191,12 @@ func LagoonFacts(w *bufio.Writer) {
 		return
 	}
 
-	factName := func(b result.Breach) string {
-		var name string
-		if result.BreachGetKeyLabel(b) != "" {
-			name = fmt.Sprintf("%s: %s", result.BreachGetKeyLabel(b),
-				result.BreachGetKey(b))
-		} else if result.BreachGetKey(b) != "" {
-			name = result.BreachGetKey(b)
-		} else if result.BreachGetValueLabel(b) != "" {
-			name = result.BreachGetValueLabel(b)
-		} else {
-			name = result.BreachGetCheckName(b) + " - " +
-				string(result.BreachGetCheckType(b))
-		}
-		return name
-	}
-
-	factValue := func(b result.Breach) string {
-		value := result.BreachGetValue(b)
-		if value == "" {
-			value = strings.Join(result.BreachGetValues(b), ", ")
-		}
-
-		label := result.BreachGetValueLabel(b)
-		if label == "" || factName(b) == label {
-			return value
-		} else {
-			value = fmt.Sprintf("%s: %s", label, value)
-		}
-
-		expected := result.BreachGetExpectedValue(b)
-		if expected == "" {
-			return value
-		} else {
-			value = fmt.Sprintf("expected: %s, %s", expected, value)
-		}
-		return value
-	}
-
 	for _, r := range RunResultList.Results {
 		for _, b := range r.Breaches {
 			facts = append(facts, lagoon.Fact{
-				Name:        factName(b),
+				Name:        lagoon.BreachFactName(b),
 				Description: result.BreachGetCheckName(b),
-				Value:       factValue(b),
+				Value:       lagoon.BreachFactValue(b),
 				Source:      lagoon.SourceName,
 				Category:    string(result.BreachGetCheckType(b)),
 			})

--- a/pkg/shipshape/output.go
+++ b/pkg/shipshape/output.go
@@ -214,14 +214,20 @@ func LagoonFacts(w *bufio.Writer) {
 			value = strings.Join(result.BreachGetValues(b), ", ")
 		}
 
-		var withLabel string
 		label := result.BreachGetValueLabel(b)
 		if label == "" || factName(b) == label {
-			withLabel = value
+			return value
 		} else {
-			withLabel = fmt.Sprintf("%s: %s", label, value)
+			value = fmt.Sprintf("%s: %s", label, value)
 		}
-		return withLabel
+
+		expected := result.BreachGetExpectedValue(b)
+		if expected == "" {
+			return value
+		} else {
+			value = fmt.Sprintf("expected: %s, %s", expected, value)
+		}
+		return value
 	}
 
 	for _, r := range RunResultList.Results {

--- a/tests/e2e/.docker/phpstan.neon
+++ b/tests/e2e/.docker/phpstan.neon
@@ -1,0 +1,18 @@
+parameters:
+  # Disable all phpstan rules.
+  customRulesetUsed: true
+  scanDirectories:
+    - /app
+  excludePaths:
+    - /app/vendor/*
+  fileExtensions:
+    - php
+    - theme
+    - inc
+  reportUnmatchedIgnoredErrors: false
+  disallowedFunctionCalls:
+    - function: 'var_dump()'
+      message: 'please change the code'
+  disallowedMethodCalls:
+    - function: 'mysqli::*()'
+      message: 'please change the code'

--- a/tests/e2e/.gitignore
+++ b/tests/e2e/.gitignore
@@ -1,5 +1,4 @@
 suites/*.log
-docker-compose.override.yml
 # Generated when running venom run -vv
 *.step.*.dump.json
 # Generated when running venom run -vvv

--- a/tests/e2e/Dockerfile
+++ b/tests/e2e/Dockerfile
@@ -1,6 +1,6 @@
-ARG SHIPSHAPE_VERSION=latest
+ARG SHIPSHAPE_VERSION
 
-FROM ghcr.io/salsadigitalauorg/shipshape:${SHIPSHAPE_VERSION} AS shipshape
+FROM ghcr.io/salsadigitalauorg/shipshape:${SHIPSHAPE_VERSION:-latest} AS shipshape
 
 FROM uselagoon/php-8.1-cli-drupal
 
@@ -28,9 +28,17 @@ RUN set -ex; \
     VENOM_LATEST=$(curl -Ls -o /dev/null \
         https://github.com/ovh/venom/releases/latest -w %{url_effective}); \
     VENOM_LATEST_VERSION=${VENOM_LATEST##*/}; \
-    [[ "$(uname -m)" == "x86_64" ]] && ARCH=amd64 || ARCH=arm64; \
+    [ "$(uname -m)" == "x86_64" ] && ARCH=amd64 || ARCH=arm64; \
     curl -LO https://github.com/ovh/venom/releases/download/${VENOM_LATEST_VERSION}/venom.linux-${ARCH}; \
     chmod +x venom.linux-${ARCH}; \
     mv venom.linux-${ARCH} /usr/local/bin/venom;
 
-COPY .docker/phpstan.neon /app/phpstan.neon
+COPY tests/e2e/.docker/phpstan.neon /app/phpstan.neon
+
+COPY . /shipshape
+
+RUN set -ex; \
+    # Install shipshape.
+    [ ! -z "$SHIPSHAPE_VERSION" ] && exit 0; \
+    ls -l /shipshape; \
+    cd /shipshape && go build -o /usr/local/bin/shipshape;

--- a/tests/e2e/Dockerfile
+++ b/tests/e2e/Dockerfile
@@ -6,13 +6,23 @@ FROM uselagoon/php-8.1-cli-drupal
 
 ARG DRUPAL_VERSION=^9.5.4
 ARG DRUSH_VERSION=^10.0
+ARG PHPSTAN_EXTENSION_INSTALLER_VERSION=^1.3
+ARG PHPSTAN_DISALLOWED_CALLS_VERSION=^2.3.0
 
 COPY --from=shipshape /usr/local/bin/shipshape /usr/local/bin/shipshape
 
 RUN set -ex; \
+    # Add golang for when we want to compile shipshape.
+    apk add --no-cache go; \
+    \
+    # Install drupal & related dependencies.
     rm -rf ~/.drush; \
     composer create-project drupal/recommended-project:${DRUPAL_VERSION} /app; \
-    cd /app && composer require drush/drush:${DRUSH_VERSION}; \
+    cd /app && composer config allow-plugins.phpstan/extension-installer true; \
+    composer require \
+        drush/drush:${DRUSH_VERSION} \
+        phpstan/extension-installer:${PHPSTAN_EXTENSION_INSTALLER_VERSION} \
+        spaze/phpstan-disallowed-calls:${PHPSTAN_DISALLOWED_CALLS_VERSION}; \
     \
     # Install venom.
     VENOM_LATEST=$(curl -Ls -o /dev/null \
@@ -22,3 +32,5 @@ RUN set -ex; \
     curl -LO https://github.com/ovh/venom/releases/download/${VENOM_LATEST_VERSION}/venom.linux-${ARCH}; \
     chmod +x venom.linux-${ARCH}; \
     mv venom.linux-${ARCH} /usr/local/bin/venom;
+
+COPY .docker/phpstan.neon /app/phpstan.neon

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -5,6 +5,6 @@ See https://github.com/ovh/venom
 ## Running the tests
 
 ```sh
-docker-compose up --detach --build
-docker-compose exec drupal venom run
+docker compose up --detach --build
+docker compose exec drupal venom run
 ```

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -8,3 +8,23 @@ See https://github.com/ovh/venom
 docker compose up --detach --build
 docker compose exec drupal venom run
 ```
+
+## Build shipshape && run tests
+
+Create a `docker-compose.override.yml` with
+```yaml
+version: "3"
+
+services:
+  drupal:
+    volumes:
+      - /path/to/shipshape:/shipshape
+```
+
+Build shipshape
+```sh
+docker compose exec drupal bash -c \
+  'cd /shipshape && CGO_ENABLED=0 go build -o /usr/local/bin/shipshape .'
+```
+
+Running the tests again from the previous section will now use the latest code.

--- a/tests/e2e/suites/phpstan.yml
+++ b/tests/e2e/suites/phpstan.yml
@@ -1,0 +1,46 @@
+name: phpstan
+
+testcases:
+- name: no directory exists
+  steps:
+  - script: |
+      cd /app;
+      rm -rf web/themes/custom;
+      shipshape -f /suites/shipshape/phpstan.yml
+    assertions:
+    - result.code ShouldEqual 0
+    - result.systemout ShouldEqual Ship is in top shape; no breach detected!
+
+- name: directory exists, no php files inside
+  steps:
+  - script: |
+      cd /app;
+      mkdir -p web/themes/custom;
+      shipshape -f /suites/shipshape/phpstan.yml
+    assertions:
+    - result.code ShouldEqual 0
+    - result.systemout ShouldEqual Ship is in top shape; no breach detected!
+
+- name: php files exists, no breaches
+  steps:
+  - script: |
+      cd /app;
+      mkdir -p web/themes/custom;
+      echo "<?php echo 'Hello world';" > web/themes/custom/custom.theme;
+      shipshape -f /suites/shipshape/phpstan.yml
+    assertions:
+    - result.code ShouldEqual 0
+    - result.systemout ShouldEqual Ship is in top shape; no breach detected!
+
+- name: breach found
+  steps:
+  - script: |
+      cd /app;
+      mkdir -p web/themes/custom;
+      echo "<?php var_dump('Hello world');" > web/themes/custom/custom.theme;
+      shipshape -f /suites/shipshape/phpstan.yml
+    assertions:
+    - result.code ShouldEqual 0
+    - result.systemout ShouldContainSubstring [/app/web/themes/custom/custom.theme]
+    - result.systemout ShouldContainSubstring Line 1
+    - result.systemout ShouldContainSubstring Calling var_dump() is forbidden, please change the code

--- a/tests/e2e/suites/shipshape/phpstan.yml
+++ b/tests/e2e/suites/shipshape/phpstan.yml
@@ -1,0 +1,8 @@
+checks:
+  phpstan:
+    - name: 'Banned PHP function list'
+      severity: high
+      configuration: phpstan.neon
+      paths:
+        - web/themes/custom
+        - themes


### PR DESCRIPTION
Pushing facts to the Lagoon API was failing due to duplication of a number of the breaches since they were using the same Fact name.

I've updated a number of the checks as well as the logic for the Facts output to have saner defaults and provides more useful context to the user.