### PR TITLE
[DEVOPS-407] Remove all usage of AddFail

### DIFF
--- a/pkg/checks/crawler/crawlercheck.go
+++ b/pkg/checks/crawler/crawlercheck.go
@@ -79,7 +79,6 @@ func (c *CrawlerCheck) RunCheck() {
 
 	crawler.OnError(func(r *colly.Response, err error) {
 		c.Result.Status = result.Fail
-		c.AddFail(fmt.Sprintf("Invalid response for: %s got %d", r.Request.URL, r.StatusCode))
 		c.AddBreach(result.KeyValueBreach{
 			Key:        fmt.Sprintf("%v", r.Request.URL),
 			ValueLabel: "invalid response",

--- a/pkg/checks/crawler/crawlercheck_test.go
+++ b/pkg/checks/crawler/crawlercheck_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	. "github.com/salsadigitalauorg/shipshape/pkg/checks/crawler"
+	"github.com/salsadigitalauorg/shipshape/pkg/result"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -58,8 +59,15 @@ func TestCrawlerCheck(t *testing.T) {
 	c.Init(Crawler)
 	c.RunCheck()
 	assert.ElementsMatch(
-		[]string{fmt.Sprintf("Invalid response for: %s/not-found got 404", server.URL)},
-		c.Result.Failures,
+		[]result.Breach{result.KeyValueBreach{
+			BreachType: result.BreachTypeKeyValue,
+			CheckType:  "crawler",
+			Severity:   "normal",
+			Key:        fmt.Sprintf("%s/not-found", server.URL),
+			ValueLabel: "invalid response",
+			Value:      "404"},
+		},
+		c.Result.Breaches,
 	)
 
 	c = CrawlerCheck{
@@ -70,7 +78,7 @@ func TestCrawlerCheck(t *testing.T) {
 
 	c.Init(Crawler)
 	c.RunCheck()
-	assert.Empty(c.Result.Failures)
+	assert.Empty(c.Result.Breaches)
 	assert.ElementsMatch(
 		[]string{"All requests completed successfully"},
 		c.Result.Passes,

--- a/pkg/checks/docker/baseimagecheck.go
+++ b/pkg/checks/docker/baseimagecheck.go
@@ -87,7 +87,6 @@ func (c *BaseImageCheck) RunCheck() {
 					}
 
 					if len(c.Allowed) > 0 && !utils.PackageCheckString(c.Allowed, match[1], match[2]) {
-						c.AddFail(name + " is using invalid base image " + match[1])
 						c.AddBreach(result.KeyValueBreach{
 							Key:        name,
 							ValueLabel: "invalid base image",
@@ -109,7 +108,6 @@ func (c *BaseImageCheck) RunCheck() {
 				}
 
 				if !utils.PackageCheckString(c.Allowed, match[1], match[2]) {
-					c.AddFail(name + " is using invalid base image " + match[1])
 					c.AddBreach(result.KeyValueBreach{
 						Key:        name,
 						ValueLabel: "invalid base image",
@@ -123,7 +121,7 @@ func (c *BaseImageCheck) RunCheck() {
 			}
 		}
 
-		if len(c.Result.Failures) == 0 {
+		if len(c.Result.Breaches) == 0 {
 			c.Result.Status = result.Pass
 		}
 	}

--- a/pkg/checks/docker/baseimagecheck_test.go
+++ b/pkg/checks/docker/baseimagecheck_test.go
@@ -55,8 +55,13 @@ func TestInvalidDockerfileCheck(t *testing.T) {
 	c.RunCheck()
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(
-		[]string{"service1 is using invalid base image bitnami/kubectl"},
-		c.Result.Failures,
+		[]result.Breach{result.KeyValueBreach{
+			BreachType: result.BreachTypeKeyValue,
+			Key:        "service1",
+			ValueLabel: "invalid base image",
+			Value:      "bitnami/kubectl"},
+		},
+		c.Result.Breaches,
 	)
 }
 
@@ -83,8 +88,13 @@ func TestInvalidDockerfileImageVersion(t *testing.T) {
 	c.RunCheck()
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(
-		[]string{"service1 is using invalid base image bitnami/kubectl"},
-		c.Result.Failures,
+		[]result.Breach{result.KeyValueBreach{
+			BreachType: result.BreachTypeKeyValue,
+			Key:        "service1",
+			ValueLabel: "invalid base image",
+			Value:      "bitnami/kubectl"},
+		},
+		c.Result.Breaches,
 	)
 }
 
@@ -149,8 +159,13 @@ func TestInvalidImageCheck(t *testing.T) {
 	c.RunCheck()
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(
-		[]string{"service4 is using invalid base image bitnami/mongodb"},
-		c.Result.Failures,
+		[]result.Breach{result.KeyValueBreach{
+			BreachType: result.BreachTypeKeyValue,
+			Key:        "service4",
+			ValueLabel: "invalid base image",
+			Value:      "bitnami/mongodb:5.0.19-debian-11-r11"},
+		},
+		c.Result.Breaches,
 	)
 }
 
@@ -167,11 +182,21 @@ func TestInvalidImageVersions(t *testing.T) {
 	c.RunCheck()
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.ElementsMatch(
-		[]string{
-			"service2 is using invalid base image bitnami/postgresql",
-			"service4 is using invalid base image bitnami/mongodb",
+		[]result.Breach{
+			result.KeyValueBreach{
+				BreachType: result.BreachTypeKeyValue,
+				Key:        "service2",
+				ValueLabel: "invalid base image",
+				Value:      "bitnami/postgresql@16",
+			},
+			result.KeyValueBreach{
+				BreachType: result.BreachTypeKeyValue,
+				Key:        "service4",
+				ValueLabel: "invalid base image",
+				Value:      "bitnami/mongodb:5.0.19-debian-11-r11",
+			},
 		},
-		c.Result.Failures,
+		c.Result.Breaches,
 	)
 }
 

--- a/pkg/checks/drupal/dbadmincheck_test.go
+++ b/pkg/checks/drupal/dbadmincheck_test.go
@@ -51,8 +51,13 @@ func TestAdminUserFetchData(t *testing.T) {
 		c := AdminUserCheck{}
 		c.FetchData()
 		assert.Equal(result.Fail, c.Result.Status)
-		assert.EqualValues([]string{"vendor/drush/drush/drush: no such file or directory"}, c.Result.Failures)
-
+		assert.EqualValues(
+			[]result.Breach{result.ValueBreach{
+				BreachType: "value",
+				Value:      "vendor/drush/drush/drush: no such file or directory",
+			}},
+			c.Result.Breaches,
+		)
 	})
 
 	curShellCommander := command.ShellCommander
@@ -66,7 +71,13 @@ func TestAdminUserFetchData(t *testing.T) {
 		c := AdminUserCheck{}
 		c.FetchData()
 		assert.Equal(result.Fail, c.Result.Status)
-		assert.EqualValues([]string{"unable to run drush command"}, c.Result.Failures)
+		assert.EqualValues(
+			[]result.Breach{result.ValueBreach{
+				BreachType: "value",
+				Value:      "unable to run drush command",
+			}},
+			c.Result.Breaches,
+		)
 	})
 
 	// correct data.
@@ -93,7 +104,13 @@ func TestAdminUserUnmarshalData(t *testing.T) {
 	t.Run("emptyDataMap", func(t *testing.T) {
 		c.UnmarshalDataMap()
 		assert.Equal(result.Fail, c.Result.Status)
-		assert.EqualValues([]string{"no data provided"}, c.Result.Failures)
+		assert.EqualValues(
+			[]result.Breach{result.ValueBreach{
+				BreachType: "value",
+				Value:      "no data provided",
+			}},
+			c.Result.Breaches,
+		)
 	})
 
 	// Incorrect json.
@@ -106,7 +123,13 @@ func TestAdminUserUnmarshalData(t *testing.T) {
 		}
 		c.UnmarshalDataMap()
 		assert.Equal(result.Fail, c.Result.Status)
-		assert.EqualValues([]string{"invalid character ']' after object key:value pair"}, c.Result.Failures)
+		assert.EqualValues(
+			[]result.Breach{result.ValueBreach{
+				BreachType: "value",
+				Value:      "invalid character ']' after object key:value pair",
+			}},
+			c.Result.Breaches,
+		)
 	})
 
 	// Correct json.
@@ -152,7 +175,12 @@ func TestAdminUserRunCheck(t *testing.T) {
 				AllowedRoles: []string{"content-admin"},
 			},
 			ExpectStatus: result.Fail,
-			ExpectFails:  []string{"Role [anonymous] has `is_admin: true`"},
+			ExpectFails: []result.Breach{result.KeyValueBreach{
+				BreachType: "key-value",
+				Key:        "is_admin: true",
+				ValueLabel: "role",
+				Value:      "anonymous",
+			}},
 		},
 
 		// Role has is_admin:true but is allowed.
@@ -205,7 +233,12 @@ func TestAdminUserRunCheck(t *testing.T) {
 				)
 			},
 			ExpectStatus: result.Fail,
-			ExpectFails:  []string{"Failed to fix disallowed admin setting for role [anonymous] due to error: unable to run drush command"},
+			ExpectFails: []result.Breach{result.KeyValueBreach{
+				BreachType: "key-value",
+				Key:        "failed to set is_admin to false",
+				ValueLabel: "role",
+				Value:      "anonymous",
+			}},
 		},
 	}
 

--- a/pkg/checks/drupal/dbmodulecheck_test.go
+++ b/pkg/checks/drupal/dbmodulecheck_test.go
@@ -86,7 +86,7 @@ node:
 
 	c = mockCheck(nil)
 	assert.Equal(result.Pass, c.Result.Status)
-	assert.Empty(c.Result.Failures)
+	assert.Empty(c.Result.Breaches)
 	assert.ElementsMatch(c.Result.Passes, []string{
 		"all required modules are enabled",
 		"all disallowed modules are disabled",
@@ -107,8 +107,23 @@ views_ui:
 		"some required modules are enabled: node",
 		"some disallowed modules are disabled: field_ui",
 	})
-	assert.ElementsMatch(c.Result.Failures, []string{
-		"required modules are not enabled: block",
-		"disallowed modules are enabled: views_ui",
-	})
+	assert.ElementsMatch(
+		[]result.Breach{
+			result.KeyValuesBreach{
+				BreachType: "key-values",
+				CheckType:  "drupal-db-module",
+				Severity:   "normal",
+				Key:        "required modules are not enabled",
+				Values:     []string{"block"},
+			},
+			result.KeyValuesBreach{
+				BreachType: "key-values",
+				CheckType:  "drupal-db-module",
+				Severity:   "normal",
+				Key:        "disallowed modules are enabled",
+				Values:     []string{"views_ui"},
+			},
+		},
+		c.Result.Breaches,
+	)
 }

--- a/pkg/checks/drupal/dbpermissionscheck.go
+++ b/pkg/checks/drupal/dbpermissionscheck.go
@@ -41,7 +41,6 @@ func (c *DbPermissionsCheck) Merge(mergeCheck config.Check) error {
 // type for further processing.
 func (c *DbPermissionsCheck) UnmarshalDataMap() {
 	if len(c.DataMap[c.ConfigName]) == 0 {
-		c.AddFail("no data provided")
 		c.AddBreach(result.ValueBreach{Value: "no data provided"})
 	}
 
@@ -52,7 +51,6 @@ func (c *DbPermissionsCheck) UnmarshalDataMap() {
 // RunCheck implements the Check logic for Drupal Permissions in database config.
 func (c *DbPermissionsCheck) RunCheck() {
 	if len(c.Disallowed) == 0 {
-		c.AddFail("list of disallowed perms not provided")
 		c.AddBreach(result.ValueBreach{Value: "list of disallowed perms not provided"})
 	}
 
@@ -74,18 +72,18 @@ func (c *DbPermissionsCheck) RunCheck() {
 
 		if c.PerformRemediation {
 			if err := c.Remediate(DbPermissionsBreach{Role: r, Perms: strings.Join(fails, ",")}); err != nil {
-				c.AddFail(fmt.Sprintf(
-					"[%s] failed to fix disallowed permissions [%s] due to error: %s",
-					r, strings.Join(fails, ", "), command.GetMsgFromCommandError(err)))
+				c.AddBreach(result.KeyValueBreach{
+					KeyLabel:   "role",
+					Key:        r,
+					ValueLabel: "failed to fix disallowed permissions due to error",
+					Value:      command.GetMsgFromCommandError(err),
+				})
 			} else {
 				c.AddRemediation(fmt.Sprintf(
 					"[%s] fixed disallowed permissions: [%s]",
 					r, strings.Join(fails, ", ")))
 			}
 		} else {
-			c.AddFail(fmt.Sprintf(
-				"[%s] disallowed permissions: [%s]",
-				r, strings.Join(fails, ", ")))
 			c.AddBreach(result.KeyValuesBreach{
 				KeyLabel:   "role",
 				Key:        r,
@@ -95,7 +93,7 @@ func (c *DbPermissionsCheck) RunCheck() {
 		}
 	}
 
-	if len(c.Result.Failures) == 0 {
+	if len(c.Result.Breaches) == 0 {
 		c.Result.Status = result.Pass
 	}
 }

--- a/pkg/checks/drupal/dbtfausercheck.go
+++ b/pkg/checks/drupal/dbtfausercheck.go
@@ -3,7 +3,9 @@ package drupal
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
+	"github.com/salsadigitalauorg/shipshape/pkg/command"
 	"github.com/salsadigitalauorg/shipshape/pkg/config"
 	"github.com/salsadigitalauorg/shipshape/pkg/result"
 )
@@ -28,11 +30,28 @@ func (c *DbUserTfaCheck) Init(ct config.CheckType) {
 
 // FetchData runs the Drush command to extract user information from the Drupal database.
 func (c *DbUserTfaCheck) FetchData() {
-	cmd := []string{"ev", "return \\Drupal::database()->query(\"SELECT users.uid, users_field_data.name FROM users LEFT JOIN users_field_data ON users.uid = users_field_data.uid WHERE users.uid != '0' AND users_field_data.status = '1' AND NOT EXISTS (SELECT 1 FROM users_data WHERE users.uid = users_data.uid AND users_data.module = 'tfa');\")->fetchAll()", "--format=json"}
+	cmd := []string{
+		"ev",
+		`return \\Drupal::database()->query(
+			\"SELECT users.uid, users_field_data.name
+				FROM users
+				LEFT JOIN users_field_data
+					ON users.uid = users_field_data.uid
+				WHERE users.uid != '0'
+					AND users_field_data.status = '1'
+					AND NOT EXISTS (
+						SELECT 1
+						FROM users_data
+						WHERE users.uid = users_data.uid
+						 	AND users_data.module = 'tfa');\")->fetchAll()`,
+		"--format=json"}
 	res, err := Drush(c.DrushPath, c.Alias, cmd).Exec()
 	if err != nil {
 		c.Result.Status = result.Fail
-		c.Result.Failures = append(c.Result.Failures, "Error calling drush ev.")
+		c.AddBreach(result.ValueBreach{
+			ValueLabel: "error fetching drush user info",
+			Value:      command.GetMsgFromCommandError(err),
+		})
 	}
 	c.DataMap = map[string][]byte{}
 	c.DataMap["db-tfa-check"] = res
@@ -50,9 +69,14 @@ func (c *DbUserTfaCheck) RunCheck() {
 		c.AddPass("All active users have two-factor authentication enabled.")
 		c.Result.Status = result.Pass
 	} else {
+		tfaDisabled := []string{}
 		for _, user := range users {
-			c.AddFail(fmt.Sprintf("Two-factor authentication not enabled for active user %s, with UID %s.", user.Name, user.UID))
+			tfaDisabled = append(tfaDisabled, fmt.Sprintf("%s:%s", user.Name, user.UID))
 		}
+		c.AddBreach(result.ValueBreach{
+			ValueLabel: "users with TFA disabled",
+			Value:      strings.Join(tfaDisabled, ", "),
+		})
 		c.Result.Status = result.Fail
 	}
 }

--- a/pkg/checks/drupal/dbtfausercheck_test.go
+++ b/pkg/checks/drupal/dbtfausercheck_test.go
@@ -28,9 +28,15 @@ func TestDbTfaUserCheck(t *testing.T) {
 		c.FetchData()
 		assert.Equal(result.Fail, c.Result.Status)
 		assert.Empty(c.Result.Passes)
-		assert.ElementsMatch(
-			[]string{"Error calling drush ev."},
-			c.Result.Failures,
+		assert.EqualValues(
+			[]result.Breach{result.ValueBreach{
+				BreachType: "value",
+				CheckType:  "drupal-db-user-tfa",
+				Severity:   "normal",
+				ValueLabel: "error fetching drush user info",
+				Value:      "unable to run drush command",
+			}},
+			c.Result.Breaches,
 		)
 	})
 
@@ -55,9 +61,15 @@ func TestDbTfaUserCheck(t *testing.T) {
 		c.RunCheck()
 		assert.Equal(result.Fail, c.Result.Status)
 		assert.Empty(c.Result.Passes)
-		assert.ElementsMatch(
-			[]string{"Two-factor authentication not enabled for active user shipshape-1, with UID 1."},
-			c.Result.Failures,
+		assert.EqualValues(
+			[]result.Breach{result.ValueBreach{
+				BreachType: "value",
+				CheckType:  "drupal-db-user-tfa",
+				Severity:   "normal",
+				ValueLabel: "users with TFA disabled",
+				Value:      "shipshape-1:1",
+			}},
+			c.Result.Breaches,
 		)
 	})
 
@@ -86,9 +98,15 @@ func TestDbTfaUserCheck(t *testing.T) {
 		c.RunCheck()
 		assert.Equal(result.Fail, c.Result.Status)
 		assert.Empty(c.Result.Passes)
-		assert.ElementsMatch(
-			[]string{"Two-factor authentication not enabled for active user shipshape-1, with UID 1.", "Two-factor authentication not enabled for active user shipshape-2, with UID 2."},
-			c.Result.Failures,
+		assert.EqualValues(
+			[]result.Breach{result.ValueBreach{
+				BreachType: "value",
+				CheckType:  "drupal-db-user-tfa",
+				Severity:   "normal",
+				ValueLabel: "users with TFA disabled",
+				Value:      "shipshape-1:1, shipshape-2:2",
+			}},
+			c.Result.Breaches,
 		)
 	})
 	t.Run("passOnEmptyQueryResult", func(t *testing.T) {
@@ -106,8 +124,8 @@ func TestDbTfaUserCheck(t *testing.T) {
 		c.FetchData()
 		c.RunCheck()
 		assert.Equal(result.Pass, c.Result.Status)
-		assert.Empty(c.Result.Failures)
-		assert.ElementsMatch(
+		assert.Empty(c.Result.Breaches)
+		assert.EqualValues(
 			[]string{"All active users have two-factor authentication enabled."},
 			c.Result.Passes,
 		)

--- a/pkg/checks/drupal/drupal.go
+++ b/pkg/checks/drupal/drupal.go
@@ -73,17 +73,11 @@ func CheckModulesInYaml(c *yaml.YamlBase, ct config.CheckType, configName string
 		required_errored,
 		required_disabled := DetermineModuleStatus(c.NodeMap[configName], ct, required)
 	if len(required_errored) > 0 {
-		c.AddFail(fmt.Sprintf(
-			"error verifying status for required modules: %s",
-			strings.Join(required_errored, ",")))
 		c.AddBreach(result.KeyValuesBreach{
 			Key:    "error verifying status for required modules",
 			Values: required_errored})
 	}
 	if len(required_disabled) > 0 {
-		c.AddFail(fmt.Sprintf(
-			"required modules are not enabled: %s",
-			strings.Join(required_disabled, ",")))
 		c.AddBreach(result.KeyValuesBreach{
 			Key:    "required modules are not enabled",
 			Values: required_disabled})
@@ -100,17 +94,11 @@ func CheckModulesInYaml(c *yaml.YamlBase, ct config.CheckType, configName string
 		disallowed_errored,
 		disallowed_disabled := DetermineModuleStatus(c.NodeMap[configName], ct, disallowed)
 	if len(disallowed_errored) > 0 {
-		c.AddFail(fmt.Sprintf(
-			"error verifying status for disallowed modules: %s",
-			strings.Join(disallowed_errored, ",")))
 		c.AddBreach(result.KeyValuesBreach{
 			Key:    "error verifying status for disallowed modules",
 			Values: disallowed_errored})
 	}
 	if len(disallowed_enabled) > 0 {
-		c.AddFail(fmt.Sprintf(
-			"disallowed modules are enabled: %s",
-			strings.Join(disallowed_enabled, ",")))
 		c.AddBreach(result.KeyValuesBreach{
 			Key:    "disallowed modules are enabled",
 			Values: disallowed_enabled})
@@ -123,7 +111,7 @@ func CheckModulesInYaml(c *yaml.YamlBase, ct config.CheckType, configName string
 			strings.Join(disallowed_disabled, ",")))
 	}
 
-	if len(c.Result.Failures) == 0 {
+	if len(c.Result.Breaches) == 0 {
 		c.Result.Status = result.Pass
 	}
 }

--- a/pkg/checks/drupal/drupal_test.go
+++ b/pkg/checks/drupal/drupal_test.go
@@ -240,7 +240,14 @@ module:
 		"all required modules are enabled",
 		"all disallowed modules are disabled",
 	})
-	assert.ElementsMatch(c.Result.Failures, []string{"disallowed modules are enabled: dblog"})
+	assert.EqualValues(
+		[]result.Breach{result.KeyValuesBreach{
+			BreachType: "key-values",
+			Key:        "disallowed modules are enabled",
+			Values:     []string{"dblog"},
+		}},
+		c.Result.Breaches,
+	)
 }
 
 func TestCheckModulesInYaml(t *testing.T) {
@@ -263,10 +270,19 @@ func TestCheckModulesInYaml(t *testing.T) {
 		"some required modules are enabled: block",
 		"some disallowed modules are disabled: views_ui",
 	})
-	assert.ElementsMatch(c.Result.Failures, []string{
-		"error verifying status for required modules: invalid character '&' at position 11, following \".node\"",
-		"error verifying status for disallowed modules: invalid character '&' at position 15, following \".field_ui\"",
-	})
+	assert.ElementsMatch(
+		[]result.Breach{
+			result.KeyValuesBreach{
+				BreachType: "key-values",
+				Key:        "error verifying status for required modules",
+				Values:     []string{"invalid character '&' at position 11, following \".node\""},
+			},
+			result.KeyValuesBreach{
+				BreachType: "key-values",
+				Key:        "error verifying status for disallowed modules",
+				Values:     []string{"invalid character '&' at position 15, following \".field_ui\""},
+			},
+		}, c.Result.Breaches)
 
 	// Required is not enabled & disallowed is enabled.
 	c = mockCheck("shipshape.extension.yml")
@@ -293,10 +309,20 @@ module:
 		"some required modules are enabled: block",
 		"some disallowed modules are disabled: field_ui",
 	})
-	assert.ElementsMatch(c.Result.Failures, []string{
-		"required modules are not enabled: node",
-		"disallowed modules are enabled: views_ui",
-	})
+	assert.ElementsMatch(
+		[]result.Breach{
+			result.KeyValuesBreach{
+				BreachType: "key-values",
+				Key:        "required modules are not enabled",
+				Values:     []string{"node"},
+			},
+			result.KeyValuesBreach{
+				BreachType: "key-values",
+				Key:        "disallowed modules are enabled",
+				Values:     []string{"views_ui"},
+			},
+		},
+		c.Result.Breaches)
 
 	c = mockCheck("shipshape.extension.yml")
 	required = []string{
@@ -310,7 +336,7 @@ module:
 	c.UnmarshalDataMap()
 	CheckModulesInYaml(&c, FileModule, "shipshape.extension.yml", required, disallowed)
 	assert.Equal(result.Pass, c.Result.Status)
-	assert.Empty(c.Result.Failures)
+	assert.Empty(c.Result.Breaches)
 	assert.ElementsMatch(c.Result.Passes, []string{
 		"all required modules are enabled",
 		"all disallowed modules are disabled",

--- a/pkg/checks/drupal/drushyamlcheck.go
+++ b/pkg/checks/drupal/drushyamlcheck.go
@@ -39,12 +39,10 @@ func (c *DrushYamlCheck) FetchData() {
 	c.DataMap[c.ConfigName], err = Drush(c.DrushPath, c.Alias, c.DrushCommand.Args).Exec()
 	if err != nil {
 		if pathErr, ok := err.(*fs.PathError); ok {
-			c.AddFail(pathErr.Path + ": " + pathErr.Err.Error())
 			c.AddBreach(result.ValueBreach{
 				Value: pathErr.Path + ": " + pathErr.Err.Error()})
 		} else {
 			msg := string(err.(*exec.ExitError).Stderr)
-			c.AddFail(strings.ReplaceAll(strings.TrimSpace(msg), "  \n  ", ""))
 			c.AddBreach(result.ValueBreach{
 				ValueLabel: c.ConfigName,
 				Value:      strings.ReplaceAll(strings.TrimSpace(msg), "  \n  ", "")})

--- a/pkg/checks/drupal/drushyamlcheck_test.go
+++ b/pkg/checks/drupal/drushyamlcheck_test.go
@@ -75,8 +75,13 @@ func TestDrushYamlCheck(t *testing.T) {
 		assert.Equal(result.Fail, c.Result.Status)
 		assert.Empty(c.Result.Passes)
 		assert.ElementsMatch(
-			[]string{"vendor/drush/drush/drush: no such file or directory"},
-			c.Result.Failures,
+			[]result.Breach{result.ValueBreach{
+				BreachType: "value",
+				CheckType:  "drush-yaml",
+				Severity:   "normal",
+				Value:      "vendor/drush/drush/drush: no such file or directory",
+			}},
+			c.Result.Breaches,
 		)
 	})
 
@@ -99,8 +104,12 @@ func TestDrushYamlCheck(t *testing.T) {
 		assert.Equal(result.Fail, c.Result.Status)
 		assert.Empty(c.Result.Passes)
 		assert.ElementsMatch(
-			[]string{"unable to run drush command"},
-			c.Result.Failures,
+			[]result.Breach{result.ValueBreach{
+				BreachType: "value",
+				ValueLabel: "core.extension",
+				Value:      "unable to run drush command",
+			}},
+			c.Result.Breaches,
 		)
 	})
 
@@ -125,6 +134,6 @@ module:
 		c.FetchData()
 		assert.NotEqual(result.Fail, c.Result.Status)
 		assert.Empty(c.Result.Passes)
-		assert.Empty(c.Result.Failures)
+		assert.Empty(c.Result.Breaches)
 	})
 }

--- a/pkg/checks/drupal/filemodulecheck_test.go
+++ b/pkg/checks/drupal/filemodulecheck_test.go
@@ -60,7 +60,7 @@ func TestFileModuleCheck(t *testing.T) {
 	c.UnmarshalDataMap()
 	c.RunCheck()
 	assert.Equal(result.Pass, c.Result.Status)
-	assert.Empty(c.Result.Failures)
+	assert.Empty(c.Result.Breaches)
 	assert.ElementsMatch(c.Result.Passes, []string{
 		"all required modules are enabled",
 		"all disallowed modules are disabled",

--- a/pkg/checks/drupal/trackingcodecheck.go
+++ b/pkg/checks/drupal/trackingcodecheck.go
@@ -35,7 +35,6 @@ func (c *TrackingCodeCheck) Merge(mergeCheck config.Check) error {
 // type for further processing.
 func (c *TrackingCodeCheck) UnmarshalDataMap() {
 	if len(c.DataMap[c.ConfigName]) == 0 {
-		c.AddFail("no data provided")
 		c.AddBreach(result.ValueBreach{Value: "no data provided"})
 	}
 
@@ -43,7 +42,6 @@ func (c *TrackingCodeCheck) UnmarshalDataMap() {
 	err := yaml.Unmarshal(c.DataMap[c.ConfigName], &c.DrushStatus)
 	if err != nil {
 		if _, ok := err.(*yaml.TypeError); !ok {
-			c.AddFail(err.Error())
 			c.AddBreach(result.ValueBreach{Value: err.Error()})
 			return
 		}
@@ -54,7 +52,6 @@ func (c *TrackingCodeCheck) RunCheck() {
 	resp, err := http.Get(c.DrushStatus.Uri)
 
 	if err != nil {
-		c.AddFail("could not determine site uri")
 		c.AddBreach(result.ValueBreach{Value: "could not determine site uri"})
 		return
 	}
@@ -68,7 +65,6 @@ func (c *TrackingCodeCheck) RunCheck() {
 		c.AddPass(fmt.Sprintf("tracking code [%s] present", c.Code))
 		c.Result.Status = result.Pass
 	} else {
-		c.AddFail(fmt.Sprintf("tracking code [%s] not present", c.Code))
 		c.AddBreach(result.KeyValueBreach{
 			Key:   "required tracking code not present",
 			Value: c.Code,

--- a/pkg/checks/drupal/trackingcodecheck_test.go
+++ b/pkg/checks/drupal/trackingcodecheck_test.go
@@ -88,8 +88,13 @@ func TestTrackingCodeCheckFails(t *testing.T) {
 	c.RunCheck()
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.ElementsMatch(
-		[]string{"tracking code [UA-xxxxxx-1] not present"},
-		c.Result.Failures,
+		[]result.Breach{result.KeyValueBreach{
+			BreachType: "key-value",
+			CheckType:  "drupal-tracking-code",
+			Severity:   "normal",
+			Key:        "required tracking code not present",
+			Value:      "UA-xxxxxx-1"}},
+		c.Result.Breaches,
 	)
 }
 

--- a/pkg/checks/drupal/userrolecheck_test.go
+++ b/pkg/checks/drupal/userrolecheck_test.go
@@ -54,8 +54,13 @@ func TestFetchData(t *testing.T) {
 		c := UserRoleCheck{}
 		c.FetchData()
 		assert.Equal(result.Fail, c.Result.Status)
-		assert.EqualValues([]string{"vendor/drush/drush/drush: no such file or directory"}, c.Result.Failures)
-
+		assert.EqualValues(
+			[]result.Breach{result.ValueBreach{
+				BreachType: "value",
+				Value:      "vendor/drush/drush/drush: no such file or directory",
+			}},
+			c.Result.Breaches,
+		)
 	})
 
 	curShellCommander := command.ShellCommander
@@ -79,13 +84,25 @@ func TestFetchData(t *testing.T) {
 		c := UserRoleCheck{}
 		c.FetchData()
 		assert.Equal(result.Fail, c.Result.Status)
-		assert.EqualValues([]string{"unable to run drush sql query"}, c.Result.Failures)
+		assert.EqualValues(
+			[]result.Breach{result.ValueBreach{
+				BreachType: "value",
+				Value:      "unable to run drush sql query",
+			}},
+			c.Result.Breaches,
+		)
 
 		sqlQueryFail = false
 		c = UserRoleCheck{}
 		c.FetchData()
 		assert.Equal(result.Fail, c.Result.Status)
-		assert.EqualValues([]string{"unable to run drush command"}, c.Result.Failures)
+		assert.EqualValues(
+			[]result.Breach{result.ValueBreach{
+				BreachType: "value",
+				Value:      "unable to run drush command",
+			}},
+			c.Result.Breaches,
+		)
 	})
 
 	// correct data.
@@ -110,7 +127,13 @@ func TestUnmarshalData(t *testing.T) {
 	c := UserRoleCheck{}
 	c.UnmarshalDataMap()
 	assert.Equal(result.Fail, c.Result.Status)
-	assert.EqualValues([]string{"no data provided"}, c.Result.Failures)
+	assert.EqualValues(
+		[]result.Breach{result.ValueBreach{
+			BreachType: "value",
+			Value:      "no data provided",
+		}},
+		c.Result.Breaches,
+	)
 
 	// Incorrect json.
 	c = UserRoleCheck{
@@ -121,7 +144,13 @@ func TestUnmarshalData(t *testing.T) {
 	}
 	c.UnmarshalDataMap()
 	assert.Equal(result.Fail, c.Result.Status)
-	assert.EqualValues([]string{"invalid character ']' after object key:value pair"}, c.Result.Failures)
+	assert.EqualValues(
+		[]result.Breach{result.ValueBreach{
+			BreachType: "value",
+			Value:      "invalid character ']' after object key:value pair",
+		}},
+		c.Result.Breaches,
+	)
 
 	// Correct json.
 	c = UserRoleCheck{
@@ -150,7 +179,13 @@ func TestRunCheck(t *testing.T) {
 	c.UnmarshalDataMap()
 	c.RunCheck()
 	assert.Equal(result.Fail, c.Result.Status)
-	assert.EqualValues([]string{"no disallowed role provided"}, c.Result.Failures)
+	assert.EqualValues(
+		[]result.Breach{result.ValueBreach{
+			BreachType: "value",
+			Value:      "no disallowed role provided",
+		}},
+		c.Result.Breaches,
+	)
 
 	// User has disallowed roles.
 	c = UserRoleCheck{
@@ -163,7 +198,16 @@ func TestRunCheck(t *testing.T) {
 	c.UnmarshalDataMap()
 	c.RunCheck()
 	assert.Equal(result.Fail, c.Result.Status)
-	assert.EqualValues([]string{"User 1 has disallowed roles: [site-admin, content-admin]"}, c.Result.Failures)
+	assert.EqualValues(
+		[]result.Breach{result.KeyValuesBreach{
+			BreachType: "key-values",
+			KeyLabel:   "user",
+			Key:        "1",
+			ValueLabel: "disallowed roles",
+			Values:     []string{"site-admin", "content-admin"},
+		}},
+		c.Result.Breaches,
+	)
 
 	// User allowed to have disallowed roles.
 	c = UserRoleCheck{

--- a/pkg/checks/file/filecheck.go
+++ b/pkg/checks/file/filecheck.go
@@ -55,7 +55,6 @@ func (c *FileCheck) RequiresData() bool { return false }
 func (c *FileCheck) RunCheck() {
 	files, err := utils.FindFiles(filepath.Join(config.ProjectDir, c.Path), c.DisallowedPattern, c.ExcludePattern, c.SkipDir)
 	if err != nil {
-		c.AddFail(err.Error())
 		c.AddBreach(result.ValueBreach{
 			ValueLabel: "error finding files",
 			Value:      err.Error()})
@@ -65,9 +64,6 @@ func (c *FileCheck) RunCheck() {
 		c.Result.Status = result.Pass
 		c.AddPass("No illegal files")
 		return
-	}
-	for _, f := range files {
-		c.AddFail(fmt.Sprintf("Illegal file found: %s", f))
 	}
 	c.AddBreach(result.KeyValueBreach{
 		Key:   fmt.Sprintf("%s - illegal files found", c.Name),

--- a/pkg/checks/file/filecheck_test.go
+++ b/pkg/checks/file/filecheck_test.go
@@ -52,28 +52,43 @@ func TestFileCheckRunCheck(t *testing.T) {
 		Path:              "file-non-existent",
 		DisallowedPattern: "^(adminer|phpmyadmin|bigdump)?\\.php$",
 	}
+	c.Name = "filecheck1"
 	c.Init(File)
 	c.RunCheck()
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.Equal(0, len(c.Result.Passes))
 	assert.EqualValues(
-		[]string{"lstat testdata/file-non-existent: no such file or directory"},
-		c.Result.Failures,
+		[]result.Breach{result.ValueBreach{
+			CheckType:  "file",
+			CheckName:  "filecheck1",
+			BreachType: result.BreachTypeValue,
+			Severity:   "normal",
+			ValueLabel: "error finding files",
+			Value:      "lstat testdata/file-non-existent: no such file or directory",
+		}},
+		c.Result.Breaches,
 	)
 
 	c = FileCheck{
 		DisallowedPattern: "^(adminer|phpmyadmin|bigdump)?\\.php$",
 	}
+	c.Name = "filecheck2"
 	c.Init(File)
 	c.RunCheck()
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.Equal(0, len(c.Result.Passes))
 	assert.EqualValues(
-		[]string{
-			"Illegal file found: testdata/adminer.php",
-			"Illegal file found: testdata/sub/phpmyadmin.php",
+		[]result.Breach{
+			result.KeyValueBreach{
+				CheckType:  "file",
+				CheckName:  "filecheck2",
+				BreachType: result.BreachTypeKeyValue,
+				Severity:   "normal",
+				Key:        "filecheck2 - illegal files found",
+				Value:      "testdata/adminer.php\ntestdata/sub/phpmyadmin.php",
+			},
 		},
-		c.Result.Failures,
+		c.Result.Breaches,
 	)
 
 	c = FileCheck{
@@ -84,6 +99,6 @@ func TestFileCheckRunCheck(t *testing.T) {
 	c.RunCheck()
 
 	assert.Equal(result.Pass, c.Result.Status)
-	assert.Equal(0, len(c.Result.Failures))
+	assert.Equal(0, len(c.Result.Breaches))
 	assert.EqualValues([]string{"No illegal files"}, c.Result.Passes)
 }

--- a/pkg/checks/json/json_test.go
+++ b/pkg/checks/json/json_test.go
@@ -1,13 +1,14 @@
 package json_test
 
 import (
+	"testing"
+
 	"github.com/goccy/go-json"
 	. "github.com/salsadigitalauorg/shipshape/pkg/checks/json"
 	"github.com/salsadigitalauorg/shipshape/pkg/checks/yaml"
 	"github.com/salsadigitalauorg/shipshape/pkg/config"
 	"github.com/salsadigitalauorg/shipshape/pkg/result"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestJsonCheckUnmarshalDataMap(t *testing.T) {
@@ -33,9 +34,16 @@ func TestJsonCheckUnmarshalDataMap(t *testing.T) {
 	c.UnmarshalDataMap()
 	assertions.Equal(result.Fail, c.Result.Status)
 	assertions.EqualValues(0, len(c.Result.Passes))
-	assertions.EqualValues(
-		[]string{"JSON error: invalid character 'p' looking for beginning of value"},
-		c.Result.Failures)
+	assertions.ElementsMatch(
+		[]result.Breach{
+			result.ValueBreach{
+				BreachType: result.BreachTypeValue,
+				ValueLabel: "JSON error",
+				Value:      "invalid character 'p' looking for beginning of value",
+			},
+		},
+		c.Result.Breaches,
+	)
 
 	// Valid data.
 	c = JsonCheck{
@@ -56,7 +64,7 @@ func TestJsonCheckUnmarshalDataMap(t *testing.T) {
 	}
 
 	c.UnmarshalDataMap()
-	assertions.EqualValues(0, len(c.Result.Failures))
+	assertions.EqualValues(0, len(c.Result.Breaches))
 }
 
 func TestJsonCheckKeyValue(t *testing.T) {

--- a/pkg/checks/sca/apptypecheck_test.go
+++ b/pkg/checks/sca/apptypecheck_test.go
@@ -26,8 +26,12 @@ func TestIsDrupalCheck(t *testing.T) {
 	c.RunCheck()
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(
-		[]string{"drupal detected at ./testdata/drupal"},
-		c.Result.Failures,
+		[]result.Breach{result.KeyValueBreach{
+			BreachType: "key-value",
+			Key:        "[./testdata/drupal] contains disallowed frameworks",
+			Value:      "[drupal]",
+		}},
+		c.Result.Breaches,
 	)
 }
 
@@ -62,8 +66,12 @@ func TestIsWordpressCheck(t *testing.T) {
 	c.RunCheck()
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(
-		[]string{"wordpress detected at ./testdata/wordpress"},
-		c.Result.Failures,
+		[]result.Breach{result.KeyValueBreach{
+			BreachType: "key-value",
+			Key:        "[./testdata/wordpress] contains disallowed frameworks",
+			Value:      "[wordpress]",
+		}},
+		c.Result.Breaches,
 	)
 }
 
@@ -84,8 +92,12 @@ func TestIsSymfonyCheck(t *testing.T) {
 	c.RunCheck()
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(
-		[]string{"symfony detected at ./testdata/symfony"},
-		c.Result.Failures,
+		[]result.Breach{result.KeyValueBreach{
+			BreachType: "key-value",
+			Key:        "[./testdata/symfony] contains disallowed frameworks",
+			Value:      "[symfony]",
+		}},
+		c.Result.Breaches,
 	)
 }
 
@@ -106,8 +118,12 @@ func TestIsLaravelCheck(t *testing.T) {
 	c.RunCheck()
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(
-		[]string{"laravel detected at ./testdata/laravel"},
-		c.Result.Failures,
+		[]result.Breach{result.KeyValueBreach{
+			BreachType: "key-value",
+			Key:        "[./testdata/laravel] contains disallowed frameworks",
+			Value:      "[laravel]",
+		}},
+		c.Result.Breaches,
 	)
 }
 

--- a/pkg/checks/yaml/yamlcheck.go
+++ b/pkg/checks/yaml/yamlcheck.go
@@ -38,7 +38,6 @@ func (c *YamlCheck) readFile(fkey string, fname string) {
 			c.AddPass(fmt.Sprintf("File %s does not exist", fname))
 			c.Result.Status = result.Pass
 		} else {
-			c.AddFail(err.Error())
 			c.AddBreach(result.ValueBreach{
 				ValueLabel: "error reading file: " + fname,
 				Value:      err.Error()})
@@ -66,7 +65,6 @@ func (c *YamlCheck) FetchData() {
 				c.AddPass(fmt.Sprintf("Path %s does not exist", configPath))
 				c.Result.Status = result.Pass
 			} else {
-				c.AddFail(err.Error())
 				c.AddBreach(result.ValueBreach{
 					ValueLabel: "error finding files in path: " + configPath,
 					Value:      err.Error()})
@@ -79,7 +77,6 @@ func (c *YamlCheck) FetchData() {
 			c.Result.Status = result.Pass
 			return
 		} else if len(files) == 0 {
-			c.AddFail("no matching config files found")
 			c.AddBreach(result.ValueBreach{
 				ValueLabel: c.Name + "- no file",
 				Value:      "no matching yaml files found"})
@@ -91,7 +88,6 @@ func (c *YamlCheck) FetchData() {
 			c.readFile(fname, fname)
 		}
 	} else {
-		c.AddFail("no file provided")
 		c.AddBreach(result.ValueBreach{
 			ValueLabel: c.Name + "- no file",
 			Value:      "no file provided"})

--- a/pkg/checks/yaml/yamllintcheck.go
+++ b/pkg/checks/yaml/yamllintcheck.go
@@ -2,6 +2,7 @@ package yaml
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/salsadigitalauorg/shipshape/pkg/config"
 	"github.com/salsadigitalauorg/shipshape/pkg/result"
@@ -25,11 +26,13 @@ func (c *YamlLintCheck) UnmarshalDataMap() {
 		err := yaml.Unmarshal([]byte(data), &ifc)
 		if err != nil {
 			if typeErr, ok := err.(*yaml.TypeError); ok {
-				for _, msg := range typeErr.Errors {
-					c.AddFail(fmt.Sprintf("[%s] %s", f, msg))
-				}
+				c.AddBreach(result.ValueBreach{
+					ValueLabel: "cannot decode yaml: " + f,
+					Value:      strings.Join(typeErr.Errors, "\n")})
 			} else {
-				c.AddFail(fmt.Sprintf("[%s] %s", f, err.Error()))
+				c.AddBreach(result.ValueBreach{
+					ValueLabel: "yaml error: " + f,
+					Value:      err.Error()})
 			}
 		} else {
 			c.AddPass(fmt.Sprintf("%s has valid yaml.", f))

--- a/pkg/checks/yaml/yamllintcheck_test.go
+++ b/pkg/checks/yaml/yamllintcheck_test.go
@@ -53,13 +53,25 @@ func TestYamlLintCheck(t *testing.T) {
 	c.FetchData()
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.Empty(c.Result.Passes)
-	assert.ElementsMatch([]string{"no file provided"}, c.Result.Failures)
+	assert.ElementsMatch(
+		[]result.Breach{
+			result.ValueBreach{
+				BreachType: "value",
+				CheckType:  "yamllint",
+				CheckName:  "Test yaml lint",
+				Severity:   "normal",
+				ValueLabel: "Test yaml lint- no file",
+				Value:      "no file provided",
+			},
+		},
+		c.Result.Breaches,
+	)
 
 	c = mockCheck("non-existent-file.yml", []string{}, true)
 	c.Init(YamlLint)
 	c.FetchData()
 	assert.NotEqual(result.Fail, c.Result.Status)
-	assert.Empty(c.Result.Failures)
+	assert.Empty(c.Result.Breaches)
 	assert.ElementsMatch(
 		[]string{"File testdata/non-existent-file.yml does not exist"},
 		c.Result.Passes,
@@ -69,7 +81,7 @@ func TestYamlLintCheck(t *testing.T) {
 	c.Init(YamlLint)
 	c.FetchData()
 	assert.NotEqual(result.Fail, c.Result.Status)
-	assert.Empty(c.Result.Failures)
+	assert.Empty(c.Result.Breaches)
 	assert.ElementsMatch([]string{
 		"File testdata/non-existent-file.yml does not exist",
 		"File testdata/yaml-invalid.yml does not exist",
@@ -81,8 +93,17 @@ func TestYamlLintCheck(t *testing.T) {
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.Empty(c.Result.Passes)
 	assert.ElementsMatch(
-		[]string{"open testdata/non-existent-file.yml: no such file or directory"},
-		c.Result.Failures,
+		[]result.Breach{
+			result.ValueBreach{
+				BreachType: "value",
+				CheckType:  "yamllint",
+				CheckName:  "Test yaml lint",
+				Severity:   "normal",
+				ValueLabel: "error reading file: testdata/non-existent-file.yml",
+				Value:      "open testdata/non-existent-file.yml: no such file or directory",
+			},
+		},
+		c.Result.Breaches,
 	)
 
 	c = mockCheck("", []string{"non-existent-file.yml", "yamllint-invalid.yml"}, false)
@@ -91,8 +112,17 @@ func TestYamlLintCheck(t *testing.T) {
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.Empty(c.Result.Passes)
 	assert.ElementsMatch(
-		[]string{"open testdata/non-existent-file.yml: no such file or directory"},
-		c.Result.Failures,
+		[]result.Breach{
+			result.ValueBreach{
+				BreachType: "value",
+				CheckType:  "yamllint",
+				CheckName:  "Test yaml lint",
+				Severity:   "normal",
+				ValueLabel: "error reading file: testdata/non-existent-file.yml",
+				Value:      "open testdata/non-existent-file.yml: no such file or directory",
+			},
+		},
+		c.Result.Breaches,
 	)
 
 	c = mockCheck("", []string{}, false)
@@ -105,8 +135,17 @@ this: yaml
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.Empty(c.Result.Passes)
 	assert.ElementsMatch(
-		[]string{"[yaml-invalid.yml] line 3: mapping key \"this\" already defined at line 2"},
-		c.Result.Failures,
+		[]result.Breach{
+			result.ValueBreach{
+				BreachType: "value",
+				CheckType:  "yamllint",
+				CheckName:  "Test yaml lint",
+				Severity:   "normal",
+				ValueLabel: "cannot decode yaml: yaml-invalid.yml",
+				Value:      "line 3: mapping key \"this\" already defined at line 2",
+			},
+		},
+		c.Result.Breaches,
 	)
 
 	c = mockCheck("", []string{}, false)
@@ -117,7 +156,7 @@ valid: yaml
 `)
 	c.UnmarshalDataMap()
 	assert.Equal(result.Pass, c.Result.Status)
-	assert.Empty(c.Result.Failures)
+	assert.Empty(c.Result.Breaches)
 	assert.ElementsMatch(
 		[]string{"yaml-valid.yml has valid yaml."},
 		c.Result.Passes,
@@ -134,8 +173,14 @@ foo: bar
 		assert.Equal(result.Fail, c.Result.Status)
 		assert.Empty(c.Result.Passes)
 		assert.ElementsMatch(
-			[]string{"[yaml-invalid-root.yml] yaml: line 1: did not find expected key"},
-			c.Result.Failures,
+			[]result.Breach{
+				result.ValueBreach{
+					BreachType: "value",
+					ValueLabel: "yaml error: yaml-invalid-root.yml",
+					Value:      "yaml: line 1: did not find expected key",
+				},
+			},
+			c.Result.Breaches,
 		)
 	})
 
@@ -149,7 +194,7 @@ foo: bar
 `)}
 		c.UnmarshalDataMap()
 		assert.Equal(result.Pass, c.Result.Status)
-		assert.Empty(c.Result.Failures)
+		assert.Empty(c.Result.Breaches)
 		assert.ElementsMatch(
 			[]string{"yaml-valid-list.yml has valid yaml."},
 			c.Result.Passes,

--- a/pkg/config/checkbase.go
+++ b/pkg/config/checkbase.go
@@ -63,7 +63,7 @@ func (c *CheckBase) FetchData() {}
 func (c *CheckBase) HasData(failCheck bool) bool {
 	if c.DataMap == nil {
 		if failCheck {
-			c.AddFail("no data available")
+			c.AddBreach(result.ValueBreach{Value: "no data available"})
 		}
 		return false
 	}
@@ -73,15 +73,6 @@ func (c *CheckBase) HasData(failCheck bool) bool {
 // UnmarshalDataMap attempts to parse the DataMap into a structure that
 // can be used to execute the check. Any failure here should fail the check.
 func (c *CheckBase) UnmarshalDataMap() {}
-
-// AddFail appends a Fail to the Result and sets the Check as Fail.
-func (c *CheckBase) AddFail(msg string) {
-	c.Result.Status = result.Fail
-	c.Result.Failures = append(
-		c.Result.Failures,
-		msg,
-	)
-}
 
 // AddBreach appends a Breach to the Result and sets the Check as Fail.
 func (c *CheckBase) AddBreach(b result.Breach) {
@@ -120,7 +111,7 @@ func (c *CheckBase) AddRemediation(msg string) {
 // generating the result and remediating breaches.
 // This is where c.Result should be populated.
 func (c *CheckBase) RunCheck() {
-	c.AddFail("not implemented")
+	c.AddBreach(result.ValueBreach{Value: "not implemented"})
 }
 
 // GetResult returns a ref of the result.

--- a/pkg/config/testdata/testchecks/testchecks.go
+++ b/pkg/config/testdata/testchecks/testchecks.go
@@ -2,10 +2,12 @@ package testchecks
 
 import (
 	"github.com/salsadigitalauorg/shipshape/pkg/config"
+	"github.com/salsadigitalauorg/shipshape/pkg/utils"
 )
 
 const TestCheck1 config.CheckType = "test-check-1"
 const TestCheck2 config.CheckType = "test-check-2"
+const TestCheck3 config.CheckType = "test-check-3"
 
 type TestCheck1Check struct {
 	config.CheckBase `yaml:",inline"`
@@ -14,7 +16,23 @@ type TestCheck1Check struct {
 
 func (*TestCheck1Check) RequiresData() bool { return false }
 
+// Merge implementation for test-check-1 check.
+func (c *TestCheck1Check) Merge(mergeCheck config.Check) error {
+	testCheck1MergeCheck := mergeCheck.(*TestCheck1Check)
+	if err := c.CheckBase.Merge(&testCheck1MergeCheck.CheckBase); err != nil {
+		return err
+	}
+
+	utils.MergeString(&c.Foo, testCheck1MergeCheck.Foo)
+	return nil
+}
+
 type TestCheck2Check struct {
+	config.CheckBase `yaml:",inline"`
+	Bar              string `yaml:"bar"`
+}
+
+type TestCheck3Check struct {
 	config.CheckBase `yaml:",inline"`
 	Bar              string `yaml:"bar"`
 }
@@ -22,4 +40,5 @@ type TestCheck2Check struct {
 func RegisterChecks() {
 	config.ChecksRegistry[TestCheck1] = func() config.Check { return &TestCheck1Check{} }
 	config.ChecksRegistry[TestCheck2] = func() config.Check { return &TestCheck2Check{} }
+	config.ChecksRegistry[TestCheck3] = func() config.Check { return &TestCheck3Check{} }
 }

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -42,7 +42,7 @@ type Check interface {
 	HasData(failCheck bool) bool
 	FetchData()
 	UnmarshalDataMap()
-	AddFail(msg string)
+	AddBreach(result.Breach)
 	AddPass(msg string)
 	AddWarning(msg string)
 	SetPerformRemediation(flag bool)

--- a/pkg/internal/testutils_runcheck.go
+++ b/pkg/internal/testutils_runcheck.go
@@ -63,12 +63,12 @@ func TestRunCheck(t *testing.T, ctest RunCheckTest) {
 	}
 
 	if ctest.ExpectNoFail {
-		assert.Empty(r.Failures)
+		assert.Empty(r.Breaches)
 	} else {
 		assert.ElementsMatchf(
 			ctest.ExpectFails,
-			r.Failures,
-			"Expected fails: %#v \nGot %#v", ctest.ExpectFails, r.Failures)
+			r.Breaches,
+			"Expected fails: %#v \nGot %#v", ctest.ExpectFails, r.Breaches)
 	}
 
 	if ctest.ExpectNoRemediations {

--- a/pkg/internal/testutils_runcheck.go
+++ b/pkg/internal/testutils_runcheck.go
@@ -25,7 +25,7 @@ type RunCheckTest struct {
 	ExpectNoPass         bool
 	ExpectPasses         []string
 	ExpectNoFail         bool
-	ExpectFails          []string
+	ExpectFails          []result.Breach
 	ExpectNoRemediations bool
 	ExpectRemediations   []string
 }

--- a/pkg/result/breach.go
+++ b/pkg/result/breach.go
@@ -1,7 +1,14 @@
 package result
 
+import (
+	"fmt"
+	"strings"
+)
+
 // Breach provides a representation for different breach types.
-type Breach interface{}
+type Breach interface {
+	String() string
+}
 
 type BreachType string
 
@@ -28,6 +35,10 @@ type ValueBreach struct {
 	ExpectedValue string
 }
 
+func (b ValueBreach) String() string {
+	return fmt.Sprintf("[%s] %s", b.ValueLabel, b.Value)
+}
+
 // Breach with key and value.
 // Example:
 //
@@ -48,6 +59,13 @@ type KeyValueBreach struct {
 	ExpectedValue string
 }
 
+func (b KeyValueBreach) String() string {
+	if b.ExpectedValue != "" {
+		return fmt.Sprintf("[%s] '%s' equals '%s', expected '%s'", b.KeyLabel, b.Key, b.Value, b.ExpectedValue)
+	}
+	return fmt.Sprintf("[%s %s] %s: %s", b.KeyLabel, b.Key, b.ValueLabel, b.Value)
+}
+
 // Breach with key and list of values.
 // Example:
 //
@@ -65,6 +83,11 @@ type KeyValuesBreach struct {
 	Key        string
 	ValueLabel string
 	Values     []string
+}
+
+func (b KeyValuesBreach) String() string {
+	return fmt.Sprintf("[%s:%s] %s: %s", b.KeyLabel, b.Key, b.ValueLabel,
+		"["+strings.Join(b.Values, ", ")+"]")
 }
 
 func BreachSetCommonValues(bIfc *Breach, checkType string, checkName string, severity string) {

--- a/pkg/result/breach.go
+++ b/pkg/result/breach.go
@@ -36,7 +36,10 @@ type ValueBreach struct {
 }
 
 func (b ValueBreach) String() string {
-	return fmt.Sprintf("[%s] %s", b.ValueLabel, b.Value)
+	if b.ValueLabel != "" {
+		return fmt.Sprintf("[%s] %s", b.ValueLabel, b.Value)
+	}
+	return fmt.Sprintf("%s", b.Value)
 }
 
 // Breach with key and value.
@@ -63,7 +66,7 @@ func (b KeyValueBreach) String() string {
 	if b.ExpectedValue != "" {
 		return fmt.Sprintf("[%s] '%s' equals '%s', expected '%s'", b.KeyLabel, b.Key, b.Value, b.ExpectedValue)
 	}
-	return fmt.Sprintf("[%s %s] %s: %s", b.KeyLabel, b.Key, b.ValueLabel, b.Value)
+	return fmt.Sprintf("[%s:%s] %s: %s", b.KeyLabel, b.Key, b.ValueLabel, b.Value)
 }
 
 // Breach with key and list of values.
@@ -86,8 +89,11 @@ type KeyValuesBreach struct {
 }
 
 func (b KeyValuesBreach) String() string {
-	return fmt.Sprintf("[%s:%s] %s: %s", b.KeyLabel, b.Key, b.ValueLabel,
-		"["+strings.Join(b.Values, ", ")+"]")
+	if b.KeyLabel != "" && b.ValueLabel != "" {
+		return fmt.Sprintf("[%s:%s] %s: %s", b.KeyLabel, b.Key, b.ValueLabel,
+			"["+strings.Join(b.Values, ", ")+"]")
+	}
+	return fmt.Sprintf("%s: %s", b.Key, "["+strings.Join(b.Values, ", ")+"]")
 }
 
 func BreachSetCommonValues(bIfc *Breach, checkType string, checkName string, severity string) {

--- a/pkg/result/breach_test.go
+++ b/pkg/result/breach_test.go
@@ -8,10 +8,103 @@ import (
 	. "github.com/salsadigitalauorg/shipshape/pkg/result"
 )
 
-func TestBreachSetCommonValues(t *testing.T) {
+func TestBreachValueBreachStringer(t *testing.T) {
 	assert := assert.New(t)
 
-	type bogusBreach struct{}
+	tests := []struct {
+		name     string
+		breach   Breach
+		expected string
+	}{
+		{
+			name: "value-breach",
+			breach: ValueBreach{
+				ValueLabel: "file not found",
+				Value:      "foo.ext",
+			},
+			expected: "[file not found] foo.ext",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(test.expected, test.breach.String())
+		})
+	}
+}
+
+func TestBreachKeyValueBreachStringer(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		name     string
+		breach   Breach
+		expected string
+	}{
+		{
+			name: "key-value-breach-1",
+			breach: KeyValueBreach{
+				KeyLabel:   "config",
+				Key:        "clamav.settings",
+				ValueLabel: "key not found",
+				Value:      "enabled",
+			},
+			expected: "[config clamav.settings] key not found: enabled",
+		},
+		{
+			name: "key-value-breach-2",
+			breach: KeyValueBreach{
+				KeyLabel:      "clamav.settings",
+				Key:           "enabled",
+				Value:         "false",
+				ExpectedValue: "true",
+			},
+			expected: "[clamav.settings] 'enabled' equals 'false', expected 'true'",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(test.expected, test.breach.String())
+		})
+	}
+}
+
+func TestBreachKeyValuesBreachStringers(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		name     string
+		breach   Breach
+		expected string
+	}{
+		{
+			name: "KeyValuesBreach",
+			breach: KeyValuesBreach{
+				KeyLabel:   "role",
+				Key:        "admin",
+				ValueLabel: "disallowed permissions",
+				Values:     []string{"delete the site", "delete the world"},
+			},
+			expected: "[role:admin] disallowed permissions: [delete the site, delete the world]",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(test.expected, test.breach.String())
+		})
+	}
+}
+
+type bogusBreach struct{}
+
+func (b bogusBreach) String() string {
+	return ""
+}
+
+func TestBreachSetCommonValues(t *testing.T) {
+	assert := assert.New(t)
 
 	tests := []struct {
 		name               string
@@ -78,8 +171,6 @@ func TestBreachSetCommonValues(t *testing.T) {
 
 func TestBreachGetters(t *testing.T) {
 	assert := assert.New(t)
-
-	type bogusBreach struct{}
 
 	tests := []struct {
 		name                  string

--- a/pkg/result/breach_test.go
+++ b/pkg/result/breach_test.go
@@ -49,7 +49,7 @@ func TestBreachKeyValueBreachStringer(t *testing.T) {
 				ValueLabel: "key not found",
 				Value:      "enabled",
 			},
-			expected: "[config clamav.settings] key not found: enabled",
+			expected: "[config:clamav.settings] key not found: enabled",
 		},
 		{
 			name: "key-value-breach-2",

--- a/pkg/result/result.go
+++ b/pkg/result/result.go
@@ -18,7 +18,6 @@ type Result struct {
 	CheckType    string   `json:"check-type"`
 	Status       Status   `json:"status"`
 	Passes       []string `json:"passes"`
-	Failures     []string `json:"failures"`
 	Breaches     []Breach `json:"breaches"`
 	Warnings     []string `json:"warnings"`
 	Remediations []string `json:"remediations"`
@@ -26,9 +25,9 @@ type Result struct {
 
 // Sort reorders the Passes & Failures in order to get consistent output.
 func (r *Result) Sort() {
-	if len(r.Failures) > 0 {
-		sort.Slice(r.Failures, func(i int, j int) bool {
-			return r.Failures[i] < r.Failures[j]
+	if len(r.Breaches) > 0 {
+		sort.Slice(r.Breaches, func(i int, j int) bool {
+			return BreachGetCheckName(r.Breaches[i]) < BreachGetCheckName(r.Breaches[j])
 		})
 	}
 

--- a/pkg/result/result_test.go
+++ b/pkg/result/result_test.go
@@ -12,15 +12,25 @@ func TestResultSort(t *testing.T) {
 	assert := assert.New(t)
 
 	r := Result{
-		Passes:   []string{"z pass", "g pass", "a pass", "b pass"},
-		Failures: []string{"x fail", "h fail", "v fail", "f fail"},
+		Passes: []string{"z pass", "g pass", "a pass", "b pass"},
+		Breaches: []Breach{
+			ValueBreach{CheckName: "x", Value: "breach 1"},
+			ValueBreach{CheckName: "h", Value: "breach 2"},
+			ValueBreach{CheckName: "v", Value: "breach 3"},
+			ValueBreach{CheckName: "f", Value: "breach 4"},
+		},
 		Warnings: []string{"y warn", "i warn", "u warn", "c warn"},
 	}
 	r.Sort()
 
 	assert.EqualValues(Result{
-		Passes:   []string{"a pass", "b pass", "g pass", "z pass"},
-		Failures: []string{"f fail", "h fail", "v fail", "x fail"},
+		Passes: []string{"a pass", "b pass", "g pass", "z pass"},
+		Breaches: []Breach{
+			ValueBreach{CheckName: "f", Value: "breach 4"},
+			ValueBreach{CheckName: "h", Value: "breach 2"},
+			ValueBreach{CheckName: "v", Value: "breach 3"},
+			ValueBreach{CheckName: "x", Value: "breach 1"},
+		},
 		Warnings: []string{"c warn", "i warn", "u warn", "y warn"},
 	}, r)
 }

--- a/pkg/result/resultlist.go
+++ b/pkg/result/resultlist.go
@@ -60,7 +60,7 @@ func (rl *ResultList) AddResult(r Result) {
 	defer lock.Unlock()
 	rl.Results = append(rl.Results, r)
 
-	breachesIncr := len(r.Failures)
+	breachesIncr := len(r.Breaches)
 	atomic.AddUint32(&rl.TotalBreaches, uint32(breachesIncr))
 	rl.BreachCountByType[r.CheckType] = rl.BreachCountByType[r.CheckType] + breachesIncr
 	rl.BreachCountBySeverity[r.Severity] = rl.BreachCountBySeverity[r.Severity] + breachesIncr
@@ -71,23 +71,23 @@ func (rl *ResultList) AddResult(r Result) {
 }
 
 // GetBreachesByCheckName fetches the list of failures by check name.
-func (rl *ResultList) GetBreachesByCheckName(cn string) []string {
-	var breaches []string
+func (rl *ResultList) GetBreachesByCheckName(cn string) []Breach {
+	var breaches []Breach
 	for _, r := range rl.Results {
 		if r.Name == cn {
-			breaches = append(breaches, r.Failures...)
+			breaches = append(breaches, r.Breaches...)
 		}
 	}
 	return breaches
 }
 
 // GetBreachesBySeverity fetches the list of failures by severity.
-func (rl *ResultList) GetBreachesBySeverity(s string) []string {
-	var breaches []string
+func (rl *ResultList) GetBreachesBySeverity(s string) []Breach {
+	var breaches []Breach
 
 	for _, r := range rl.Results {
 		if r.Severity == s {
-			breaches = append(breaches, r.Failures...)
+			breaches = append(breaches, r.Breaches...)
 		}
 	}
 	return breaches

--- a/pkg/shipshape/output.go
+++ b/pkg/shipshape/output.go
@@ -30,14 +30,14 @@ func TableDisplay(w *tabwriter.Writer) {
 		if len(r.Passes) > 0 {
 			linePass = r.Passes[0]
 		}
-		if len(r.Failures) > 0 {
-			lineFail = r.Failures[0]
+		if len(r.Breaches) > 0 {
+			lineFail = r.Breaches[0].String()
 		}
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", r.Name, r.Status, linePass, lineFail)
 
-		if len(r.Passes) > 1 || len(r.Failures) > 1 {
+		if len(r.Passes) > 1 || len(r.Breaches) > 1 {
 			numPasses := len(r.Passes)
-			numFailures := len(r.Failures)
+			numFailures := len(r.Breaches)
 
 			// How many additional lines?
 			numAddLines := numPasses
@@ -52,7 +52,7 @@ func TableDisplay(w *tabwriter.Writer) {
 					linePass = r.Passes[i]
 				}
 				if numFailures > i {
-					lineFail = r.Failures[i]
+					lineFail = r.Breaches[i].String()
 				}
 				fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", "", "", linePass, lineFail)
 			}
@@ -105,11 +105,11 @@ func SimpleDisplay(w *bufio.Writer) {
 	}
 
 	for _, r := range RunResultList.Results {
-		if len(r.Failures) == 0 {
+		if len(r.Breaches) == 0 {
 			continue
 		}
 		fmt.Fprintf(w, "  ### %s\n", r.Name)
-		for _, f := range r.Failures {
+		for _, f := range r.Breaches {
 			fmt.Fprintf(w, "     -- %s\n", f)
 		}
 		fmt.Fprintln(w)
@@ -143,7 +143,7 @@ func JUnit(w *bufio.Writer) {
 			}
 
 			for _, b := range RunResultList.GetBreachesByCheckName(c.GetName()) {
-				tc.Errors = append(tc.Errors, JUnitError{Message: b})
+				tc.Errors = append(tc.Errors, JUnitError{Message: b.String()})
 			}
 			ts.TestCases = append(ts.TestCases, tc)
 		}

--- a/pkg/shipshape/shipshape.go
+++ b/pkg/shipshape/shipshape.go
@@ -191,11 +191,11 @@ func ProcessCheck(rl *result.ResultList, c config.Check) {
 		contextLogger.Print("fetching data")
 		c.FetchData()
 		c.HasData(true)
-		if len(c.GetResult().Failures) == 0 {
+		if len(c.GetResult().Breaches) == 0 {
 			c.UnmarshalDataMap()
 		}
 	}
-	if len(c.GetResult().Failures) == 0 && len(c.GetResult().Passes) == 0 {
+	if len(c.GetResult().Breaches) == 0 && len(c.GetResult().Passes) == 0 {
 		contextLogger.Print("running check")
 		c.RunCheck()
 		c.GetResult().Sort()

--- a/pkg/shipshape/shipshape_test.go
+++ b/pkg/shipshape/shipshape_test.go
@@ -157,7 +157,35 @@ func TestRunChecks(t *testing.T) {
 		string(testchecks.TestCheck2): 1,
 	}, rl.BreachCountByType)
 	assert.ElementsMatch([]result.Result{
-		{Name: "test1stcheck", Severity: "normal", CheckType: "test-check-1", Status: "Fail", Passes: []string(nil), Failures: []string{"no data available"}, Warnings: []string(nil)},
-		{Name: "test2ndcheck", Severity: "normal", CheckType: "test-check-2", Status: "Fail", Passes: []string(nil), Failures: []string{"no data available"}, Warnings: []string(nil)}},
+		{
+			Name:      "test1stcheck",
+			Severity:  "normal",
+			CheckType: "test-check-1",
+			Status:    "Fail",
+			Passes:    []string(nil),
+			Breaches: []result.Breach{result.ValueBreach{
+				BreachType: "value",
+				CheckType:  "test-check-1",
+				CheckName:  "test1stcheck",
+				Severity:   "normal",
+				Value:      "no data available",
+			}},
+			Warnings: []string(nil),
+		},
+		{
+			Name:      "test2ndcheck",
+			Severity:  "normal",
+			CheckType: "test-check-2",
+			Status:    "Fail",
+			Passes:    []string(nil),
+			Breaches: []result.Breach{result.ValueBreach{
+				BreachType: "value",
+				CheckType:  "test-check-2",
+				CheckName:  "test2ndcheck",
+				Severity:   "normal",
+				Value:      "no data available",
+			}},
+			Warnings: []string(nil),
+		}},
 		rl.Results)
 }


### PR DESCRIPTION
This is a pretty big refactor which

- removes all usage of `Checkbase.AddFail` with `Checkbase.AddBreach`
- uses breaches for `SimpleDisplay` by adding Stringer functions to all Breach types
- removes the `Failures` field from `Result`
- replaces all tests `Failures` comparisons with `Breaches`