### PR TITLE
Add remediation support for drush yaml checks

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,11 +24,11 @@ jobs:
       with:
         go-version: 1.21
 
-    - name: Vet
-      run: go vet ./...
-
     - name: Run generators
       run: go generate ./...
+
+    - name: Vet
+      run: go vet ./...
 
     - name: Build
       run: go build -ldflags="-s -w" -o build/shipshape . && ls -lh build/shipshape

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
+# Generated files
+registry_gen.go
+pkg/result/breach_gen.go
+
 build
 dist/
 docker-compose.override.yml
 node_modules
-registry_gen.go
 venom-output

--- a/cmd/gen.go
+++ b/cmd/gen.go
@@ -12,6 +12,7 @@ import (
 var (
 	arg          string
 	checkpackage string
+	breachTypes  []string
 )
 
 func main() {
@@ -25,11 +26,18 @@ func main() {
 		}
 		gen.Registry(checkpackage)
 		break
+	case "breach-type":
+		if len(breachTypes) == 0 {
+			log.Fatal("missing flags; struct is required")
+		}
+		gen.BreachType(breachTypes)
+		break
 	}
 }
 
 func parseFlags() {
 	pflag.StringVar(&checkpackage, "checkpackage", "", "The package to which the check belongs")
+	pflag.StringSliceVar(&breachTypes, "type", []string{}, "The breach type")
 	pflag.Parse()
 }
 

--- a/cmd/gen/breachtype.go
+++ b/cmd/gen/breachtype.go
@@ -1,0 +1,70 @@
+package gen
+
+import (
+	"bytes"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+)
+
+func BreachType(breachTypes []string) {
+	log.Println("Generating breach type funcs -", strings.Join(breachTypes, ","))
+
+	breachTypeFile := "breach_gen.go"
+	breachTypeFullFilePath := filepath.Join(getScriptPath(), "..", "..", "pkg", "result", breachTypeFile)
+	if err := os.Remove(breachTypeFullFilePath); err != nil && !os.IsNotExist(err) {
+		log.Fatalln(err)
+	}
+	createFile(breachTypeFullFilePath, "package result\n")
+
+	for _, bt := range breachTypes {
+		appendFileContent(breachTypeFullFilePath, breachTypeFuncs(bt))
+	}
+}
+
+func breachTypeFuncs(bt string) string {
+	tmplStr := `
+/*
+ * {{.BreachType}}Breach
+ */
+func (b *{{.BreachType}}Breach) GetCheckName() string {
+	return b.CheckName
+}
+
+func (b *{{.BreachType}}Breach) GetCheckType() string {
+	return b.CheckType
+}
+
+func (b *{{.BreachType}}Breach) GetRemediation() *Remediation {
+	return &b.Remediation
+}
+
+func (b *{{.BreachType}}Breach) GetSeverity() string {
+	return b.Severity
+}
+
+func (b *{{.BreachType}}Breach) GetType() BreachType {
+	return BreachType{{.BreachType}}
+}
+
+func (b *{{.BreachType}}Breach) SetCommonValues(checkType string, checkName string, severity string) {
+	b.BreachType = b.GetType()
+	b.CheckType = checkType
+	b.CheckName = checkName
+	b.Severity = severity
+}
+`
+	tmpl, err := template.New("breachTypeFuncs").Parse(tmplStr)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	buf := &bytes.Buffer{}
+	err = tmpl.Execute(buf, struct{ BreachType string }{bt})
+	if err != nil {
+		log.Fatalln(err)
+	}
+	return buf.String()
+}

--- a/cmd/gen/breachtype.go
+++ b/cmd/gen/breachtype.go
@@ -55,6 +55,13 @@ func (b *{{.BreachType}}Breach) SetCommonValues(checkType string, checkName stri
 	b.CheckName = checkName
 	b.Severity = severity
 }
+
+func (b *{{.BreachType}}Breach) SetRemediation(status RemediationStatus, msg string) {
+	b.Remediation.Status = status
+	if msg != "" {
+		b.Remediation.Messages = []string{msg}
+	}
+}
 `
 	tmpl, err := template.New("breachTypeFuncs").Parse(tmplStr)
 	if err != nil {

--- a/cmd/gen/helpers.go
+++ b/cmd/gen/helpers.go
@@ -1,0 +1,79 @@
+package gen
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func getScriptPath() string {
+	_, b, _, _ := runtime.Caller(0)
+	return filepath.Dir(b)
+}
+
+func createFile(fullpath string, firstTimeContent string) {
+	if f, err := os.Stat(fullpath); err == nil && !f.IsDir() {
+		return
+	} else if !os.IsNotExist(err) {
+		log.Fatalln(err)
+	}
+
+	f, err := os.OpenFile(fullpath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer func() {
+		f.Close()
+	}()
+
+	if firstTimeContent == "" {
+		return
+	}
+
+	if _, err := f.Write([]byte(firstTimeContent)); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func getFileLines(fullpath string) []string {
+	input, err := os.ReadFile(fullpath)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	return strings.Split(string(input), "\n")
+}
+
+func writeFileContent(fullpath string, content string) {
+	err := os.WriteFile(fullpath, []byte(content), 0644)
+	if err != nil {
+		log.Fatalln(err)
+	}
+}
+
+func appendFileContent(fullpath string, content string) {
+	input, err := os.ReadFile(fullpath)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	output := string(input) + content
+	writeFileContent(fullpath, output)
+}
+
+func writeFileLines(fullpath string, lines []string) {
+	output := strings.Join(lines, "\n")
+	err := os.WriteFile(fullpath, []byte(output), 0644)
+	if err != nil {
+		log.Fatalln(err)
+	}
+}
+
+func stringSliceMatch(slice []string, item string) bool {
+	for _, s := range slice {
+		if strings.Contains(s, item) {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/gen/registry.go
+++ b/cmd/gen/registry.go
@@ -24,7 +24,9 @@ func Registry(chkPkg string) {
 	importLine := fmt.Sprintf("import _ \"%s\"", pkgFullName)
 	newFileLines := []string{}
 	for i, line := range fileLines {
-		if i == 2 {
+		// Add the import line before the last line,
+		// so that the last line is always a newline.
+		if i == len(fileLines)-1 {
 			newFileLines = append(newFileLines, importLine)
 		}
 		newFileLines = append(newFileLines, line)

--- a/cmd/gen/registry.go
+++ b/cmd/gen/registry.go
@@ -3,68 +3,20 @@ package gen
 import (
 	"fmt"
 	"log"
-	"os"
 	"path/filepath"
-	"runtime"
-	"strings"
 )
-
-var registryFile = "registry_gen.go"
-var fullRegistryFilePath string
 
 // Registry adds the checks for a package to the registry.
 func Registry(chkPkg string) {
-	fullRegistryFilePath = filepath.Join(getScriptPath(), "../../", registryFile)
-	createFile()
-	addImportLine(chkPkg)
-}
+	log.Println("Generating checks registry - adding", chkPkg)
 
-func getScriptPath() string {
-	_, b, _, _ := runtime.Caller(0)
-	return filepath.Dir(b)
-}
+	registryFile := "registry_gen.go"
+	registryFullFilePath := filepath.Join(getScriptPath(), "..", "..", registryFile)
+	createFile(registryFullFilePath, "package main\n\n")
 
-func createFile() {
-	if f, err := os.Stat(fullRegistryFilePath); err == nil && !f.IsDir() {
-		return
-	} else if !os.IsNotExist(err) {
-		log.Fatal(err)
-	}
-
-	f, err := os.OpenFile(fullRegistryFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer func() {
-		f.Close()
-	}()
-
-	if _, err := f.Write([]byte("package main\n\n")); err != nil {
-		log.Fatal(err)
-	}
-}
-
-func getFileLines() []string {
-	input, err := os.ReadFile(fullRegistryFilePath)
-	if err != nil {
-		log.Fatalln(err)
-	}
-
-	return strings.Split(string(input), "\n")
-}
-
-func writeFileLines(lines []string) {
-	output := strings.Join(lines, "\n")
-	err := os.WriteFile(fullRegistryFilePath, []byte(output), 0644)
-	if err != nil {
-		log.Fatalln(err)
-	}
-}
-
-func addImportLine(chkPkg string) {
 	pkgFullName := fmt.Sprintf("github.com/salsadigitalauorg/shipshape/pkg/checks/%s", chkPkg)
 
-	fileLines := getFileLines()
+	fileLines := getFileLines(registryFullFilePath)
 	if stringSliceMatch(fileLines, pkgFullName) {
 		return
 	}
@@ -77,14 +29,5 @@ func addImportLine(chkPkg string) {
 		}
 		newFileLines = append(newFileLines, line)
 	}
-	writeFileLines(newFileLines)
-}
-
-func stringSliceMatch(slice []string, item string) bool {
-	for _, s := range slice {
-		if strings.Contains(s, item) {
-			return true
-		}
-	}
-	return false
+	writeFileLines(registryFullFilePath, newFileLines)
 }

--- a/pkg/checks/crawler/crawlercheck.go
+++ b/pkg/checks/crawler/crawlercheck.go
@@ -79,7 +79,7 @@ func (c *CrawlerCheck) RunCheck() {
 
 	crawler.OnError(func(r *colly.Response, err error) {
 		c.Result.Status = result.Fail
-		c.AddBreach(result.KeyValueBreach{
+		c.AddBreach(&result.KeyValueBreach{
 			Key:        fmt.Sprintf("%v", r.Request.URL),
 			ValueLabel: "invalid response",
 			Value:      fmt.Sprintf("%d", r.StatusCode),

--- a/pkg/checks/crawler/crawlercheck_test.go
+++ b/pkg/checks/crawler/crawlercheck_test.go
@@ -59,7 +59,7 @@ func TestCrawlerCheck(t *testing.T) {
 	c.Init(Crawler)
 	c.RunCheck()
 	assert.ElementsMatch(
-		[]result.Breach{result.KeyValueBreach{
+		[]result.Breach{&result.KeyValueBreach{
 			BreachType: result.BreachTypeKeyValue,
 			CheckType:  "crawler",
 			Severity:   "normal",

--- a/pkg/checks/docker/baseimagecheck.go
+++ b/pkg/checks/docker/baseimagecheck.go
@@ -87,7 +87,7 @@ func (c *BaseImageCheck) RunCheck() {
 					}
 
 					if len(c.Allowed) > 0 && !utils.PackageCheckString(c.Allowed, match[1], match[2]) {
-						c.AddBreach(result.KeyValueBreach{
+						c.AddBreach(&result.KeyValueBreach{
 							Key:        name,
 							ValueLabel: "invalid base image",
 							Value:      match[1],
@@ -108,7 +108,7 @@ func (c *BaseImageCheck) RunCheck() {
 				}
 
 				if !utils.PackageCheckString(c.Allowed, match[1], match[2]) {
-					c.AddBreach(result.KeyValueBreach{
+					c.AddBreach(&result.KeyValueBreach{
 						Key:        name,
 						ValueLabel: "invalid base image",
 						Value:      def.Image,

--- a/pkg/checks/docker/baseimagecheck_test.go
+++ b/pkg/checks/docker/baseimagecheck_test.go
@@ -55,7 +55,7 @@ func TestInvalidDockerfileCheck(t *testing.T) {
 	c.RunCheck()
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(
-		[]result.Breach{result.KeyValueBreach{
+		[]result.Breach{&result.KeyValueBreach{
 			BreachType: result.BreachTypeKeyValue,
 			Key:        "service1",
 			ValueLabel: "invalid base image",
@@ -88,7 +88,7 @@ func TestInvalidDockerfileImageVersion(t *testing.T) {
 	c.RunCheck()
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(
-		[]result.Breach{result.KeyValueBreach{
+		[]result.Breach{&result.KeyValueBreach{
 			BreachType: result.BreachTypeKeyValue,
 			Key:        "service1",
 			ValueLabel: "invalid base image",
@@ -159,7 +159,7 @@ func TestInvalidImageCheck(t *testing.T) {
 	c.RunCheck()
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(
-		[]result.Breach{result.KeyValueBreach{
+		[]result.Breach{&result.KeyValueBreach{
 			BreachType: result.BreachTypeKeyValue,
 			Key:        "service4",
 			ValueLabel: "invalid base image",
@@ -183,13 +183,13 @@ func TestInvalidImageVersions(t *testing.T) {
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.ElementsMatch(
 		[]result.Breach{
-			result.KeyValueBreach{
+			&result.KeyValueBreach{
 				BreachType: result.BreachTypeKeyValue,
 				Key:        "service2",
 				ValueLabel: "invalid base image",
 				Value:      "bitnami/postgresql@16",
 			},
-			result.KeyValueBreach{
+			&result.KeyValueBreach{
 				BreachType: result.BreachTypeKeyValue,
 				Key:        "service4",
 				ValueLabel: "invalid base image",

--- a/pkg/checks/docker/baseimagecheck_test.go
+++ b/pkg/checks/docker/baseimagecheck_test.go
@@ -53,6 +53,7 @@ func TestInvalidDockerfileCheck(t *testing.T) {
 		Paths:   []string{"./fixtures/compose-dockerfile"},
 	}
 	c.RunCheck()
+	c.Result.DetermineResultStatus(false)
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(
 		[]result.Breach{&result.KeyValueBreach{
@@ -86,6 +87,7 @@ func TestInvalidDockerfileImageVersion(t *testing.T) {
 		Paths:   []string{"./fixtures/compose-dockerfile"},
 	}
 	c.RunCheck()
+	c.Result.DetermineResultStatus(false)
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(
 		[]result.Breach{&result.KeyValueBreach{
@@ -157,6 +159,7 @@ func TestInvalidImageCheck(t *testing.T) {
 		Paths: []string{"./fixtures/compose-image"},
 	}
 	c.RunCheck()
+	c.Result.DetermineResultStatus(false)
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(
 		[]result.Breach{&result.KeyValueBreach{
@@ -180,6 +183,7 @@ func TestInvalidImageVersions(t *testing.T) {
 		Paths: []string{"./fixtures/compose-image"},
 	}
 	c.RunCheck()
+	c.Result.DetermineResultStatus(false)
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.ElementsMatch(
 		[]result.Breach{

--- a/pkg/checks/drupal/dbadmincheck.go
+++ b/pkg/checks/drupal/dbadmincheck.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/salsadigitalauorg/shipshape/pkg/command"
 	"github.com/salsadigitalauorg/shipshape/pkg/config"
 	"github.com/salsadigitalauorg/shipshape/pkg/result"
 	"github.com/salsadigitalauorg/shipshape/pkg/utils"
@@ -146,15 +147,14 @@ func (c *AdminUserCheck) Remediate() {
 		if !ok {
 			continue
 		}
+
 		_, err := Drush(c.DrushPath, c.Alias, []string{"config:set", "user.role." + b.Value, "is_admin", "0"}).Exec()
 		if err != nil {
-			c.AddBreach(&result.KeyValueBreach{
-				Key:        "failed to set is_admin to false",
-				ValueLabel: "role",
-				Value:      b.Value,
-			})
+			b.SetRemediation(result.RemediationStatusFailed, fmt.Sprintf(
+				"failed to set is_admin to false for role '%s' due to error: %s",
+				b.Value, command.GetMsgFromCommandError(err)))
 		} else {
-			c.AddRemediation(fmt.Sprintf(
+			b.SetRemediation(result.RemediationStatusSuccess, fmt.Sprintf(
 				"Fixed disallowed admin setting for role [%s]", b.Value))
 		}
 	}

--- a/pkg/checks/drupal/dbadmincheck_test.go
+++ b/pkg/checks/drupal/dbadmincheck_test.go
@@ -52,7 +52,7 @@ func TestAdminUserFetchData(t *testing.T) {
 		c.FetchData()
 		assert.Equal(result.Fail, c.Result.Status)
 		assert.EqualValues(
-			[]result.Breach{result.ValueBreach{
+			[]result.Breach{&result.ValueBreach{
 				BreachType: "value",
 				Value:      "vendor/drush/drush/drush: no such file or directory",
 			}},
@@ -72,7 +72,7 @@ func TestAdminUserFetchData(t *testing.T) {
 		c.FetchData()
 		assert.Equal(result.Fail, c.Result.Status)
 		assert.EqualValues(
-			[]result.Breach{result.ValueBreach{
+			[]result.Breach{&result.ValueBreach{
 				BreachType: "value",
 				Value:      "unable to run drush command",
 			}},
@@ -105,7 +105,7 @@ func TestAdminUserUnmarshalData(t *testing.T) {
 		c.UnmarshalDataMap()
 		assert.Equal(result.Fail, c.Result.Status)
 		assert.EqualValues(
-			[]result.Breach{result.ValueBreach{
+			[]result.Breach{&result.ValueBreach{
 				BreachType: "value",
 				Value:      "no data provided",
 			}},
@@ -124,7 +124,7 @@ func TestAdminUserUnmarshalData(t *testing.T) {
 		c.UnmarshalDataMap()
 		assert.Equal(result.Fail, c.Result.Status)
 		assert.EqualValues(
-			[]result.Breach{result.ValueBreach{
+			[]result.Breach{&result.ValueBreach{
 				BreachType: "value",
 				Value:      "invalid character ']' after object key:value pair",
 			}},
@@ -174,7 +174,7 @@ func TestAdminUserRunCheck(t *testing.T) {
 				AllowedRoles: []string{"content-admin"},
 			},
 			ExpectStatus: result.Fail,
-			ExpectFails: []result.Breach{result.KeyValueBreach{
+			ExpectFails: []result.Breach{&result.KeyValueBreach{
 				BreachType: "key-value",
 				Key:        "is_admin: true",
 				ValueLabel: "role",

--- a/pkg/checks/drupal/dbmodulecheck_test.go
+++ b/pkg/checks/drupal/dbmodulecheck_test.go
@@ -81,6 +81,7 @@ node:
 		c.Init(DbModule)
 		c.UnmarshalDataMap()
 		c.RunCheck()
+		c.Result.DetermineResultStatus(false)
 		return c
 	}
 

--- a/pkg/checks/drupal/dbmodulecheck_test.go
+++ b/pkg/checks/drupal/dbmodulecheck_test.go
@@ -109,14 +109,14 @@ views_ui:
 	})
 	assert.ElementsMatch(
 		[]result.Breach{
-			result.KeyValuesBreach{
+			&result.KeyValuesBreach{
 				BreachType: "key-values",
 				CheckType:  "drupal-db-module",
 				Severity:   "normal",
 				Key:        "required modules are not enabled",
 				Values:     []string{"block"},
 			},
-			result.KeyValuesBreach{
+			&result.KeyValuesBreach{
 				BreachType: "key-values",
 				CheckType:  "drupal-db-module",
 				Severity:   "normal",

--- a/pkg/checks/drupal/dbpermissionscheck.go
+++ b/pkg/checks/drupal/dbpermissionscheck.go
@@ -90,14 +90,11 @@ func (c *DbPermissionsCheck) Remediate() {
 			c.DrushPath, c.Alias,
 			[]string{"role:perm:remove", b.Key, strings.Join(b.Values, ",")}).Exec()
 		if err != nil {
-			c.AddBreach(&result.KeyValueBreach{
-				KeyLabel:   "role",
-				Key:        b.Key,
-				ValueLabel: "failed to fix disallowed permissions due to error",
-				Value:      command.GetMsgFromCommandError(err),
-			})
+			b.SetRemediation(result.RemediationStatusFailed, fmt.Sprintf(
+				"failed to fix disallowed permissions for role '%s' due to error: %s",
+				b.Key, command.GetMsgFromCommandError(err)))
 		} else {
-			c.AddRemediation(fmt.Sprintf(
+			b.SetRemediation(result.RemediationStatusSuccess, fmt.Sprintf(
 				"[%s] fixed disallowed permissions: [%s]",
 				b.Key, strings.Join(b.Values, ", ")))
 		}

--- a/pkg/checks/drupal/dbpermissionscheck.go
+++ b/pkg/checks/drupal/dbpermissionscheck.go
@@ -41,7 +41,7 @@ func (c *DbPermissionsCheck) Merge(mergeCheck config.Check) error {
 // type for further processing.
 func (c *DbPermissionsCheck) UnmarshalDataMap() {
 	if len(c.DataMap[c.ConfigName]) == 0 {
-		c.AddBreach(result.ValueBreach{Value: "no data provided"})
+		c.AddBreach(&result.ValueBreach{Value: "no data provided"})
 	}
 
 	c.Permissions = map[string]DrushRole{}
@@ -51,7 +51,7 @@ func (c *DbPermissionsCheck) UnmarshalDataMap() {
 // RunCheck implements the Check logic for Drupal Permissions in database config.
 func (c *DbPermissionsCheck) RunCheck() {
 	if len(c.Disallowed) == 0 {
-		c.AddBreach(result.ValueBreach{Value: "list of disallowed perms not provided"})
+		c.AddBreach(&result.ValueBreach{Value: "list of disallowed perms not provided"})
 	}
 
 	for r, perms := range c.Permissions {
@@ -70,7 +70,7 @@ func (c *DbPermissionsCheck) RunCheck() {
 			return fails[i] < fails[j]
 		})
 
-		c.AddBreach(result.KeyValuesBreach{
+		c.AddBreach(&result.KeyValuesBreach{
 			KeyLabel:   "role",
 			Key:        r,
 			ValueLabel: "permissions",
@@ -82,7 +82,7 @@ func (c *DbPermissionsCheck) RunCheck() {
 // Remediate attempts to remove any disallowed permissions detected.
 func (c *DbPermissionsCheck) Remediate() {
 	for _, b := range c.Result.Breaches {
-		b, ok := b.(result.KeyValuesBreach)
+		b, ok := b.(*result.KeyValuesBreach)
 		if !ok {
 			continue
 		}
@@ -90,7 +90,7 @@ func (c *DbPermissionsCheck) Remediate() {
 			c.DrushPath, c.Alias,
 			[]string{"role:perm:remove", b.Key, strings.Join(b.Values, ",")}).Exec()
 		if err != nil {
-			c.AddBreach(result.KeyValueBreach{
+			c.AddBreach(&result.KeyValueBreach{
 				KeyLabel:   "role",
 				Key:        b.Key,
 				ValueLabel: "failed to fix disallowed permissions due to error",

--- a/pkg/checks/drupal/dbpermissionscheck_test.go
+++ b/pkg/checks/drupal/dbpermissionscheck_test.go
@@ -70,7 +70,7 @@ func TestDbPermissionsUnmarshalDataMap(t *testing.T) {
 		assert.Equal(result.Fail, c.Result.Status)
 		assert.Empty(c.Result.Passes)
 		assert.EqualValues(
-			[]result.Breach{result.ValueBreach{
+			[]result.Breach{&result.ValueBreach{
 				BreachType: "value",
 				Value:      "no data provided",
 			}},
@@ -132,7 +132,7 @@ func TestDbPermissionsRunCheck(t *testing.T) {
 			Init:         true,
 			ExpectStatus: result.Fail,
 			ExpectNoPass: true,
-			ExpectFails: []result.Breach{result.ValueBreach{
+			ExpectFails: []result.Breach{&result.ValueBreach{
 				BreachType: "value",
 				Severity:   "normal",
 				Value:      "list of disallowed perms not provided",
@@ -208,7 +208,7 @@ func TestDbPermissionsRunCheck(t *testing.T) {
 				"[authenticated] no disallowed permissions",
 			},
 			ExpectFails: []result.Breach{
-				result.KeyValuesBreach{
+				&result.KeyValuesBreach{
 					BreachType: "key-values",
 					Severity:   "normal",
 					KeyLabel:   "role",
@@ -216,7 +216,7 @@ func TestDbPermissionsRunCheck(t *testing.T) {
 					ValueLabel: "permissions",
 					Values:     []string{"administer modules", "administer permissions"},
 				},
-				result.KeyValuesBreach{
+				&result.KeyValuesBreach{
 					BreachType: "key-values",
 					Severity:   "normal",
 					KeyLabel:   "role",
@@ -327,7 +327,7 @@ func TestDbPermissionsRunCheck(t *testing.T) {
 				"[authenticated] no disallowed permissions",
 			},
 			ExpectFails: []result.Breach{
-				result.KeyValueBreach{
+				&result.KeyValueBreach{
 					BreachType: "key-value",
 					Severity:   "normal",
 					KeyLabel:   "role",
@@ -335,7 +335,7 @@ func TestDbPermissionsRunCheck(t *testing.T) {
 					ValueLabel: "failed to fix disallowed permissions due to error",
 					Value:      "unable to run drush command",
 				},
-				result.KeyValueBreach{
+				&result.KeyValueBreach{
 					BreachType: "key-value",
 					Severity:   "normal",
 					KeyLabel:   "role",
@@ -371,14 +371,14 @@ func TestDbPermissionsRemediate(t *testing.T) {
 			nil)
 
 		c := DbPermissionsCheck{}
-		c.AddBreach(result.KeyValuesBreach{
+		c.AddBreach(&result.KeyValuesBreach{
 			KeyLabel:   "role",
 			Key:        "foo",
 			ValueLabel: "permissions",
 			Values:     []string{"bar", "baz"},
 		})
 		c.Remediate()
-		assert.EqualValues([]result.Breach{result.ValueBreach{
+		assert.EqualValues([]result.Breach{&result.ValueBreach{
 			BreachType: "value",
 			Value:      "unable to run drush command",
 		}}, c.Result.Breaches)
@@ -389,7 +389,7 @@ func TestDbPermissionsRemediate(t *testing.T) {
 		command.ShellCommander = internal.ShellCommanderMaker(nil, nil, &generatedCommand)
 
 		c := DbPermissionsCheck{}
-		c.AddBreach(result.KeyValuesBreach{
+		c.AddBreach(&result.KeyValuesBreach{
 			KeyLabel:   "role",
 			Key:        "foo",
 			ValueLabel: "permissions",

--- a/pkg/checks/drupal/dbpermissionscheck_test.go
+++ b/pkg/checks/drupal/dbpermissionscheck_test.go
@@ -371,8 +371,17 @@ func TestDbPermissionsRemediate(t *testing.T) {
 			nil)
 
 		c := DbPermissionsCheck{}
-		err := c.Remediate(DbPermissionsBreach{Role: "foo", Perms: "bar,baz"})
-		assert.Error(err, "unable to run drush command")
+		c.AddBreach(result.KeyValuesBreach{
+			KeyLabel:   "role",
+			Key:        "foo",
+			ValueLabel: "permissions",
+			Values:     []string{"bar", "baz"},
+		})
+		c.Remediate()
+		assert.EqualValues([]result.Breach{result.ValueBreach{
+			BreachType: "value",
+			Value:      "unable to run drush command",
+		}}, c.Result.Breaches)
 	})
 
 	t.Run("drushCommandIsCorrect", func(t *testing.T) {
@@ -380,7 +389,13 @@ func TestDbPermissionsRemediate(t *testing.T) {
 		command.ShellCommander = internal.ShellCommanderMaker(nil, nil, &generatedCommand)
 
 		c := DbPermissionsCheck{}
-		c.Remediate(DbPermissionsBreach{Role: "foo", Perms: "bar,baz"})
+		c.AddBreach(result.KeyValuesBreach{
+			KeyLabel:   "role",
+			Key:        "foo",
+			ValueLabel: "permissions",
+			Values:     []string{"bar", "baz"},
+		})
+		c.Remediate()
 		assert.Equal("vendor/drush/drush/drush role:perm:remove foo bar,baz", generatedCommand)
 	})
 }

--- a/pkg/checks/drupal/dbtfausercheck.go
+++ b/pkg/checks/drupal/dbtfausercheck.go
@@ -48,7 +48,7 @@ func (c *DbUserTfaCheck) FetchData() {
 	res, err := Drush(c.DrushPath, c.Alias, cmd).Exec()
 	if err != nil {
 		c.Result.Status = result.Fail
-		c.AddBreach(result.ValueBreach{
+		c.AddBreach(&result.ValueBreach{
 			ValueLabel: "error fetching drush user info",
 			Value:      command.GetMsgFromCommandError(err),
 		})
@@ -73,7 +73,7 @@ func (c *DbUserTfaCheck) RunCheck() {
 		for _, user := range users {
 			tfaDisabled = append(tfaDisabled, fmt.Sprintf("%s:%s", user.Name, user.UID))
 		}
-		c.AddBreach(result.ValueBreach{
+		c.AddBreach(&result.ValueBreach{
 			ValueLabel: "users with TFA disabled",
 			Value:      strings.Join(tfaDisabled, ", "),
 		})

--- a/pkg/checks/drupal/dbtfausercheck_test.go
+++ b/pkg/checks/drupal/dbtfausercheck_test.go
@@ -29,7 +29,7 @@ func TestDbTfaUserCheck(t *testing.T) {
 		assert.Equal(result.Fail, c.Result.Status)
 		assert.Empty(c.Result.Passes)
 		assert.EqualValues(
-			[]result.Breach{result.ValueBreach{
+			[]result.Breach{&result.ValueBreach{
 				BreachType: "value",
 				CheckType:  "drupal-db-user-tfa",
 				Severity:   "normal",
@@ -62,7 +62,7 @@ func TestDbTfaUserCheck(t *testing.T) {
 		assert.Equal(result.Fail, c.Result.Status)
 		assert.Empty(c.Result.Passes)
 		assert.EqualValues(
-			[]result.Breach{result.ValueBreach{
+			[]result.Breach{&result.ValueBreach{
 				BreachType: "value",
 				CheckType:  "drupal-db-user-tfa",
 				Severity:   "normal",
@@ -99,7 +99,7 @@ func TestDbTfaUserCheck(t *testing.T) {
 		assert.Equal(result.Fail, c.Result.Status)
 		assert.Empty(c.Result.Passes)
 		assert.EqualValues(
-			[]result.Breach{result.ValueBreach{
+			[]result.Breach{&result.ValueBreach{
 				BreachType: "value",
 				CheckType:  "drupal-db-user-tfa",
 				Severity:   "normal",

--- a/pkg/checks/drupal/drupal.go
+++ b/pkg/checks/drupal/drupal.go
@@ -73,12 +73,12 @@ func CheckModulesInYaml(c *yaml.YamlBase, ct config.CheckType, configName string
 		required_errored,
 		required_disabled := DetermineModuleStatus(c.NodeMap[configName], ct, required)
 	if len(required_errored) > 0 {
-		c.AddBreach(result.KeyValuesBreach{
+		c.AddBreach(&result.KeyValuesBreach{
 			Key:    "error verifying status for required modules",
 			Values: required_errored})
 	}
 	if len(required_disabled) > 0 {
-		c.AddBreach(result.KeyValuesBreach{
+		c.AddBreach(&result.KeyValuesBreach{
 			Key:    "required modules are not enabled",
 			Values: required_disabled})
 	}
@@ -94,12 +94,12 @@ func CheckModulesInYaml(c *yaml.YamlBase, ct config.CheckType, configName string
 		disallowed_errored,
 		disallowed_disabled := DetermineModuleStatus(c.NodeMap[configName], ct, disallowed)
 	if len(disallowed_errored) > 0 {
-		c.AddBreach(result.KeyValuesBreach{
+		c.AddBreach(&result.KeyValuesBreach{
 			Key:    "error verifying status for disallowed modules",
 			Values: disallowed_errored})
 	}
 	if len(disallowed_enabled) > 0 {
-		c.AddBreach(result.KeyValuesBreach{
+		c.AddBreach(&result.KeyValuesBreach{
 			Key:    "disallowed modules are enabled",
 			Values: disallowed_enabled})
 	}

--- a/pkg/checks/drupal/drupal_test.go
+++ b/pkg/checks/drupal/drupal_test.go
@@ -265,7 +265,6 @@ func TestCheckModulesInYaml(t *testing.T) {
 	}
 	c.UnmarshalDataMap()
 	CheckModulesInYaml(&c, FileModule, "shipshape.extension.yml", required, disallowed)
-	assert.Equal(result.Fail, c.Result.Status)
 	assert.ElementsMatch(c.Result.Passes, []string{
 		"some required modules are enabled: block",
 		"some disallowed modules are disabled: views_ui",
@@ -304,7 +303,6 @@ module:
 	}
 	c.UnmarshalDataMap()
 	CheckModulesInYaml(&c, FileModule, "shipshape.extension.yml", required, disallowed)
-	assert.Equal(result.Fail, c.Result.Status)
 	assert.ElementsMatch(c.Result.Passes, []string{
 		"some required modules are enabled: block",
 		"some disallowed modules are disabled: field_ui",

--- a/pkg/checks/drupal/drupal_test.go
+++ b/pkg/checks/drupal/drupal_test.go
@@ -241,7 +241,7 @@ module:
 		"all disallowed modules are disabled",
 	})
 	assert.EqualValues(
-		[]result.Breach{result.KeyValuesBreach{
+		[]result.Breach{&result.KeyValuesBreach{
 			BreachType: "key-values",
 			Key:        "disallowed modules are enabled",
 			Values:     []string{"dblog"},
@@ -272,12 +272,12 @@ func TestCheckModulesInYaml(t *testing.T) {
 	})
 	assert.ElementsMatch(
 		[]result.Breach{
-			result.KeyValuesBreach{
+			&result.KeyValuesBreach{
 				BreachType: "key-values",
 				Key:        "error verifying status for required modules",
 				Values:     []string{"invalid character '&' at position 11, following \".node\""},
 			},
-			result.KeyValuesBreach{
+			&result.KeyValuesBreach{
 				BreachType: "key-values",
 				Key:        "error verifying status for disallowed modules",
 				Values:     []string{"invalid character '&' at position 15, following \".field_ui\""},
@@ -311,12 +311,12 @@ module:
 	})
 	assert.ElementsMatch(
 		[]result.Breach{
-			result.KeyValuesBreach{
+			&result.KeyValuesBreach{
 				BreachType: "key-values",
 				Key:        "required modules are not enabled",
 				Values:     []string{"node"},
 			},
-			result.KeyValuesBreach{
+			&result.KeyValuesBreach{
 				BreachType: "key-values",
 				Key:        "disallowed modules are enabled",
 				Values:     []string{"views_ui"},

--- a/pkg/checks/drupal/drush_test.go
+++ b/pkg/checks/drupal/drush_test.go
@@ -61,5 +61,5 @@ func TestDrushQuery(t *testing.T) {
 
 	_, err := drupal.Drush("", "", []string{}).Query("SELECT uid FROM users")
 	assert.NoError(t, err)
-	assert.Equal(t, "vendor/drush/drush/drush sql:query SELECT uid FROM users", generatedCommand)
+	assert.Equal(t, "vendor/drush/drush/drush sql:query 'SELECT uid FROM users'", generatedCommand)
 }

--- a/pkg/checks/drupal/drushyamlcheck.go
+++ b/pkg/checks/drupal/drushyamlcheck.go
@@ -39,11 +39,11 @@ func (c *DrushYamlCheck) FetchData() {
 	c.DataMap[c.ConfigName], err = Drush(c.DrushPath, c.Alias, c.DrushCommand.Args).Exec()
 	if err != nil {
 		if pathErr, ok := err.(*fs.PathError); ok {
-			c.AddBreach(result.ValueBreach{
+			c.AddBreach(&result.ValueBreach{
 				Value: pathErr.Path + ": " + pathErr.Err.Error()})
 		} else {
 			msg := string(err.(*exec.ExitError).Stderr)
-			c.AddBreach(result.ValueBreach{
+			c.AddBreach(&result.ValueBreach{
 				ValueLabel: c.ConfigName,
 				Value:      strings.ReplaceAll(strings.TrimSpace(msg), "  \n  ", "")})
 		}
@@ -55,7 +55,7 @@ func (c *DrushYamlCheck) FetchData() {
 func (c *DrushYamlCheck) Remediate() {
 	_, err := Drush(c.DrushPath, c.Alias, strings.Fields(c.RemediationCommand)).Exec()
 	if err != nil {
-		c.AddBreach(result.ValueBreach{
+		c.AddBreach(&result.ValueBreach{
 			ValueLabel: c.ConfigName,
 			Value:      err.Error()})
 	}

--- a/pkg/checks/drupal/drushyamlcheck.go
+++ b/pkg/checks/drupal/drushyamlcheck.go
@@ -49,3 +49,14 @@ func (c *DrushYamlCheck) FetchData() {
 		}
 	}
 }
+
+// Remediate attempts to remediate a breach by running the drush command
+// specified in the check.
+func (c *DrushYamlCheck) Remediate() {
+	_, err := Drush(c.DrushPath, c.Alias, strings.Fields(c.RemediationCommand)).Exec()
+	if err != nil {
+		c.AddBreach(result.ValueBreach{
+			ValueLabel: c.ConfigName,
+			Value:      err.Error()})
+	}
+}

--- a/pkg/checks/drupal/drushyamlcheck_test.go
+++ b/pkg/checks/drupal/drushyamlcheck_test.go
@@ -76,7 +76,7 @@ func TestDrushYamlCheckFetchData(t *testing.T) {
 				Command:    "status",
 				ConfigName: "core.extension",
 			},
-			ExpectBreaches: []result.Breach{result.ValueBreach{
+			ExpectBreaches: []result.Breach{&result.ValueBreach{
 				BreachType: "value",
 				CheckType:  "drush-yaml",
 				Severity:   "normal",
@@ -98,7 +98,7 @@ func TestDrushYamlCheckFetchData(t *testing.T) {
 					nil,
 				)
 			},
-			ExpectBreaches: []result.Breach{result.ValueBreach{
+			ExpectBreaches: []result.Breach{&result.ValueBreach{
 				BreachType: "value",
 				CheckType:  "drush-yaml",
 				Severity:   "normal",
@@ -177,7 +177,7 @@ func TestDrushYamlCheckRunCheck(t *testing.T) {
 			PreRun: func(t *testing.T) {
 				command.ShellCommander = internal.ShellCommanderMaker(nil, nil, nil)
 			},
-			ExpectFails: []result.Breach{result.KeyValueBreach{
+			ExpectFails: []result.Breach{&result.KeyValueBreach{
 				BreachType:    "key-value",
 				KeyLabel:      "core.extension",
 				Key:           "profile",
@@ -205,7 +205,7 @@ func TestDrushYamlCheckRunCheck(t *testing.T) {
 			PreRun: func(t *testing.T) {
 				command.ShellCommander = internal.ShellCommanderMaker(nil, nil, nil)
 			},
-			ExpectFails: []result.Breach{result.KeyValueBreach{
+			ExpectFails: []result.Breach{&result.KeyValueBreach{
 				BreachType:    "key-value",
 				KeyLabel:      "core.extension",
 				Key:           "profile",

--- a/pkg/checks/drupal/forbiddenusercheck.go
+++ b/pkg/checks/drupal/forbiddenusercheck.go
@@ -77,14 +77,12 @@ func (c *ForbiddenUserCheck) Remediate() {
 
 		_, err := Drush(c.DrushPath, c.Alias, []string{"user:block", "--uid=" + c.UserId}).Exec()
 		if err != nil {
-			c.AddBreach(&result.KeyValueBreach{
-				KeyLabel:   "user",
-				Key:        c.UserId,
-				ValueLabel: "error blocking forbidden user",
-				Value:      command.GetMsgFromCommandError(err),
-			})
+			b.SetRemediation(result.RemediationStatusFailed, fmt.Sprintf(
+				"error blocking forbidden user '%s' due to error: %s",
+				c.UserId, command.GetMsgFromCommandError(err)))
 		} else {
-			c.AddRemediation(fmt.Sprintf("Blocked the forbidden user [%s]", c.UserId))
+			b.SetRemediation(result.RemediationStatusSuccess, fmt.Sprintf(
+				"Blocked the forbidden user [%s]", c.UserId))
 		}
 	}
 

--- a/pkg/checks/drupal/forbiddenusercheck_test.go
+++ b/pkg/checks/drupal/forbiddenusercheck_test.go
@@ -176,10 +176,11 @@ func TestForbiddenUserCheck_Remediate(t *testing.T) {
 			&exec.ExitError{Stderr: []byte("Unable to find a matching user")},
 			nil,
 		)
-		err := c.Remediate(nil)
-		assertions.NotNil(err)
-		msg := string(err.(*exec.ExitError).Stderr)
-		assertions.Equal("Unable to find a matching user", msg)
+		c.Remediate()
+		assertions.EqualValues([]result.Breach{result.ValueBreach{
+			BreachType: "value",
+			Value:      "Unable to find a matching user",
+		}}, c.Result.Breaches)
 	})
 
 	t.Run("passOnBlockingInactiveUser", func(t *testing.T) {

--- a/pkg/checks/drupal/forbiddenusercheck_test.go
+++ b/pkg/checks/drupal/forbiddenusercheck_test.go
@@ -48,7 +48,7 @@ func TestForbiddenUserCheck_RunCheck(t *testing.T) {
 		c.RunCheck()
 		assertions.Equal(result.Fail, c.Result.Status)
 		assertions.EqualValues(
-			[]result.Breach{result.ValueBreach{
+			[]result.Breach{&result.ValueBreach{
 				BreachType: "value",
 				Value:      "vendor/drush/drush/drush: no such file or directory",
 			}},
@@ -69,7 +69,7 @@ func TestForbiddenUserCheck_RunCheck(t *testing.T) {
 		c.RunCheck()
 		assertions.Empty(c.Result.Passes)
 		assertions.ElementsMatch(
-			[]result.Breach{result.ValueBreach{
+			[]result.Breach{&result.ValueBreach{
 				BreachType: "value",
 				CheckType:  "drupal-user-forbidden",
 				Severity:   "normal",
@@ -94,7 +94,7 @@ func TestForbiddenUserCheck_RunCheck(t *testing.T) {
 		assertions.Equal(result.Fail, c.Result.Status)
 		assertions.Empty(c.Result.Passes)
 		assertions.ElementsMatch(
-			[]result.Breach{result.ValueBreach{
+			[]result.Breach{&result.ValueBreach{
 				BreachType: "value",
 				CheckType:  "drupal-user-forbidden",
 				Severity:   "normal",
@@ -124,7 +124,7 @@ func TestForbiddenUserCheck_RunCheck(t *testing.T) {
 		assertions.Equal(result.Fail, c.Result.Status)
 		assertions.Empty(c.Result.Passes)
 		assertions.ElementsMatch(
-			[]result.Breach{result.KeyValueBreach{
+			[]result.Breach{&result.KeyValueBreach{
 				BreachType: "key-value",
 				CheckType:  "drupal-user-forbidden",
 				Severity:   "normal",
@@ -177,7 +177,7 @@ func TestForbiddenUserCheck_Remediate(t *testing.T) {
 			nil,
 		)
 		c.Remediate()
-		assertions.EqualValues([]result.Breach{result.ValueBreach{
+		assertions.EqualValues([]result.Breach{&result.ValueBreach{
 			BreachType: "value",
 			Value:      "Unable to find a matching user",
 		}}, c.Result.Breaches)

--- a/pkg/checks/drupal/rolepermissionscheck.go
+++ b/pkg/checks/drupal/rolepermissionscheck.go
@@ -41,11 +41,11 @@ func (c *RolePermissionsCheck) GetRolePermissions() []string {
 
 	var pathError *fs.PathError
 	if err != nil && errors.As(err, &pathError) {
-		c.AddBreach(result.ValueBreach{
+		c.AddBreach(&result.ValueBreach{
 			Value: pathError.Path + ": " + pathError.Err.Error()})
 	} else if err != nil {
 		msg := string(err.(*exec.ExitError).Stderr)
-		c.AddBreach(result.ValueBreach{
+		c.AddBreach(&result.ValueBreach{
 			Value: strings.ReplaceAll(strings.TrimSpace(msg), "  \n  ", "")})
 	} else {
 		// Unmarshal role:list JSON.
@@ -63,7 +63,7 @@ func (c *RolePermissionsCheck) GetRolePermissions() []string {
 		err = json.Unmarshal(drushOutput, &rolePermissionsMap)
 		var syntaxError *json.SyntaxError
 		if err != nil && errors.As(err, &syntaxError) {
-			c.AddBreach(result.ValueBreach{Value: err.Error()})
+			c.AddBreach(&result.ValueBreach{Value: err.Error()})
 		}
 
 		if len(rolePermissionsMap[c.RoleId]["perms"]) > 0 {
@@ -87,7 +87,7 @@ func (c *RolePermissionsCheck) Merge(mergeCheck config.Check) error {
 // RunCheck implements the Check logic for role permissions.
 func (c *RolePermissionsCheck) RunCheck() {
 	if c.RoleId == "" {
-		c.AddBreach(result.ValueBreach{Value: "no role ID provided"})
+		c.AddBreach(&result.ValueBreach{Value: "no role ID provided"})
 		return
 	}
 
@@ -95,7 +95,7 @@ func (c *RolePermissionsCheck) RunCheck() {
 	// Check for required permissions.
 	diff := utils.StringSlicesInterdiffUnique(rolePermissions, c.RequiredPermissions)
 	if len(diff) > 0 {
-		c.AddBreach(result.KeyValueBreach{
+		c.AddBreach(&result.KeyValueBreach{
 			KeyLabel:   "role",
 			Key:        c.RoleId,
 			ValueLabel: "missing permissions",
@@ -106,7 +106,7 @@ func (c *RolePermissionsCheck) RunCheck() {
 	// Check for disallowed permissions.
 	diff = utils.StringSlicesIntersectUnique(rolePermissions, c.DisallowedPermissions)
 	if len(diff) > 0 {
-		c.AddBreach(result.KeyValueBreach{
+		c.AddBreach(&result.KeyValueBreach{
 			KeyLabel:   "role",
 			Key:        c.RoleId,
 			ValueLabel: "disallowed permissions",

--- a/pkg/checks/drupal/rolepermissionscheck_test.go
+++ b/pkg/checks/drupal/rolepermissionscheck_test.go
@@ -44,7 +44,7 @@ func TestRolePermissionsCheck_RunCheck(t *testing.T) {
 		c.RunCheck()
 		assertions.Equal(result.Fail, c.Result.Status)
 		assertions.ElementsMatch(
-			[]result.Breach{result.ValueBreach{
+			[]result.Breach{&result.ValueBreach{
 				BreachType: result.BreachTypeValue,
 				Value:      "no role ID provided"}},
 			c.Result.Breaches,
@@ -58,7 +58,7 @@ func TestRolePermissionsCheck_RunCheck(t *testing.T) {
 		c.RunCheck()
 		assertions.Equal(result.Fail, c.Result.Status)
 		assertions.ElementsMatch(
-			[]result.Breach{result.ValueBreach{
+			[]result.Breach{&result.ValueBreach{
 				BreachType: result.BreachTypeValue,
 				Value:      "vendor/drush/drush/drush: no such file or directory"}},
 			c.Result.Breaches)
@@ -79,7 +79,7 @@ func TestRolePermissionsCheck_RunCheck(t *testing.T) {
 		c.RunCheck()
 		assertions.Empty(c.Result.Passes)
 		assertions.ElementsMatch(
-			[]result.Breach{result.ValueBreach{
+			[]result.Breach{&result.ValueBreach{
 				BreachType: result.BreachTypeValue,
 				CheckType:  "drupal-role-permissions",
 				Severity:   "normal",
@@ -104,7 +104,7 @@ func TestRolePermissionsCheck_RunCheck(t *testing.T) {
 		assertions.Equal(result.Fail, c.Result.Status)
 		assertions.Empty(c.Result.Passes)
 		assertions.ElementsMatch(
-			[]result.Breach{result.ValueBreach{
+			[]result.Breach{&result.ValueBreach{
 				BreachType: result.BreachTypeValue,
 				CheckType:  "drupal-role-permissions",
 				Severity:   "normal",
@@ -146,7 +146,7 @@ func TestRolePermissionsCheck_RunCheck(t *testing.T) {
 		assertions.Empty(c.Result.Passes)
 		assertions.ElementsMatch(
 			[]result.Breach{
-				result.KeyValueBreach{
+				&result.KeyValueBreach{
 					BreachType: result.BreachTypeKeyValue,
 					CheckType:  "drupal-role-permissions",
 					Severity:   "normal",
@@ -155,7 +155,7 @@ func TestRolePermissionsCheck_RunCheck(t *testing.T) {
 					ValueLabel: "missing permissions",
 					Value:      "[setup own tfa]",
 				},
-				result.KeyValueBreach{
+				&result.KeyValueBreach{
 					BreachType: result.BreachTypeKeyValue,
 					CheckType:  "drupal-role-permissions",
 					Severity:   "normal",

--- a/pkg/checks/drupal/rolepermissionscheck_test.go
+++ b/pkg/checks/drupal/rolepermissionscheck_test.go
@@ -42,6 +42,7 @@ func TestRolePermissionsCheck_RunCheck(t *testing.T) {
 	t.Run("failOnNoRoleProvided", func(t *testing.T) {
 		c := drupal.RolePermissionsCheck{}
 		c.RunCheck()
+		c.Result.DetermineResultStatus(false)
 		assertions.Equal(result.Fail, c.Result.Status)
 		assertions.ElementsMatch(
 			[]result.Breach{&result.ValueBreach{
@@ -56,6 +57,7 @@ func TestRolePermissionsCheck_RunCheck(t *testing.T) {
 			RoleId: "authenticated",
 		}
 		c.RunCheck()
+		c.Result.DetermineResultStatus(false)
 		assertions.Equal(result.Fail, c.Result.Status)
 		assertions.ElementsMatch(
 			[]result.Breach{&result.ValueBreach{
@@ -77,6 +79,7 @@ func TestRolePermissionsCheck_RunCheck(t *testing.T) {
 			nil,
 		)
 		c.RunCheck()
+		c.Result.DetermineResultStatus(false)
 		assertions.Empty(c.Result.Passes)
 		assertions.ElementsMatch(
 			[]result.Breach{&result.ValueBreach{
@@ -101,6 +104,7 @@ func TestRolePermissionsCheck_RunCheck(t *testing.T) {
 			nil,
 		)
 		c.RunCheck()
+		c.Result.DetermineResultStatus(false)
 		assertions.Equal(result.Fail, c.Result.Status)
 		assertions.Empty(c.Result.Passes)
 		assertions.ElementsMatch(
@@ -142,6 +146,7 @@ func TestRolePermissionsCheck_RunCheck(t *testing.T) {
 			nil,
 		)
 		c.RunCheck()
+		c.Result.DetermineResultStatus(false)
 		assertions.Equal(result.Fail, c.Result.Status)
 		assertions.Empty(c.Result.Passes)
 		assertions.ElementsMatch(
@@ -197,6 +202,7 @@ func TestRolePermissionsCheck_RunCheck(t *testing.T) {
 			nil,
 		)
 		c.RunCheck()
+		c.Result.DetermineResultStatus(false)
 		assertions.Equal(result.Pass, c.Result.Status)
 		assertions.Empty(c.Result.Breaches)
 	})

--- a/pkg/checks/drupal/trackingcodecheck.go
+++ b/pkg/checks/drupal/trackingcodecheck.go
@@ -35,14 +35,14 @@ func (c *TrackingCodeCheck) Merge(mergeCheck config.Check) error {
 // type for further processing.
 func (c *TrackingCodeCheck) UnmarshalDataMap() {
 	if len(c.DataMap[c.ConfigName]) == 0 {
-		c.AddBreach(result.ValueBreach{Value: "no data provided"})
+		c.AddBreach(&result.ValueBreach{Value: "no data provided"})
 	}
 
 	c.DrushStatus = DrushStatus{}
 	err := yaml.Unmarshal(c.DataMap[c.ConfigName], &c.DrushStatus)
 	if err != nil {
 		if _, ok := err.(*yaml.TypeError); !ok {
-			c.AddBreach(result.ValueBreach{Value: err.Error()})
+			c.AddBreach(&result.ValueBreach{Value: err.Error()})
 			return
 		}
 	}
@@ -52,7 +52,7 @@ func (c *TrackingCodeCheck) RunCheck() {
 	resp, err := http.Get(c.DrushStatus.Uri)
 
 	if err != nil {
-		c.AddBreach(result.ValueBreach{Value: "could not determine site uri"})
+		c.AddBreach(&result.ValueBreach{Value: "could not determine site uri"})
 		return
 	}
 
@@ -65,7 +65,7 @@ func (c *TrackingCodeCheck) RunCheck() {
 		c.AddPass(fmt.Sprintf("tracking code [%s] present", c.Code))
 		c.Result.Status = result.Pass
 	} else {
-		c.AddBreach(result.KeyValueBreach{
+		c.AddBreach(&result.KeyValueBreach{
 			Key:   "required tracking code not present",
 			Value: c.Code,
 		})

--- a/pkg/checks/drupal/trackingcodecheck_test.go
+++ b/pkg/checks/drupal/trackingcodecheck_test.go
@@ -86,6 +86,7 @@ func TestTrackingCodeCheckFails(t *testing.T) {
 		Uri: "https://google.com",
 	}
 	c.RunCheck()
+	c.Result.DetermineResultStatus(false)
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.ElementsMatch(
 		[]result.Breach{&result.KeyValueBreach{
@@ -111,6 +112,7 @@ func TestTrackingCodeCheckPass(t *testing.T) {
 		Uri: "https://gist.github.com/Pominova/cf7884e7418f6ebfa412d2d3dc472a97",
 	}
 	c.RunCheck()
+	c.Result.DetermineResultStatus(false)
 	assert.Equal(result.Pass, c.Result.Status)
 	assert.ElementsMatch(
 		[]string{"tracking code [UA-xxxxxx-1] present"},

--- a/pkg/checks/drupal/trackingcodecheck_test.go
+++ b/pkg/checks/drupal/trackingcodecheck_test.go
@@ -88,7 +88,7 @@ func TestTrackingCodeCheckFails(t *testing.T) {
 	c.RunCheck()
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.ElementsMatch(
-		[]result.Breach{result.KeyValueBreach{
+		[]result.Breach{&result.KeyValueBreach{
 			BreachType: "key-value",
 			CheckType:  "drupal-tracking-code",
 			Severity:   "normal",

--- a/pkg/checks/drupal/types.go
+++ b/pkg/checks/drupal/types.go
@@ -22,12 +22,12 @@ type DrushCommand struct {
 }
 
 type DrushYamlCheck struct {
-	yaml.YamlBase      `yaml:",inline"`
-	DrushCommand       `yaml:",inline"`
-	Command            string `yaml:"command"`
-	ConfigName         string `yaml:"config-name"`
-	RemediationCommand string `yaml:"remediation-command"`
-	RemediationMsg     string `yaml:"remediation-msg"`
+	yaml.YamlBase    `yaml:",inline"`
+	DrushCommand     `yaml:",inline"`
+	Command          string `yaml:"command"`
+	ConfigName       string `yaml:"config-name"`
+	RemediateCommand string `yaml:"remediate-command"`
+	RemediateMsg     string `yaml:"remediate-msg"`
 }
 
 type FileModuleCheck struct {

--- a/pkg/checks/drupal/types.go
+++ b/pkg/checks/drupal/types.go
@@ -22,10 +22,12 @@ type DrushCommand struct {
 }
 
 type DrushYamlCheck struct {
-	yaml.YamlBase `yaml:",inline"`
-	DrushCommand  `yaml:",inline"`
-	Command       string `yaml:"command"`
-	ConfigName    string `yaml:"config-name"`
+	yaml.YamlBase      `yaml:",inline"`
+	DrushCommand       `yaml:",inline"`
+	Command            string `yaml:"command"`
+	ConfigName         string `yaml:"config-name"`
+	RemediationCommand string `yaml:"remediation-command"`
+	RemediationMsg     string `yaml:"remediation-msg"`
 }
 
 type FileModuleCheck struct {

--- a/pkg/checks/drupal/userrolecheck.go
+++ b/pkg/checks/drupal/userrolecheck.go
@@ -55,11 +55,11 @@ func (c *UserRoleCheck) getUserIds() string {
 
 	var pathErr *fs.PathError
 	if err != nil && errors.As(err, &pathErr) {
-		c.AddBreach(result.ValueBreach{
+		c.AddBreach(&result.ValueBreach{
 			Value: pathErr.Path + ": " + pathErr.Err.Error()})
 	} else if err != nil {
 		msg := string(err.(*exec.ExitError).Stderr)
-		c.AddBreach(result.ValueBreach{
+		c.AddBreach(&result.ValueBreach{
 			Value: strings.ReplaceAll(strings.TrimSpace(msg), "  \n  ", "")})
 	}
 	return string(userIds)
@@ -79,7 +79,7 @@ func (c *UserRoleCheck) FetchData() {
 	c.DataMap["user-info"], err = Drush(c.DrushPath, c.Alias, cmd).Exec()
 	if err != nil {
 		msg := string(err.(*exec.ExitError).Stderr)
-		c.AddBreach(result.ValueBreach{
+		c.AddBreach(&result.ValueBreach{
 			Value: strings.ReplaceAll(strings.TrimSpace(msg), "  \n  ", "")})
 	}
 }
@@ -88,7 +88,7 @@ func (c *UserRoleCheck) FetchData() {
 // into the userRoles for further processing.
 func (c *UserRoleCheck) UnmarshalDataMap() {
 	if len(c.DataMap["user-info"]) == 0 {
-		c.AddBreach(result.ValueBreach{Value: "no data provided"})
+		c.AddBreach(&result.ValueBreach{Value: "no data provided"})
 		return
 	}
 
@@ -96,7 +96,7 @@ func (c *UserRoleCheck) UnmarshalDataMap() {
 	err := json.Unmarshal(c.DataMap["user-info"], &userInfoMap)
 	var synErr *json.SyntaxError
 	if err != nil && errors.As(err, &synErr) {
-		c.AddBreach(result.ValueBreach{Value: err.Error()})
+		c.AddBreach(&result.ValueBreach{Value: err.Error()})
 		return
 	}
 
@@ -109,7 +109,7 @@ func (c *UserRoleCheck) UnmarshalDataMap() {
 // RunCheck implements the Check logic for disallowed user roles.
 func (c *UserRoleCheck) RunCheck() {
 	if len(c.Roles) == 0 {
-		c.AddBreach(result.ValueBreach{Value: "no disallowed role provided"})
+		c.AddBreach(&result.ValueBreach{Value: "no disallowed role provided"})
 		return
 	}
 
@@ -121,7 +121,7 @@ func (c *UserRoleCheck) RunCheck() {
 
 		disallowed := utils.StringSlicesIntersect(roles, c.Roles)
 		if len(disallowed) > 0 {
-			c.AddBreach(result.KeyValuesBreach{
+			c.AddBreach(&result.KeyValuesBreach{
 				KeyLabel:   "user",
 				Key:        fmt.Sprintf("%d", uid),
 				ValueLabel: "disallowed roles",

--- a/pkg/checks/drupal/userrolecheck.go
+++ b/pkg/checks/drupal/userrolecheck.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/salsadigitalauorg/shipshape/pkg/command"
 	"github.com/salsadigitalauorg/shipshape/pkg/config"
 	"github.com/salsadigitalauorg/shipshape/pkg/result"
 	"github.com/salsadigitalauorg/shipshape/pkg/utils"
@@ -70,7 +71,7 @@ func (c *UserRoleCheck) FetchData() {
 	var err error
 
 	userIds := c.getUserIds()
-	if c.Result.Status == result.Fail {
+	if len(c.Result.Breaches) > 0 {
 		return
 	}
 
@@ -78,7 +79,7 @@ func (c *UserRoleCheck) FetchData() {
 	cmd := []string{"user:information", "--uid=" + userIds, "--fields=roles", "--format=json"}
 	c.DataMap["user-info"], err = Drush(c.DrushPath, c.Alias, cmd).Exec()
 	if err != nil {
-		msg := string(err.(*exec.ExitError).Stderr)
+		msg := command.GetMsgFromCommandError(err)
 		c.AddBreach(&result.ValueBreach{
 			Value: strings.ReplaceAll(strings.TrimSpace(msg), "  \n  ", "")})
 	}

--- a/pkg/checks/drupal/userrolecheck_test.go
+++ b/pkg/checks/drupal/userrolecheck_test.go
@@ -55,7 +55,7 @@ func TestFetchData(t *testing.T) {
 		c.FetchData()
 		assert.Equal(result.Fail, c.Result.Status)
 		assert.EqualValues(
-			[]result.Breach{result.ValueBreach{
+			[]result.Breach{&result.ValueBreach{
 				BreachType: "value",
 				Value:      "vendor/drush/drush/drush: no such file or directory",
 			}},
@@ -85,7 +85,7 @@ func TestFetchData(t *testing.T) {
 		c.FetchData()
 		assert.Equal(result.Fail, c.Result.Status)
 		assert.EqualValues(
-			[]result.Breach{result.ValueBreach{
+			[]result.Breach{&result.ValueBreach{
 				BreachType: "value",
 				Value:      "unable to run drush sql query",
 			}},
@@ -97,7 +97,7 @@ func TestFetchData(t *testing.T) {
 		c.FetchData()
 		assert.Equal(result.Fail, c.Result.Status)
 		assert.EqualValues(
-			[]result.Breach{result.ValueBreach{
+			[]result.Breach{&result.ValueBreach{
 				BreachType: "value",
 				Value:      "unable to run drush command",
 			}},
@@ -128,7 +128,7 @@ func TestUnmarshalData(t *testing.T) {
 	c.UnmarshalDataMap()
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(
-		[]result.Breach{result.ValueBreach{
+		[]result.Breach{&result.ValueBreach{
 			BreachType: "value",
 			Value:      "no data provided",
 		}},
@@ -145,7 +145,7 @@ func TestUnmarshalData(t *testing.T) {
 	c.UnmarshalDataMap()
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(
-		[]result.Breach{result.ValueBreach{
+		[]result.Breach{&result.ValueBreach{
 			BreachType: "value",
 			Value:      "invalid character ']' after object key:value pair",
 		}},
@@ -180,7 +180,7 @@ func TestRunCheck(t *testing.T) {
 	c.RunCheck()
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(
-		[]result.Breach{result.ValueBreach{
+		[]result.Breach{&result.ValueBreach{
 			BreachType: "value",
 			Value:      "no disallowed role provided",
 		}},
@@ -199,7 +199,7 @@ func TestRunCheck(t *testing.T) {
 	c.RunCheck()
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(
-		[]result.Breach{result.KeyValuesBreach{
+		[]result.Breach{&result.KeyValuesBreach{
 			BreachType: "key-values",
 			KeyLabel:   "user",
 			Key:        "1",

--- a/pkg/checks/drupal/userrolecheck_test.go
+++ b/pkg/checks/drupal/userrolecheck_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestInit(t *testing.T) {
+func TestUserRoleCheckInit(t *testing.T) {
 	c := UserRoleCheck{}
 	c.Init(UserRole)
 	assert.True(t, c.RequiresDb)
@@ -47,13 +47,12 @@ func TestUserRoleMerge(t *testing.T) {
 	}, c)
 }
 
-func TestFetchData(t *testing.T) {
+func TestUserRoleCheckFetchData(t *testing.T) {
 	assert := assert.New(t)
 
 	t.Run("drushNotFound", func(t *testing.T) {
 		c := UserRoleCheck{}
 		c.FetchData()
-		assert.Equal(result.Fail, c.Result.Status)
 		assert.EqualValues(
 			[]result.Breach{&result.ValueBreach{
 				BreachType: "value",
@@ -63,9 +62,9 @@ func TestFetchData(t *testing.T) {
 		)
 	})
 
-	curShellCommander := command.ShellCommander
-	defer func() { command.ShellCommander = curShellCommander }()
 	t.Run("drushError", func(t *testing.T) {
+		curShellCommander := command.ShellCommander
+		defer func() { command.ShellCommander = curShellCommander }()
 		sqlQueryFail := true
 		command.ShellCommander = func(name string, arg ...string) command.IShellCommand {
 			var stdout []byte
@@ -83,7 +82,6 @@ func TestFetchData(t *testing.T) {
 		}
 		c := UserRoleCheck{}
 		c.FetchData()
-		assert.Equal(result.Fail, c.Result.Status)
 		assert.EqualValues(
 			[]result.Breach{&result.ValueBreach{
 				BreachType: "value",
@@ -95,7 +93,6 @@ func TestFetchData(t *testing.T) {
 		sqlQueryFail = false
 		c = UserRoleCheck{}
 		c.FetchData()
-		assert.Equal(result.Fail, c.Result.Status)
 		assert.EqualValues(
 			[]result.Breach{&result.ValueBreach{
 				BreachType: "value",
@@ -120,13 +117,12 @@ func TestFetchData(t *testing.T) {
 	})
 }
 
-func TestUnmarshalData(t *testing.T) {
+func TestUserRoleCheckUnmarshalData(t *testing.T) {
 	assert := assert.New(t)
 
 	// Empty datamap.
 	c := UserRoleCheck{}
 	c.UnmarshalDataMap()
-	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(
 		[]result.Breach{&result.ValueBreach{
 			BreachType: "value",
@@ -143,7 +139,6 @@ func TestUnmarshalData(t *testing.T) {
 		},
 	}
 	c.UnmarshalDataMap()
-	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(
 		[]result.Breach{&result.ValueBreach{
 			BreachType: "value",
@@ -166,64 +161,58 @@ func TestUnmarshalData(t *testing.T) {
 	assert.Equal("map[int][]string{1:[]string{\"authenticated\"}}", fmt.Sprintf("%#v", userRolesVal))
 }
 
-func TestRunCheck(t *testing.T) {
-	assert := assert.New(t)
+func TestUserRoleCheckRunCheck(t *testing.T) {
+	tt := []internal.RunCheckTest{
+		{
+			Name: "noDisallowedRoleProvided",
+			Check: &UserRoleCheck{
+				CheckBase: config.CheckBase{
+					DataMap: map[string][]byte{
+						"user-info": []byte(`{"1":{"roles":["authenticated"]}}`)},
+				},
+			},
+			ExpectStatus: result.Fail,
+			ExpectFails: []result.Breach{&result.ValueBreach{
+				BreachType: "value",
+				Value:      "no disallowed role provided"}}},
 
-	// No disallowed roles provided.
-	c := UserRoleCheck{
-		CheckBase: config.CheckBase{
-			DataMap: map[string][]byte{
-				"user-info": []byte(`{"1":{"roles":["authenticated"]}}`)},
-		},
-	}
-	c.UnmarshalDataMap()
-	c.RunCheck()
-	assert.Equal(result.Fail, c.Result.Status)
-	assert.EqualValues(
-		[]result.Breach{&result.ValueBreach{
-			BreachType: "value",
-			Value:      "no disallowed role provided",
-		}},
-		c.Result.Breaches,
-	)
+		{
+			Name: "userHasDisallowedRoles",
+			Check: &UserRoleCheck{
+				CheckBase: config.CheckBase{
+					DataMap: map[string][]byte{
+						"user-info": []byte(`{"1":{"roles":["authenticated","site-admin","content-admin"]}}`)},
+				},
+				Roles: []string{"site-admin", "content-admin"},
+			},
+			ExpectStatus: result.Fail,
+			ExpectFails: []result.Breach{&result.KeyValuesBreach{
+				BreachType: "key-values",
+				KeyLabel:   "user",
+				Key:        "1",
+				ValueLabel: "disallowed roles",
+				Values:     []string{"site-admin", "content-admin"}}}},
 
-	// User has disallowed roles.
-	c = UserRoleCheck{
-		CheckBase: config.CheckBase{
-			DataMap: map[string][]byte{
-				"user-info": []byte(`{"1":{"roles":["authenticated","site-admin","content-admin"]}}`)},
-		},
-		Roles: []string{"site-admin", "content-admin"},
-	}
-	c.UnmarshalDataMap()
-	c.RunCheck()
-	assert.Equal(result.Fail, c.Result.Status)
-	assert.EqualValues(
-		[]result.Breach{&result.KeyValuesBreach{
-			BreachType: "key-values",
-			KeyLabel:   "user",
-			Key:        "1",
-			ValueLabel: "disallowed roles",
-			Values:     []string{"site-admin", "content-admin"},
-		}},
-		c.Result.Breaches,
-	)
-
-	// User allowed to have disallowed roles.
-	c = UserRoleCheck{
-		CheckBase: config.CheckBase{
-			DataMap: map[string][]byte{
-				"user-info": []byte(`
+		{
+			Name: "userAllowedToHaveDisallowedRoles",
+			Check: &UserRoleCheck{
+				CheckBase: config.CheckBase{
+					DataMap: map[string][]byte{
+						"user-info": []byte(`
 				{
 					"1":{"roles":["authenticated"]},
 					"2":{"roles":["authenticated","site-admin","content-admin"]}
 				}
 				`)},
-		},
-		Roles:        []string{"site-admin", "content-admin"},
-		AllowedUsers: []int{2},
+				},
+				Roles:        []string{"site-admin", "content-admin"},
+				AllowedUsers: []int{2},
+			},
+			ExpectStatus: result.Pass},
 	}
-	c.UnmarshalDataMap()
-	c.RunCheck()
-	assert.Equal(result.Pass, c.Result.Status)
+
+	for _, tc := range tt {
+		tc.Check.UnmarshalDataMap()
+		internal.TestRunCheck(t, tc)
+	}
 }

--- a/pkg/checks/file/filecheck.go
+++ b/pkg/checks/file/filecheck.go
@@ -55,7 +55,7 @@ func (c *FileCheck) RequiresData() bool { return false }
 func (c *FileCheck) RunCheck() {
 	files, err := utils.FindFiles(filepath.Join(config.ProjectDir, c.Path), c.DisallowedPattern, c.ExcludePattern, c.SkipDir)
 	if err != nil {
-		c.AddBreach(result.ValueBreach{
+		c.AddBreach(&result.ValueBreach{
 			ValueLabel: "error finding files",
 			Value:      err.Error()})
 		return
@@ -65,7 +65,7 @@ func (c *FileCheck) RunCheck() {
 		c.AddPass("No illegal files")
 		return
 	}
-	c.AddBreach(result.KeyValueBreach{
+	c.AddBreach(&result.KeyValueBreach{
 		Key:   fmt.Sprintf("%s - illegal files found", c.Name),
 		Value: strings.Join(files, "\n"),
 	})

--- a/pkg/checks/file/filecheck_test.go
+++ b/pkg/checks/file/filecheck_test.go
@@ -55,6 +55,7 @@ func TestFileCheckRunCheck(t *testing.T) {
 	c.Name = "filecheck1"
 	c.Init(File)
 	c.RunCheck()
+	c.Result.DetermineResultStatus(false)
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.Equal(0, len(c.Result.Passes))
 	assert.EqualValues(
@@ -75,6 +76,7 @@ func TestFileCheckRunCheck(t *testing.T) {
 	c.Name = "filecheck2"
 	c.Init(File)
 	c.RunCheck()
+	c.Result.DetermineResultStatus(false)
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.Equal(0, len(c.Result.Passes))
 	assert.EqualValues(

--- a/pkg/checks/file/filecheck_test.go
+++ b/pkg/checks/file/filecheck_test.go
@@ -58,7 +58,7 @@ func TestFileCheckRunCheck(t *testing.T) {
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.Equal(0, len(c.Result.Passes))
 	assert.EqualValues(
-		[]result.Breach{result.ValueBreach{
+		[]result.Breach{&result.ValueBreach{
 			CheckType:  "file",
 			CheckName:  "filecheck1",
 			BreachType: result.BreachTypeValue,
@@ -79,7 +79,7 @@ func TestFileCheckRunCheck(t *testing.T) {
 	assert.Equal(0, len(c.Result.Passes))
 	assert.EqualValues(
 		[]result.Breach{
-			result.KeyValueBreach{
+			&result.KeyValueBreach{
 				CheckType:  "file",
 				CheckName:  "filecheck2",
 				BreachType: result.BreachTypeKeyValue,

--- a/pkg/checks/json/json.go
+++ b/pkg/checks/json/json.go
@@ -21,7 +21,7 @@ func (c *JsonCheck) UnmarshalDataMap() {
 		var n any
 		err := json.Unmarshal(data, &n)
 		if err != nil {
-			c.AddBreach(result.ValueBreach{ValueLabel: "JSON error", Value: err.Error()})
+			c.AddBreach(&result.ValueBreach{ValueLabel: "JSON error", Value: err.Error()})
 			return
 		}
 		c.Node[configName] = n
@@ -36,16 +36,16 @@ func (c *JsonCheck) processData(configName string) {
 		kvr, fails, err := CheckKeyValue(c.Node[configName], kv)
 		switch kvr {
 		case yaml.KeyValueError:
-			c.AddBreach(result.ValueBreach{Value: err.Error()})
+			c.AddBreach(&result.ValueBreach{Value: err.Error()})
 		case yaml.KeyValueNotFound:
-			c.AddBreach(result.KeyValueBreach{
+			c.AddBreach(&result.KeyValueBreach{
 				KeyLabel:   "config",
 				Key:        configName,
 				ValueLabel: "key not found",
 				Value:      kv.Key,
 			})
 		case yaml.KeyValueNotEqual:
-			c.AddBreach(result.KeyValueBreach{
+			c.AddBreach(&result.KeyValueBreach{
 				KeyLabel:      configName,
 				Key:           kv.Key,
 				ValueLabel:    "actual",
@@ -53,7 +53,7 @@ func (c *JsonCheck) processData(configName string) {
 				Value:         fails[0],
 			})
 		case yaml.KeyValueDisallowedFound:
-			c.AddBreach(result.KeyValuesBreach{
+			c.AddBreach(&result.KeyValuesBreach{
 				KeyLabel:   "config",
 				Key:        configName,
 				ValueLabel: fmt.Sprintf("disallowed %s", kv.Key),

--- a/pkg/checks/json/json_test.go
+++ b/pkg/checks/json/json_test.go
@@ -36,7 +36,7 @@ func TestJsonCheckUnmarshalDataMap(t *testing.T) {
 	assertions.EqualValues(0, len(c.Result.Passes))
 	assertions.ElementsMatch(
 		[]result.Breach{
-			result.ValueBreach{
+			&result.ValueBreach{
 				BreachType: result.BreachTypeValue,
 				ValueLabel: "JSON error",
 				Value:      "invalid character 'p' looking for beginning of value",

--- a/pkg/checks/json/json_test.go
+++ b/pkg/checks/json/json_test.go
@@ -32,7 +32,6 @@ func TestJsonCheckUnmarshalDataMap(t *testing.T) {
 	}
 
 	c.UnmarshalDataMap()
-	assertions.Equal(result.Fail, c.Result.Status)
 	assertions.EqualValues(0, len(c.Result.Passes))
 	assertions.ElementsMatch(
 		[]result.Breach{

--- a/pkg/checks/json/jsoncheck_test.go
+++ b/pkg/checks/json/jsoncheck_test.go
@@ -82,7 +82,7 @@ func TestJsonCheckRunCheck(t *testing.T) {
 	assertions.Empty(c.Result.Passes)
 	assertions.ElementsMatch(
 		[]result.Breach{
-			result.ValueBreach{
+			&result.ValueBreach{
 				BreachType: result.BreachTypeValue,
 				ValueLabel: "- no file",
 				Value:      "no file provided",
@@ -101,7 +101,7 @@ func TestJsonCheckRunCheck(t *testing.T) {
 	assertions.Empty(c.Result.Passes)
 	assertions.ElementsMatch(
 		[]result.Breach{
-			result.ValueBreach{
+			&result.ValueBreach{
 				CheckType:  "json",
 				Severity:   "normal",
 				BreachType: result.BreachTypeValue,
@@ -144,7 +144,7 @@ func TestJsonCheckRunCheck(t *testing.T) {
 	assertions.Empty(c.Result.Passes)
 	assertions.ElementsMatch(
 		[]result.Breach{
-			result.ValueBreach{
+			&result.ValueBreach{
 				BreachType: result.BreachTypeValue,
 				ValueLabel: "error finding files in path: testdata",
 				Value:      "error parsing regexp: missing argument to repetition operator: `*`",
@@ -161,7 +161,7 @@ func TestJsonCheckRunCheck(t *testing.T) {
 	assertions.Empty(c.Result.Passes)
 	assertions.ElementsMatch(
 		[]result.Breach{
-			result.ValueBreach{
+			&result.ValueBreach{
 				BreachType: result.BreachTypeValue,
 				ValueLabel: "- no file",
 				Value:      "no matching yaml files found",
@@ -209,7 +209,7 @@ func TestJsonCheckRunCheck(t *testing.T) {
 		c.Result.Passes)
 	assertions.ElementsMatch(
 		[]result.Breach{
-			result.KeyValueBreach{
+			&result.KeyValueBreach{
 				BreachType:    result.BreachTypeKeyValue,
 				KeyLabel:      "testdata/composer.array.json",
 				Key:           "$.license",
@@ -217,7 +217,7 @@ func TestJsonCheckRunCheck(t *testing.T) {
 				Value:         "BSD",
 				ExpectedValue: "MIT",
 			},
-			result.KeyValueBreach{
+			&result.KeyValueBreach{
 				BreachType:    result.BreachTypeKeyValue,
 				KeyLabel:      "testdata/dir/composer.array.json",
 				Key:           "$.license",
@@ -225,7 +225,7 @@ func TestJsonCheckRunCheck(t *testing.T) {
 				Value:         "BSD",
 				ExpectedValue: "MIT",
 			},
-			result.KeyValueBreach{
+			&result.KeyValueBreach{
 				BreachType:    result.BreachTypeKeyValue,
 				KeyLabel:      "testdata/dir/subdir/composer.array.json",
 				Key:           "$.license",
@@ -261,7 +261,7 @@ func TestJsonCheckRunCheck(t *testing.T) {
 	assertions.Empty(c.Result.Passes)
 	assertions.ElementsMatch(
 		[]result.Breach{
-			result.KeyValuesBreach{
+			&result.KeyValuesBreach{
 				BreachType: result.BreachTypeKeyValues,
 				KeyLabel:   "config",
 				Key:        "composer.map.json",
@@ -295,7 +295,7 @@ func TestJsonCheckRunCheck(t *testing.T) {
 	assertions.Empty(c.Result.Passes)
 	assertions.ElementsMatch(
 		[]result.Breach{
-			result.KeyValuesBreach{
+			&result.KeyValuesBreach{
 				BreachType: result.BreachTypeKeyValues,
 				KeyLabel:   "config",
 				Key:        "composer.map.json",
@@ -329,7 +329,7 @@ func TestJsonCheckRunCheck(t *testing.T) {
 	assertions.Empty(c.Result.Passes)
 	assertions.ElementsMatch(
 		[]result.Breach{
-			result.ValueBreach{
+			&result.ValueBreach{
 				BreachType: result.BreachTypeValue,
 				Value:      "json: invalid path format: found invalid path character * after dot",
 			},
@@ -358,7 +358,7 @@ func TestJsonCheckRunCheck(t *testing.T) {
 	assertions.Empty(c.Result.Passes)
 	assertions.ElementsMatch(
 		[]result.Breach{
-			result.KeyValueBreach{
+			&result.KeyValueBreach{
 				BreachType: result.BreachTypeKeyValue,
 				KeyLabel:   "config",
 				Key:        "composer.map.json",

--- a/pkg/checks/phpstan/phpstan.go
+++ b/pkg/checks/phpstan/phpstan.go
@@ -119,11 +119,11 @@ func (c *PhpStanCheck) FetchData() {
 	c.DataMap["phpstan"], err = command.ShellCommander(phpstanPath, args...).Output()
 	if err != nil {
 		if pathErr, ok := err.(*fs.PathError); ok {
-			c.AddBreach(result.ValueBreach{
+			c.AddBreach(&result.ValueBreach{
 				ValueLabel: pathErr.Path,
 				Value:      pathErr.Err.Error()})
 		} else if len(c.DataMap["phpstan"]) == 0 { // If errors were found, exit code will be 1.
-			c.AddBreach(result.ValueBreach{
+			c.AddBreach(&result.ValueBreach{
 				ValueLabel: "Phpstan failed to run",
 				Value:      string(err.(*exec.ExitError).Stderr)})
 		}
@@ -135,7 +135,7 @@ func (c *PhpStanCheck) FetchData() {
 func (c *PhpStanCheck) HasData(failCheck bool) bool {
 	if c.DataMap == nil && len(c.Result.Passes) == 0 {
 		if failCheck {
-			c.AddBreach(result.ValueBreach{Value: "no data available"})
+			c.AddBreach(&result.ValueBreach{Value: "no data available"})
 		}
 		return false
 	}
@@ -158,7 +158,7 @@ func (c *PhpStanCheck) UnmarshalDataMap() {
 	c.phpstanResult = PhpStanResult{}
 	err := json.Unmarshal(c.DataMap["phpstan"], &c.phpstanResult)
 	if err != nil {
-		c.AddBreach(result.ValueBreach{
+		c.AddBreach(&result.ValueBreach{
 			ValueLabel: "unable to parse phpstan result",
 			Value:      err.Error()})
 		return
@@ -172,7 +172,7 @@ func (c *PhpStanCheck) UnmarshalDataMap() {
 	// Unmarshal file errors.
 	err = json.Unmarshal(c.phpstanResult.FilesRaw, &c.phpstanResult.Files)
 	if err != nil {
-		c.AddBreach(result.ValueBreach{
+		c.AddBreach(&result.ValueBreach{
 			ValueLabel: "unable to parse phpstan file errors",
 			Value:      err.Error()})
 		return
@@ -193,14 +193,14 @@ func (c *PhpStanCheck) RunCheck() {
 			errLines = append(errLines, fmt.Sprintf("line %d: %s", er.Line, er.Message))
 
 		}
-		c.AddBreach(result.KeyValueBreach{
+		c.AddBreach(&result.KeyValueBreach{
 			Key:   fmt.Sprintf("file contains banned functions: %s", file),
 			Value: strings.Join(errLines, "\n"),
 		})
 	}
 
 	if len(c.phpstanResult.Errors) > 0 {
-		c.AddBreach(result.ValueBreach{
+		c.AddBreach(&result.ValueBreach{
 			ValueLabel: "errors encountered when running phpstan",
 			Value:      strings.Join(c.phpstanResult.Errors, "\n")})
 	}

--- a/pkg/checks/phpstan/phpstan_test.go
+++ b/pkg/checks/phpstan/phpstan_test.go
@@ -128,8 +128,6 @@ func TestFetchDataBinNotExists(t *testing.T) {
 		Paths:  []string{dir},
 	}
 	c.FetchData()
-
-	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(
 		[]result.Breach{&result.ValueBreach{
 			BreachType: "value",
@@ -175,7 +173,6 @@ func TestHasData(t *testing.T) {
 		assert := assert.New(t)
 		c := PhpStanCheck{}
 		assert.False(c.HasData(true))
-		assert.Equal(result.Fail, c.Result.Status)
 		assert.EqualValues(
 			[]result.Breach{&result.ValueBreach{
 				BreachType: "value",
@@ -227,7 +224,6 @@ func TestUnmarshalDataMap(t *testing.T) {
 		},
 	}
 	c.UnmarshalDataMap()
-	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(
 		[]result.Breach{&result.ValueBreach{
 			BreachType: "value",
@@ -255,6 +251,7 @@ func TestRunCheck(t *testing.T) {
 	}
 	c.UnmarshalDataMap()
 	c.RunCheck()
+	c.Result.DetermineResultStatus(false)
 	assert.Equal(result.Pass, c.Result.Status)
 	assert.EqualValues([]string{"no error found"}, c.Result.Passes)
 
@@ -268,6 +265,7 @@ func TestRunCheck(t *testing.T) {
 	}
 	c.UnmarshalDataMap()
 	c.RunCheck()
+	c.Result.DetermineResultStatus(false)
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(
 		[]result.Breach{&result.KeyValueBreach{
@@ -288,6 +286,7 @@ func TestRunCheck(t *testing.T) {
 	}
 	c.UnmarshalDataMap()
 	c.RunCheck()
+	c.Result.DetermineResultStatus(false)
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(
 		[]result.Breach{&result.ValueBreach{

--- a/pkg/checks/phpstan/phpstan_test.go
+++ b/pkg/checks/phpstan/phpstan_test.go
@@ -131,7 +131,7 @@ func TestFetchDataBinNotExists(t *testing.T) {
 
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(
-		[]result.Breach{result.ValueBreach{
+		[]result.Breach{&result.ValueBreach{
 			BreachType: "value",
 			ValueLabel: "Phpstan failed to run",
 			Value:      "/my/custom/path/phpstan: no such file or directory",
@@ -177,7 +177,7 @@ func TestHasData(t *testing.T) {
 		assert.False(c.HasData(true))
 		assert.Equal(result.Fail, c.Result.Status)
 		assert.EqualValues(
-			[]result.Breach{result.ValueBreach{
+			[]result.Breach{&result.ValueBreach{
 				BreachType: "value",
 				Value:      "no data available",
 			}},
@@ -229,7 +229,7 @@ func TestUnmarshalDataMap(t *testing.T) {
 	c.UnmarshalDataMap()
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(
-		[]result.Breach{result.ValueBreach{
+		[]result.Breach{&result.ValueBreach{
 			BreachType: "value",
 			ValueLabel: "unable to parse phpstan file errors",
 			Value: "json: cannot unmarshal array into Go value of type " +
@@ -270,7 +270,7 @@ func TestRunCheck(t *testing.T) {
 	c.RunCheck()
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(
-		[]result.Breach{result.KeyValueBreach{
+		[]result.Breach{&result.KeyValueBreach{
 			BreachType: "key-value",
 			Key:        "file contains banned functions: /app/web/themes/custom/custom/test-theme/info.php",
 			Value:      "line 3: Calling curl_exec() is forbidden, please change the code",
@@ -290,7 +290,7 @@ func TestRunCheck(t *testing.T) {
 	c.RunCheck()
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(
-		[]result.Breach{result.ValueBreach{
+		[]result.Breach{&result.ValueBreach{
 			BreachType: "value",
 			ValueLabel: "errors encountered when running phpstan",
 			Value:      "Error found in file foo",

--- a/pkg/checks/sca/apptypecheck.go
+++ b/pkg/checks/sca/apptypecheck.go
@@ -105,7 +105,7 @@ func (c *AppTypeCheck) RunCheck() {
 			}
 		}
 		if len(disallowedFound) > 0 {
-			c.AddBreach(result.KeyValueBreach{
+			c.AddBreach(&result.KeyValueBreach{
 				Key:   fmt.Sprintf("[%s] contains disallowed frameworks", path),
 				Value: "[" + strings.Join(disallowedFound, ", ") + "]",
 			})

--- a/pkg/checks/sca/apptypecheck_test.go
+++ b/pkg/checks/sca/apptypecheck_test.go
@@ -26,7 +26,7 @@ func TestIsDrupalCheck(t *testing.T) {
 	c.RunCheck()
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(
-		[]result.Breach{result.KeyValueBreach{
+		[]result.Breach{&result.KeyValueBreach{
 			BreachType: "key-value",
 			Key:        "[./testdata/drupal] contains disallowed frameworks",
 			Value:      "[drupal]",
@@ -66,7 +66,7 @@ func TestIsWordpressCheck(t *testing.T) {
 	c.RunCheck()
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(
-		[]result.Breach{result.KeyValueBreach{
+		[]result.Breach{&result.KeyValueBreach{
 			BreachType: "key-value",
 			Key:        "[./testdata/wordpress] contains disallowed frameworks",
 			Value:      "[wordpress]",
@@ -92,7 +92,7 @@ func TestIsSymfonyCheck(t *testing.T) {
 	c.RunCheck()
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(
-		[]result.Breach{result.KeyValueBreach{
+		[]result.Breach{&result.KeyValueBreach{
 			BreachType: "key-value",
 			Key:        "[./testdata/symfony] contains disallowed frameworks",
 			Value:      "[symfony]",
@@ -118,7 +118,7 @@ func TestIsLaravelCheck(t *testing.T) {
 	c.RunCheck()
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(
-		[]result.Breach{result.KeyValueBreach{
+		[]result.Breach{&result.KeyValueBreach{
 			BreachType: "key-value",
 			Key:        "[./testdata/laravel] contains disallowed frameworks",
 			Value:      "[laravel]",

--- a/pkg/checks/sca/apptypecheck_test.go
+++ b/pkg/checks/sca/apptypecheck_test.go
@@ -24,6 +24,7 @@ func TestIsDrupalCheck(t *testing.T) {
 	c.Dependencies["drupal"] = []string{"drupal/core-recommended"}
 
 	c.RunCheck()
+	c.Result.DetermineResultStatus(false)
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(
 		[]result.Breach{&result.KeyValueBreach{
@@ -64,6 +65,7 @@ func TestIsWordpressCheck(t *testing.T) {
 	c.Dirs["wordpress"] = []string{"wp-admin", "wp-content", "wp-includes"}
 
 	c.RunCheck()
+	c.Result.DetermineResultStatus(false)
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(
 		[]result.Breach{&result.KeyValueBreach{
@@ -90,6 +92,7 @@ func TestIsSymfonyCheck(t *testing.T) {
 	c.Dependencies["symfony"] = []string{"symfony/runtime", "symfony/symfony", "symfony/framework"}
 
 	c.RunCheck()
+	c.Result.DetermineResultStatus(false)
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(
 		[]result.Breach{&result.KeyValueBreach{
@@ -116,6 +119,7 @@ func TestIsLaravelCheck(t *testing.T) {
 	c.Dependencies["laravel"] = []string{"laravel/framework", "laravel/tinker"}
 
 	c.RunCheck()
+	c.Result.DetermineResultStatus(false)
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(
 		[]result.Breach{&result.KeyValueBreach{

--- a/pkg/checks/yaml/yaml.go
+++ b/pkg/checks/yaml/yaml.go
@@ -52,7 +52,7 @@ func (c *YamlBase) UnmarshalDataMap() {
 		n := yaml.Node{}
 		err := yaml.Unmarshal([]byte(data), &n)
 		if err != nil {
-			c.AddBreach(result.ValueBreach{Value: err.Error()})
+			c.AddBreach(&result.ValueBreach{Value: err.Error()})
 			return
 		}
 		c.NodeMap[configName] = n
@@ -66,16 +66,16 @@ func (c *YamlBase) determineBreaches(configName string) {
 		kvr, fails, err := CheckKeyValue(c.NodeMap[configName], kv)
 		switch kvr {
 		case KeyValueError:
-			c.AddBreach(result.ValueBreach{Value: err.Error()})
+			c.AddBreach(&result.ValueBreach{Value: err.Error()})
 		case KeyValueNotFound:
-			c.AddBreach(result.KeyValueBreach{
+			c.AddBreach(&result.KeyValueBreach{
 				KeyLabel:   "config",
 				Key:        configName,
 				ValueLabel: "key not found",
 				Value:      kv.Key,
 			})
 		case KeyValueNotEqual:
-			c.AddBreach(result.KeyValueBreach{
+			c.AddBreach(&result.KeyValueBreach{
 				KeyLabel:      configName,
 				Key:           kv.Key,
 				ValueLabel:    "actual",
@@ -83,7 +83,7 @@ func (c *YamlBase) determineBreaches(configName string) {
 				Value:         fails[0],
 			})
 		case KeyValueDisallowedFound:
-			c.AddBreach(result.KeyValuesBreach{
+			c.AddBreach(&result.KeyValuesBreach{
 				KeyLabel:   "config",
 				Key:        configName,
 				ValueLabel: fmt.Sprintf("disallowed %s", kv.Key),

--- a/pkg/checks/yaml/yaml_test.go
+++ b/pkg/checks/yaml/yaml_test.go
@@ -54,7 +54,7 @@ foo:
 	c.UnmarshalDataMap()
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(0, len(c.Result.Passes))
-	assert.ElementsMatch([]result.Breach{result.ValueBreach{
+	assert.ElementsMatch([]result.Breach{&result.ValueBreach{
 		BreachType: result.BreachTypeValue,
 		Value:      "yaml: line 4: found character that cannot start any token"}},
 		c.Result.Breaches)
@@ -93,7 +93,7 @@ foo:
 	c.RunCheck()
 
 	assert.Equal(result.Fail, c.Result.Status)
-	assert.ElementsMatch([]result.Breach{result.ValueBreach{
+	assert.ElementsMatch([]result.Breach{&result.ValueBreach{
 		BreachType: result.BreachTypeValue,
 		Value:      "invalid character '&' at position 3, following \"baz\""}},
 		c.Result.Breaches)
@@ -271,7 +271,7 @@ func TestYamlBase(t *testing.T) {
 	c := YamlBase{}
 	c.HasData(true)
 	assert.Equal(result.Fail, c.Result.Status)
-	assert.ElementsMatch([]result.Breach{result.ValueBreach{
+	assert.ElementsMatch([]result.Breach{&result.ValueBreach{
 		BreachType: result.BreachTypeValue,
 		Value:      "no data available"}},
 		c.Result.Breaches)
@@ -316,7 +316,7 @@ notification:
 	c.RunCheck()
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(0, len(c.Result.Passes))
-	assert.ElementsMatch([]result.Breach{result.KeyValueBreach{
+	assert.ElementsMatch([]result.Breach{&result.KeyValueBreach{
 		BreachType: result.BreachTypeKeyValue,
 		KeyLabel:   "config",
 		Key:        "data",
@@ -336,7 +336,7 @@ notification:
 	c.RunCheck()
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(0, len(c.Result.Passes))
-	assert.ElementsMatch([]result.Breach{result.KeyValueBreach{
+	assert.ElementsMatch([]result.Breach{&result.KeyValueBreach{
 		BreachType:    result.BreachTypeKeyValue,
 		KeyLabel:      "data",
 		Key:           "check.interval_days",
@@ -395,7 +395,7 @@ efgh:
 	c.RunCheck()
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(0, len(c.Result.Passes))
-	assert.ElementsMatch([]result.Breach{result.KeyValuesBreach{
+	assert.ElementsMatch([]result.Breach{&result.KeyValuesBreach{
 		BreachType: result.BreachTypeKeyValues,
 		KeyLabel:   "config",
 		Key:        "data",
@@ -434,7 +434,7 @@ foo:
 	c.RunCheck()
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(0, len(c.Result.Passes))
-	assert.ElementsMatch([]result.Breach{result.KeyValuesBreach{
+	assert.ElementsMatch([]result.Breach{&result.KeyValuesBreach{
 		BreachType: result.BreachTypeKeyValues,
 		KeyLabel:   "config",
 		Key:        "data",

--- a/pkg/checks/yaml/yaml_test.go
+++ b/pkg/checks/yaml/yaml_test.go
@@ -52,7 +52,6 @@ foo:
 		},
 	}
 	c.UnmarshalDataMap()
-	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(0, len(c.Result.Passes))
 	assert.ElementsMatch([]result.Breach{&result.ValueBreach{
 		BreachType: result.BreachTypeValue,
@@ -91,6 +90,7 @@ foo:
 		},
 	}
 	c.RunCheck()
+	c.Result.DetermineResultStatus(false)
 
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.ElementsMatch([]result.Breach{&result.ValueBreach{
@@ -270,7 +270,6 @@ func TestYamlBase(t *testing.T) {
 
 	c := YamlBase{}
 	c.HasData(true)
-	assert.Equal(result.Fail, c.Result.Status)
 	assert.ElementsMatch([]result.Breach{&result.ValueBreach{
 		BreachType: result.BreachTypeValue,
 		Value:      "no data available"}},
@@ -314,6 +313,7 @@ notification:
 		},
 	}
 	c.RunCheck()
+	c.Result.DetermineResultStatus(false)
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(0, len(c.Result.Passes))
 	assert.ElementsMatch([]result.Breach{&result.KeyValueBreach{
@@ -334,6 +334,7 @@ notification:
 	}
 	c.UnmarshalDataMap()
 	c.RunCheck()
+	c.Result.DetermineResultStatus(false)
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(0, len(c.Result.Passes))
 	assert.ElementsMatch([]result.Breach{&result.KeyValueBreach{
@@ -359,6 +360,7 @@ notification:
 	}
 	c.UnmarshalDataMap()
 	c.RunCheck()
+	c.Result.DetermineResultStatus(false)
 	assert.Equal(result.Pass, c.Result.Status)
 	assert.EqualValues(0, len(c.Result.Breaches))
 	assert.EqualValues(
@@ -393,6 +395,7 @@ efgh:
 	}
 	c.UnmarshalDataMap()
 	c.RunCheck()
+	c.Result.DetermineResultStatus(false)
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(0, len(c.Result.Passes))
 	assert.ElementsMatch([]result.Breach{&result.KeyValuesBreach{
@@ -432,6 +435,7 @@ foo:
 	c := mockCheck()
 	c.UnmarshalDataMap()
 	c.RunCheck()
+	c.Result.DetermineResultStatus(false)
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.EqualValues(0, len(c.Result.Passes))
 	assert.ElementsMatch([]result.Breach{&result.KeyValuesBreach{
@@ -446,6 +450,7 @@ foo:
 	c.Values[0].Disallowed = []string{"e"}
 	c.UnmarshalDataMap()
 	c.RunCheck()
+	c.Result.DetermineResultStatus(false)
 	assert.Equal(result.Pass, c.Result.Status)
 	assert.EqualValues(0, len(c.Result.Breaches))
 	assert.EqualValues([]string{"[data] no disallowed 'foo'"}, c.Result.Passes)

--- a/pkg/checks/yaml/yamlcheck.go
+++ b/pkg/checks/yaml/yamlcheck.go
@@ -38,7 +38,7 @@ func (c *YamlCheck) readFile(fkey string, fname string) {
 			c.AddPass(fmt.Sprintf("File %s does not exist", fname))
 			c.Result.Status = result.Pass
 		} else {
-			c.AddBreach(result.ValueBreach{
+			c.AddBreach(&result.ValueBreach{
 				ValueLabel: "error reading file: " + fname,
 				Value:      err.Error()})
 		}
@@ -65,7 +65,7 @@ func (c *YamlCheck) FetchData() {
 				c.AddPass(fmt.Sprintf("Path %s does not exist", configPath))
 				c.Result.Status = result.Pass
 			} else {
-				c.AddBreach(result.ValueBreach{
+				c.AddBreach(&result.ValueBreach{
 					ValueLabel: "error finding files in path: " + configPath,
 					Value:      err.Error()})
 			}
@@ -77,7 +77,7 @@ func (c *YamlCheck) FetchData() {
 			c.Result.Status = result.Pass
 			return
 		} else if len(files) == 0 {
-			c.AddBreach(result.ValueBreach{
+			c.AddBreach(&result.ValueBreach{
 				ValueLabel: c.Name + "- no file",
 				Value:      "no matching yaml files found"})
 			return
@@ -88,7 +88,7 @@ func (c *YamlCheck) FetchData() {
 			c.readFile(fname, fname)
 		}
 	} else {
-		c.AddBreach(result.ValueBreach{
+		c.AddBreach(&result.ValueBreach{
 			ValueLabel: c.Name + "- no file",
 			Value:      "no file provided"})
 	}

--- a/pkg/checks/yaml/yamlcheck_test.go
+++ b/pkg/checks/yaml/yamlcheck_test.go
@@ -238,8 +238,8 @@ notification:
 
 	config.ProjectDir = "testdata"
 	for _, tc := range tt {
-		tc.Check.Init(Yaml)
 		t.Run(tc.Name, func(innerT *testing.T) {
+			tc.Check.Init(Yaml)
 			internal.TestFetchData(innerT, tc)
 		})
 	}

--- a/pkg/checks/yaml/yamlcheck_test.go
+++ b/pkg/checks/yaml/yamlcheck_test.go
@@ -57,7 +57,6 @@ func TestYamlCheckFetchData(t *testing.T) {
 					Value:      "no file provided",
 				},
 			},
-			ExpectStatusFail: true,
 		},
 
 		{
@@ -79,7 +78,6 @@ func TestYamlCheckFetchData(t *testing.T) {
 					Value:      "open testdata/non-existent.yml: no such file or directory",
 				},
 			},
-			ExpectStatusFail: true,
 		},
 
 		{
@@ -93,8 +91,7 @@ func TestYamlCheckFetchData(t *testing.T) {
 				File:          "non-existent.yml",
 				IgnoreMissing: &cTrue,
 			},
-			ExpectPasses:     []string{"File testdata/non-existent.yml does not exist"},
-			ExpectStatusPass: true,
+			ExpectPasses: []string{"File testdata/non-existent.yml does not exist"},
 		},
 
 		{
@@ -138,7 +135,6 @@ notification:
 					Value:      "error parsing regexp: missing argument to repetition operator: `*`",
 				},
 			},
-			ExpectStatusFail: true,
 		},
 
 		{
@@ -160,7 +156,6 @@ notification:
 					Value:      "no matching yaml files found",
 				},
 			},
-			ExpectStatusFail: true,
 		},
 
 		{
@@ -174,8 +169,7 @@ notification:
 				Pattern:       "bla.*.yml",
 				IgnoreMissing: &cTrue,
 			},
-			ExpectPasses:     []string{"no matching config files found"},
-			ExpectStatusPass: true,
+			ExpectPasses: []string{"no matching config files found"},
 		},
 
 		{

--- a/pkg/checks/yaml/yamlcheck_test.go
+++ b/pkg/checks/yaml/yamlcheck_test.go
@@ -49,7 +49,7 @@ func TestYamlCheckFetchData(t *testing.T) {
 				},
 			},
 			ExpectBreaches: []result.Breach{
-				result.ValueBreach{
+				&result.ValueBreach{
 					BreachType: "value",
 					CheckType:  "yaml",
 					Severity:   "normal",
@@ -71,7 +71,7 @@ func TestYamlCheckFetchData(t *testing.T) {
 				File: "non-existent.yml",
 			},
 			ExpectBreaches: []result.Breach{
-				result.ValueBreach{
+				&result.ValueBreach{
 					BreachType: "value",
 					CheckType:  "yaml",
 					Severity:   "normal",
@@ -130,7 +130,7 @@ notification:
 				Path:    "",
 			},
 			ExpectBreaches: []result.Breach{
-				result.ValueBreach{
+				&result.ValueBreach{
 					BreachType: "value",
 					CheckType:  "yaml",
 					Severity:   "normal",
@@ -152,7 +152,7 @@ notification:
 				Pattern: "bla.*.yml",
 			},
 			ExpectBreaches: []result.Breach{
-				result.ValueBreach{
+				&result.ValueBreach{
 					BreachType: "value",
 					CheckType:  "yaml",
 					Severity:   "normal",

--- a/pkg/checks/yaml/yamllintcheck.go
+++ b/pkg/checks/yaml/yamllintcheck.go
@@ -26,11 +26,11 @@ func (c *YamlLintCheck) UnmarshalDataMap() {
 		err := yaml.Unmarshal([]byte(data), &ifc)
 		if err != nil {
 			if typeErr, ok := err.(*yaml.TypeError); ok {
-				c.AddBreach(result.ValueBreach{
+				c.AddBreach(&result.ValueBreach{
 					ValueLabel: "cannot decode yaml: " + f,
 					Value:      strings.Join(typeErr.Errors, "\n")})
 			} else {
-				c.AddBreach(result.ValueBreach{
+				c.AddBreach(&result.ValueBreach{
 					ValueLabel: "yaml error: " + f,
 					Value:      err.Error()})
 			}

--- a/pkg/checks/yaml/yamllintcheck_test.go
+++ b/pkg/checks/yaml/yamllintcheck_test.go
@@ -55,7 +55,7 @@ func TestYamlLintCheck(t *testing.T) {
 	assert.Empty(c.Result.Passes)
 	assert.ElementsMatch(
 		[]result.Breach{
-			result.ValueBreach{
+			&result.ValueBreach{
 				BreachType: "value",
 				CheckType:  "yamllint",
 				CheckName:  "Test yaml lint",
@@ -94,7 +94,7 @@ func TestYamlLintCheck(t *testing.T) {
 	assert.Empty(c.Result.Passes)
 	assert.ElementsMatch(
 		[]result.Breach{
-			result.ValueBreach{
+			&result.ValueBreach{
 				BreachType: "value",
 				CheckType:  "yamllint",
 				CheckName:  "Test yaml lint",
@@ -113,7 +113,7 @@ func TestYamlLintCheck(t *testing.T) {
 	assert.Empty(c.Result.Passes)
 	assert.ElementsMatch(
 		[]result.Breach{
-			result.ValueBreach{
+			&result.ValueBreach{
 				BreachType: "value",
 				CheckType:  "yamllint",
 				CheckName:  "Test yaml lint",
@@ -136,7 +136,7 @@ this: yaml
 	assert.Empty(c.Result.Passes)
 	assert.ElementsMatch(
 		[]result.Breach{
-			result.ValueBreach{
+			&result.ValueBreach{
 				BreachType: "value",
 				CheckType:  "yamllint",
 				CheckName:  "Test yaml lint",
@@ -174,7 +174,7 @@ foo: bar
 		assert.Empty(c.Result.Passes)
 		assert.ElementsMatch(
 			[]result.Breach{
-				result.ValueBreach{
+				&result.ValueBreach{
 					BreachType: "value",
 					ValueLabel: "yaml error: yaml-invalid-root.yml",
 					Value:      "yaml: line 1: did not find expected key",

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -10,6 +10,8 @@ import (
 	"errors"
 	"io/fs"
 	"os/exec"
+
+	log "github.com/sirupsen/logrus"
 )
 
 // IShellCommand is an interface for running shell commands.
@@ -25,7 +27,12 @@ type ExecShellCommand struct {
 // NewExecShellCommander returns a command instance.
 func NewExecShellCommander(name string, arg ...string) IShellCommand {
 	execCmd := exec.Command(name, arg...)
-	return ExecShellCommand{Cmd: execCmd}
+	return &ExecShellCommand{Cmd: execCmd}
+}
+
+func (c *ExecShellCommand) Output() ([]byte, error) {
+	log.WithField("command", c).Debug("running command")
+	return c.Cmd.Output()
 }
 
 // ShellCommander provides a wrapper around the commander to allow for better

--- a/pkg/command/command_test.go
+++ b/pkg/command/command_test.go
@@ -21,7 +21,7 @@ func TestExecReplacement(t *testing.T) {
 
 	t.Run("differentStruct", func(t *testing.T) {
 		cmd := command.ShellCommander("foo", "bar")
-		assert.IsType(command.ExecShellCommand{}, cmd)
+		assert.IsType(&command.ExecShellCommand{}, cmd)
 
 		curShellCommander := command.ShellCommander
 		defer func() { command.ShellCommander = curShellCommander }()

--- a/pkg/config/checkbase.go
+++ b/pkg/config/checkbase.go
@@ -119,9 +119,12 @@ func (c *CheckBase) GetResult() *result.Result {
 	return &c.Result
 }
 
+// ShouldPerformRemediation returns whether to remediate or not.
+func (c *CheckBase) ShouldPerformRemediation() bool {
+	return c.PerformRemediation
+}
+
 // Remediate should implement the logic to fix the breach(es).
 // Any type or custom struct can be used for the breach; it just needs to be
 // cast to the required type before being used.
-func (c *CheckBase) Remediate(breachIfc interface{}) error {
-	return nil
-}
+func (c *CheckBase) Remediate() {}

--- a/pkg/config/checkbase.go
+++ b/pkg/config/checkbase.go
@@ -63,7 +63,7 @@ func (c *CheckBase) FetchData() {}
 func (c *CheckBase) HasData(failCheck bool) bool {
 	if c.DataMap == nil {
 		if failCheck {
-			c.AddBreach(result.ValueBreach{Value: "no data available"})
+			c.AddBreach(&result.ValueBreach{Value: "no data available"})
 		}
 		return false
 	}
@@ -77,7 +77,7 @@ func (c *CheckBase) UnmarshalDataMap() {}
 // AddBreach appends a Breach to the Result and sets the Check as Fail.
 func (c *CheckBase) AddBreach(b result.Breach) {
 	c.Result.Status = result.Fail
-	result.BreachSetCommonValues(&b, string(c.cType), c.Name, string(c.Severity))
+	b.SetCommonValues(string(c.cType), c.Name, string(c.Severity))
 	c.Result.Breaches = append(
 		c.Result.Breaches,
 		b,
@@ -111,7 +111,7 @@ func (c *CheckBase) AddRemediation(msg string) {
 // generating the result and remediating breaches.
 // This is where c.Result should be populated.
 func (c *CheckBase) RunCheck() {
-	c.AddBreach(result.ValueBreach{Value: "not implemented"})
+	c.AddBreach(&result.ValueBreach{Value: "not implemented"})
 }
 
 // GetResult returns a ref of the result.

--- a/pkg/config/checkbase.go
+++ b/pkg/config/checkbase.go
@@ -116,7 +116,11 @@ func (c *CheckBase) ShouldPerformRemediation() bool {
 // Remediate should implement the logic to fix the breach(es).
 // Any type or custom struct can be used for the breach; it just needs to be
 // cast to the required type before being used.
-func (c *CheckBase) Remediate() {}
+func (c *CheckBase) Remediate() {
+	for _, b := range c.Result.Breaches {
+		b.SetRemediation(result.RemediationStatusNoSupport, "")
+	}
+}
 
 // GetResult returns a ref of the result.
 func (c *CheckBase) GetResult() *result.Result {

--- a/pkg/config/checkbase.go
+++ b/pkg/config/checkbase.go
@@ -101,11 +101,6 @@ func (c *CheckBase) SetPerformRemediation(flag bool) {
 	c.PerformRemediation = flag
 }
 
-// AddRemediation appends a Remediation message to the result.
-func (c *CheckBase) AddRemediation(msg string) {
-	// c.Result.Remediations = append(c.Result.Remediations, msg)
-}
-
 // RunCheck contains the core logic for running the check,
 // generating the result and remediating breaches.
 // This is where c.Result should be populated.

--- a/pkg/config/checkbase.go
+++ b/pkg/config/checkbase.go
@@ -76,7 +76,6 @@ func (c *CheckBase) UnmarshalDataMap() {}
 
 // AddBreach appends a Breach to the Result and sets the Check as Fail.
 func (c *CheckBase) AddBreach(b result.Breach) {
-	c.Result.Status = result.Fail
 	b.SetCommonValues(string(c.cType), c.Name, string(c.Severity))
 	c.Result.Breaches = append(
 		c.Result.Breaches,
@@ -102,9 +101,9 @@ func (c *CheckBase) SetPerformRemediation(flag bool) {
 	c.PerformRemediation = flag
 }
 
-// AddWarning appends a Warning message to the result.
+// AddRemediation appends a Remediation message to the result.
 func (c *CheckBase) AddRemediation(msg string) {
-	c.Result.Remediations = append(c.Result.Remediations, msg)
+	// c.Result.Remediations = append(c.Result.Remediations, msg)
 }
 
 // RunCheck contains the core logic for running the check,
@@ -112,11 +111,6 @@ func (c *CheckBase) AddRemediation(msg string) {
 // This is where c.Result should be populated.
 func (c *CheckBase) RunCheck() {
 	c.AddBreach(&result.ValueBreach{Value: "not implemented"})
-}
-
-// GetResult returns a ref of the result.
-func (c *CheckBase) GetResult() *result.Result {
-	return &c.Result
 }
 
 // ShouldPerformRemediation returns whether to remediate or not.
@@ -128,3 +122,8 @@ func (c *CheckBase) ShouldPerformRemediation() bool {
 // Any type or custom struct can be used for the breach; it just needs to be
 // cast to the required type before being used.
 func (c *CheckBase) Remediate() {}
+
+// GetResult returns a ref of the result.
+func (c *CheckBase) GetResult() *result.Result {
+	return &c.Result
+}

--- a/pkg/config/checkbase_test.go
+++ b/pkg/config/checkbase_test.go
@@ -60,13 +60,25 @@ func TestHasData(t *testing.T) {
 
 	c := CheckBase{Name: "foo"}
 	assert.False(c.HasData(false))
+	assert.Empty(c.Result.Breaches)
+	c.Result.DetermineResultStatus(false)
 	assert.NotEqual(result.Fail, c.Result.Status)
 
 	assert.False(c.HasData(true))
+	assert.EqualValues([]result.Breach{
+		&result.ValueBreach{
+			BreachType: "value",
+			CheckName:  "foo",
+			Value:      "no data available",
+		},
+	}, c.Result.Breaches)
+	c.Result.DetermineResultStatus(false)
 	assert.Equal(result.Fail, c.Result.Status)
 
 	c = CheckBase{Name: "foo", DataMap: map[string][]byte{"foo": []byte(`bar`)}}
 	assert.True(c.HasData(true))
+	assert.Empty(c.Result.Breaches)
+	c.Result.DetermineResultStatus(false)
 	assert.NotEqual(result.Fail, c.Result.Status)
 }
 
@@ -141,8 +153,9 @@ func TestCheckBaseRunCheck(t *testing.T) {
 	c := CheckBase{}
 	c.FetchData()
 	c.RunCheck()
+	c.Result.DetermineResultStatus(false)
 	assert.Equal(result.Fail, c.Result.Status)
-	assert.ElementsMatch(
+	assert.EqualValues(
 		[]result.Breach{&result.ValueBreach{
 			BreachType: result.BreachTypeValue,
 			Value:      "not implemented",

--- a/pkg/config/checkbase_test.go
+++ b/pkg/config/checkbase_test.go
@@ -89,21 +89,21 @@ func TestAddBreach(t *testing.T) {
 			checkType: vbCheckType,
 			checkName: "vbCheck",
 			severity:  "high",
-			breach:    result.ValueBreach{},
+			breach:    &result.ValueBreach{},
 		},
 		{
 			name:      "KeyValueBreach",
 			checkType: kvbCheckType,
 			checkName: "kvbCheck",
 			severity:  "low",
-			breach:    result.KeyValueBreach{},
+			breach:    &result.KeyValueBreach{},
 		},
 		{
 			name:      "KeyValuesBreach",
 			checkType: kvsbCheckType,
 			checkName: "kvsbCheck",
 			severity:  "normal",
-			breach:    result.KeyValuesBreach{},
+			breach:    &result.KeyValuesBreach{},
 		},
 	}
 
@@ -112,9 +112,9 @@ func TestAddBreach(t *testing.T) {
 			c := CheckBase{Name: test.checkName, Severity: test.severity}
 			c.Init(test.checkType)
 			c.AddBreach(test.breach)
-			assert.Equal(string(test.checkType), result.BreachGetCheckType(c.Result.Breaches[0]))
-			assert.Equal(test.checkName, result.BreachGetCheckName(c.Result.Breaches[0]))
-			assert.Equal(string(test.severity), result.BreachGetSeverity(c.Result.Breaches[0]))
+			assert.Equal(string(test.checkType), c.Result.Breaches[0].GetCheckType())
+			assert.Equal(test.checkName, c.Result.Breaches[0].GetCheckName())
+			assert.Equal(string(test.severity), c.Result.Breaches[0].GetSeverity())
 		})
 	}
 }
@@ -143,7 +143,7 @@ func TestCheckBaseRunCheck(t *testing.T) {
 	c.RunCheck()
 	assert.Equal(result.Fail, c.Result.Status)
 	assert.ElementsMatch(
-		[]result.Breach{result.ValueBreach{
+		[]result.Breach{&result.ValueBreach{
 			BreachType: result.BreachTypeValue,
 			Value:      "not implemented",
 		}},

--- a/pkg/config/checkbase_test.go
+++ b/pkg/config/checkbase_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type testCheckForCheckBaseInit struct{}
-
 const testCheckForCheckBaseInitType CheckType = "testCheckForCheckBaseInitType"
 
 func TestCheckBaseInit(t *testing.T) {
@@ -167,8 +165,7 @@ func TestRemediate(t *testing.T) {
 	t.Run("notSupported", func(t *testing.T) {
 		c := testCheckRemediationNotSupported{}
 
-		err := c.Remediate(nil)
-		assert.NoError(err)
+		c.Remediate()
 		assert.Empty(c.Result.Passes)
 		assert.Empty(c.Result.Breaches)
 	})

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -46,7 +46,6 @@ type Check interface {
 	AddPass(msg string)
 	AddWarning(msg string)
 	SetPerformRemediation(flag bool)
-	AddRemediation(msg string)
 	RunCheck()
 	ShouldPerformRemediation() bool
 	Remediate()

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -49,7 +49,8 @@ type Check interface {
 	AddRemediation(msg string)
 	RunCheck()
 	GetResult() *result.Result
-	Remediate(breachIfc interface{}) error
+	ShouldPerformRemediation() bool
+	Remediate()
 }
 
 // CheckBase provides the basic structure for all Checks.

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -48,9 +48,9 @@ type Check interface {
 	SetPerformRemediation(flag bool)
 	AddRemediation(msg string)
 	RunCheck()
-	GetResult() *result.Result
 	ShouldPerformRemediation() bool
 	Remediate()
+	GetResult() *result.Result
 }
 
 // CheckBase provides the basic structure for all Checks.

--- a/pkg/internal/testutils_command.go
+++ b/pkg/internal/testutils_command.go
@@ -17,11 +17,18 @@ func (sc TestShellCommand) Output() ([]byte, error) {
 // ShellCommanderMaker is a commander generator that can return the provided
 // stdout or stderr, and can also update a given variable with the generated
 // command.
-func ShellCommanderMaker(out *string, err error, updateVar *string) func(name string, arg ...string) command.IShellCommand {
+func ShellCommanderMaker(out *string, err error, generatedCommand *string) func(name string, arg ...string) command.IShellCommand {
 	return func(name string, arg ...string) command.IShellCommand {
-		if updateVar != nil {
-			fullCmd := append([]string{name}, arg...)
-			*updateVar = strings.Join(fullCmd, " ")
+		if generatedCommand != nil {
+			fullCmd := name
+			for _, a := range arg {
+				// Add quotes when there are spaces.
+				if len(strings.Fields(a)) > 1 {
+					a = "'" + a + "'"
+				}
+				fullCmd += " " + a
+			}
+			*generatedCommand = fullCmd
 		}
 		var stdout []byte
 		if out != nil {

--- a/pkg/internal/testutils_fetchdata.go
+++ b/pkg/internal/testutils_fetchdata.go
@@ -18,7 +18,7 @@ type FetchDataTest struct {
 	// Initialise the check before testing.
 	Init bool
 	// Func to run before running the check
-	PreRun func(t *testing.T)
+	PreFetch func(t *testing.T)
 	// Expected values after running the check.
 	ExpectPasses     []string
 	ExpectBreaches   []result.Breach
@@ -31,6 +31,11 @@ type FetchDataTest struct {
 func TestFetchData(t *testing.T, ctest FetchDataTest) {
 	t.Helper()
 	assert := assert.New(t)
+
+	if ctest.PreFetch != nil {
+		ctest.PreFetch(t)
+	}
+
 	ctest.Check.FetchData()
 
 	r := ctest.Check.GetResult()

--- a/pkg/internal/testutils_fetchdata.go
+++ b/pkg/internal/testutils_fetchdata.go
@@ -20,11 +20,9 @@ type FetchDataTest struct {
 	// Func to run before running the check
 	PreFetch func(t *testing.T)
 	// Expected values after running the check.
-	ExpectPasses     []string
-	ExpectBreaches   []result.Breach
-	ExpectStatusFail bool
-	ExpectStatusPass bool
-	ExpectDataMap    map[string][]byte
+	ExpectPasses   []string
+	ExpectBreaches []result.Breach
+	ExpectDataMap  map[string][]byte
 }
 
 // TestFetchData can be used to run test scenarios in test tables.
@@ -39,15 +37,6 @@ func TestFetchData(t *testing.T, ctest FetchDataTest) {
 	ctest.Check.FetchData()
 
 	r := ctest.Check.GetResult()
-
-	if ctest.ExpectStatusFail {
-		assert.Equal(result.Fail, r.Status)
-	} else if ctest.ExpectStatusPass {
-		assert.Equal(result.Pass, r.Status)
-	} else {
-		assert.NotEqual(result.Fail, r.Status)
-		assert.NotEqual(result.Pass, r.Status)
-	}
 
 	if len(ctest.ExpectPasses) > 0 {
 		assert.ElementsMatch(ctest.ExpectPasses, r.Passes)

--- a/pkg/internal/testutils_fetchdata.go
+++ b/pkg/internal/testutils_fetchdata.go
@@ -1,0 +1,63 @@
+package internal
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/salsadigitalauorg/shipshape/pkg/config"
+	"github.com/salsadigitalauorg/shipshape/pkg/result"
+	"github.com/stretchr/testify/assert"
+)
+
+// FetchDataTest can be used to create test scenarios using test tables,
+// for the FetchData method using TestFetchData below.
+type FetchDataTest struct {
+	// Name of the test.
+	Name  string
+	Check config.Check
+	// Initialise the check before testing.
+	Init bool
+	// Func to run before running the check
+	PreRun func(t *testing.T)
+	// Expected values after running the check.
+	ExpectPasses     []string
+	ExpectBreaches   []result.Breach
+	ExpectStatusFail bool
+	ExpectStatusPass bool
+	ExpectDataMap    map[string][]byte
+}
+
+// TestFetchData can be used to run test scenarios in test tables.
+func TestFetchData(t *testing.T, ctest FetchDataTest) {
+	t.Helper()
+	assert := assert.New(t)
+	ctest.Check.FetchData()
+
+	r := ctest.Check.GetResult()
+
+	if ctest.ExpectStatusFail {
+		assert.Equal(result.Fail, r.Status)
+	} else if ctest.ExpectStatusPass {
+		assert.Equal(result.Pass, r.Status)
+	} else {
+		assert.NotEqual(result.Fail, r.Status)
+		assert.NotEqual(result.Pass, r.Status)
+	}
+
+	if len(ctest.ExpectPasses) > 0 {
+		assert.ElementsMatch(ctest.ExpectPasses, r.Passes)
+	} else {
+		assert.Empty(r.Passes)
+	}
+
+	if len(ctest.ExpectBreaches) > 0 {
+		assert.ElementsMatch(ctest.ExpectBreaches, r.Breaches)
+	} else {
+		assert.Empty(r.Breaches)
+	}
+
+	if ctest.ExpectDataMap != nil {
+		dataMap := reflect.ValueOf(ctest.Check).Elem().FieldByName("DataMap").Interface().(map[string][]byte)
+		assert.EqualValues(ctest.ExpectDataMap, dataMap)
+	}
+}

--- a/pkg/internal/testutils_remediate.go
+++ b/pkg/internal/testutils_remediate.go
@@ -1,0 +1,94 @@
+package internal
+
+import (
+	"io"
+	"testing"
+
+	"github.com/salsadigitalauorg/shipshape/pkg/command"
+	"github.com/salsadigitalauorg/shipshape/pkg/config"
+	"github.com/salsadigitalauorg/shipshape/pkg/result"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+// CheckTest can be used to create test scenarios, especially using test tables,
+// for the RunCheck method using TestRunCheck below.
+type RemediateTest struct {
+	// Name of the test.
+	Name     string
+	Check    config.Check
+	Breaches []result.Breach
+	// Func to run before running Remediate
+	PreRun func(t *testing.T)
+	// Expected values after running Remediate.
+	ExpectGeneratedCommand  string
+	ExpectStatusFail        bool
+	ExpectNoBreach          bool
+	ExpectBreaches          []result.Breach
+	ExpectRemediationStatus result.RemediationStatus
+	ExpectNoRemediations    bool
+	ExpectRemediations      []string
+}
+
+// TestRunCheck can be used to run test scenarios in test tables.
+func TestRemediate(t *testing.T, rt RemediateTest) {
+	t.Helper()
+	assert := assert.New(t)
+	// Hide logging output.
+	currLogOut := logrus.StandardLogger().Out
+	defer logrus.SetOutput(currLogOut)
+	logrus.SetOutput(io.Discard)
+
+	if rt.PreRun != nil {
+		rt.PreRun(t)
+	}
+
+	var generatedCommand string
+	if rt.ExpectGeneratedCommand != "" {
+		curShellCommander := command.ShellCommander
+		defer func() { command.ShellCommander = curShellCommander }()
+		command.ShellCommander = ShellCommanderMaker(nil, nil, &generatedCommand)
+	}
+	rt.Check.Remediate()
+	if rt.ExpectGeneratedCommand != "" {
+		assert.Equal(rt.ExpectGeneratedCommand, generatedCommand)
+	}
+
+	r := rt.Check.GetResult()
+	r.DetermineResultStatus(true)
+
+	if rt.ExpectStatusFail {
+		assert.Equal(result.Fail, r.Status)
+	}
+	if rt.ExpectNoBreach {
+		assert.Empty(r.Breaches)
+	} else {
+		assert.ElementsMatchf(
+			rt.ExpectBreaches,
+			r.Breaches,
+			"Expected breaches: %#v \nGot %#v", rt.ExpectBreaches, r.Breaches)
+	}
+
+	assert.Equal(rt.ExpectRemediationStatus, r.RemediationStatus)
+	if rt.ExpectNoRemediations {
+		assert.NotEmpty(r.Breaches)
+		remediationsFound := false
+		for _, b := range r.Breaches {
+			if b.GetRemediation().Status != "" {
+				remediationsFound = true
+				break
+			}
+		}
+		assert.False(remediationsFound, "Expected no remediations, but found some")
+	} else if len(rt.ExpectRemediations) > 0 {
+		assert.NotEmpty(r.Breaches)
+		remediationMsgs := []string{}
+		for _, b := range r.Breaches {
+			remediationMsgs = append(remediationMsgs, b.GetRemediation().Messages...)
+		}
+		assert.ElementsMatchf(
+			rt.ExpectRemediations,
+			remediationMsgs,
+			"Expected remediations: %#v \nGot %#v", rt.ExpectRemediations, remediationMsgs)
+	}
+}

--- a/pkg/lagoon/lagoon.go
+++ b/pkg/lagoon/lagoon.go
@@ -226,8 +226,8 @@ func BreachFactName(b result.Breach) string {
 	} else if result.BreachGetValueLabel(b) != "" {
 		name = result.BreachGetValueLabel(b)
 	} else {
-		name = result.BreachGetCheckName(b) + " - " +
-			string(result.BreachGetCheckType(b))
+		name = b.GetCheckName() + " - " +
+			string(b.GetCheckType())
 	}
 	return name
 }

--- a/pkg/lagoon/lagoon_test.go
+++ b/pkg/lagoon/lagoon_test.go
@@ -205,7 +205,7 @@ func TestBreachFactNameAndValue(t *testing.T) {
 	}{
 		{
 			name: "value breach - no label",
-			breach: result.ValueBreach{
+			breach: &result.ValueBreach{
 				CheckName: "illegal file",
 				CheckType: "file",
 				Value:     "/an/illegal/file",
@@ -215,7 +215,7 @@ func TestBreachFactNameAndValue(t *testing.T) {
 		},
 		{
 			name: "value breach - label",
-			breach: result.ValueBreach{
+			breach: &result.ValueBreach{
 				CheckName:  "illegal file",
 				CheckType:  "file",
 				ValueLabel: "the illegal file exists",
@@ -226,7 +226,7 @@ func TestBreachFactNameAndValue(t *testing.T) {
 		},
 		{
 			name: "key-value breach - with value label",
-			breach: result.KeyValueBreach{
+			breach: &result.KeyValueBreach{
 				CheckName:  "illegal file",
 				CheckType:  "file",
 				Key:        "illegal file found",
@@ -238,7 +238,7 @@ func TestBreachFactNameAndValue(t *testing.T) {
 		},
 		{
 			name: "key-value breach - with value and key labels",
-			breach: result.KeyValueBreach{
+			breach: &result.KeyValueBreach{
 				CheckName:  "illegal file",
 				CheckType:  "file",
 				KeyLabel:   "illegal file found in",
@@ -251,7 +251,7 @@ func TestBreachFactNameAndValue(t *testing.T) {
 		},
 		{
 			name: "value breach - with value and key labels and expected value",
-			breach: result.KeyValueBreach{
+			breach: &result.KeyValueBreach{
 				CheckName:     "update module status",
 				CheckType:     "module-status",
 				KeyLabel:      "disallowed module found",
@@ -264,7 +264,7 @@ func TestBreachFactNameAndValue(t *testing.T) {
 		},
 		{
 			name: "key-values breach - no label",
-			breach: result.KeyValuesBreach{
+			breach: &result.KeyValuesBreach{
 				CheckName: "illegal files",
 				CheckType: "file",
 				Values:    []string{"/an/illegal/file", "/another/illegal/file"},

--- a/pkg/result/breach.go
+++ b/pkg/result/breach.go
@@ -9,6 +9,7 @@ import (
 type Breach interface {
 	GetCheckName() string
 	GetCheckType() string
+	GetRemediation() *Remediation
 	GetSeverity() string
 	GetType() BreachType
 	SetCommonValues(checkType string, checkName string, severity string)
@@ -26,6 +27,8 @@ const (
 	BreachTypeKeyValues BreachType = "key-values"
 )
 
+//go:generate go run ../../cmd/gen.go breach-type --type=Value,KeyValue,KeyValues
+
 // Simple breach with no key.
 // Example:
 //
@@ -38,29 +41,7 @@ type ValueBreach struct {
 	ValueLabel    string
 	Value         string
 	ExpectedValue string
-}
-
-func (b *ValueBreach) GetCheckName() string {
-	return b.CheckName
-}
-
-func (b *ValueBreach) GetCheckType() string {
-	return b.CheckType
-}
-
-func (b *ValueBreach) GetSeverity() string {
-	return b.Severity
-}
-
-func (b *ValueBreach) GetType() BreachType {
-	return BreachTypeValue
-}
-
-func (b *ValueBreach) SetCommonValues(checkType string, checkName string, severity string) {
-	b.BreachType = b.GetType()
-	b.CheckType = checkType
-	b.CheckName = checkName
-	b.Severity = severity
+	Remediation
 }
 
 func (b ValueBreach) String() string {
@@ -88,29 +69,7 @@ type KeyValueBreach struct {
 	ValueLabel    string
 	Value         string
 	ExpectedValue string
-}
-
-func (b *KeyValueBreach) GetCheckName() string {
-	return b.CheckName
-}
-
-func (b *KeyValueBreach) GetCheckType() string {
-	return b.CheckType
-}
-
-func (b *KeyValueBreach) GetType() BreachType {
-	return BreachTypeKeyValue
-}
-
-func (b *KeyValueBreach) GetSeverity() string {
-	return b.Severity
-}
-
-func (b *KeyValueBreach) SetCommonValues(checkType string, checkName string, severity string) {
-	b.BreachType = b.GetType()
-	b.CheckType = checkType
-	b.CheckName = checkName
-	b.Severity = severity
+	Remediation
 }
 
 func (b KeyValueBreach) String() string {
@@ -137,29 +96,7 @@ type KeyValuesBreach struct {
 	Key        string
 	ValueLabel string
 	Values     []string
-}
-
-func (b *KeyValuesBreach) GetCheckName() string {
-	return b.CheckName
-}
-
-func (b *KeyValuesBreach) GetCheckType() string {
-	return b.CheckType
-}
-
-func (b *KeyValuesBreach) GetSeverity() string {
-	return b.Severity
-}
-
-func (b *KeyValuesBreach) GetType() BreachType {
-	return BreachTypeKeyValues
-}
-
-func (b *KeyValuesBreach) SetCommonValues(checkType string, checkName string, severity string) {
-	b.BreachType = b.GetType()
-	b.CheckType = checkType
-	b.CheckName = checkName
-	b.Severity = severity
+	Remediation
 }
 
 func (b KeyValuesBreach) String() string {

--- a/pkg/result/breach.go
+++ b/pkg/result/breach.go
@@ -7,6 +7,11 @@ import (
 
 // Breach provides a representation for different breach types.
 type Breach interface {
+	GetCheckName() string
+	GetCheckType() string
+	GetSeverity() string
+	GetType() BreachType
+	SetCommonValues(checkType string, checkName string, severity string)
 	String() string
 }
 
@@ -35,11 +40,34 @@ type ValueBreach struct {
 	ExpectedValue string
 }
 
+func (b *ValueBreach) GetCheckName() string {
+	return b.CheckName
+}
+
+func (b *ValueBreach) GetCheckType() string {
+	return b.CheckType
+}
+
+func (b *ValueBreach) GetSeverity() string {
+	return b.Severity
+}
+
+func (b *ValueBreach) GetType() BreachType {
+	return BreachTypeValue
+}
+
+func (b *ValueBreach) SetCommonValues(checkType string, checkName string, severity string) {
+	b.BreachType = b.GetType()
+	b.CheckType = checkType
+	b.CheckName = checkName
+	b.Severity = severity
+}
+
 func (b ValueBreach) String() string {
 	if b.ValueLabel != "" {
 		return fmt.Sprintf("[%s] %s", b.ValueLabel, b.Value)
 	}
-	return fmt.Sprintf("%s", b.Value)
+	return b.Value
 }
 
 // Breach with key and value.
@@ -60,6 +88,29 @@ type KeyValueBreach struct {
 	ValueLabel    string
 	Value         string
 	ExpectedValue string
+}
+
+func (b *KeyValueBreach) GetCheckName() string {
+	return b.CheckName
+}
+
+func (b *KeyValueBreach) GetCheckType() string {
+	return b.CheckType
+}
+
+func (b *KeyValueBreach) GetType() BreachType {
+	return BreachTypeKeyValue
+}
+
+func (b *KeyValueBreach) GetSeverity() string {
+	return b.Severity
+}
+
+func (b *KeyValueBreach) SetCommonValues(checkType string, checkName string, severity string) {
+	b.BreachType = b.GetType()
+	b.CheckType = checkType
+	b.CheckName = checkName
+	b.Severity = severity
 }
 
 func (b KeyValueBreach) String() string {
@@ -88,6 +139,29 @@ type KeyValuesBreach struct {
 	Values     []string
 }
 
+func (b *KeyValuesBreach) GetCheckName() string {
+	return b.CheckName
+}
+
+func (b *KeyValuesBreach) GetCheckType() string {
+	return b.CheckType
+}
+
+func (b *KeyValuesBreach) GetSeverity() string {
+	return b.Severity
+}
+
+func (b *KeyValuesBreach) GetType() BreachType {
+	return BreachTypeKeyValues
+}
+
+func (b *KeyValuesBreach) SetCommonValues(checkType string, checkName string, severity string) {
+	b.BreachType = b.GetType()
+	b.CheckType = checkType
+	b.CheckName = checkName
+	b.Severity = severity
+}
+
 func (b KeyValuesBreach) String() string {
 	if b.KeyLabel != "" && b.ValueLabel != "" {
 		return fmt.Sprintf("[%s:%s] %s: %s", b.KeyLabel, b.Key, b.ValueLabel,
@@ -96,121 +170,55 @@ func (b KeyValuesBreach) String() string {
 	return fmt.Sprintf("%s: %s", b.Key, "["+strings.Join(b.Values, ", ")+"]")
 }
 
-func BreachSetCommonValues(bIfc *Breach, checkType string, checkName string, severity string) {
-	if b, ok := (*bIfc).(ValueBreach); ok {
-		b.BreachType = BreachTypeValue
-		b.CheckType = checkType
-		b.CheckName = checkName
-		b.Severity = severity
-		*bIfc = b
-	} else if b, ok := (*bIfc).(KeyValueBreach); ok {
-		b.BreachType = BreachTypeKeyValue
-		b.CheckType = checkType
-		b.CheckName = checkName
-		b.Severity = severity
-		*bIfc = b
-	} else if b, ok := (*bIfc).(KeyValuesBreach); ok {
-		b.BreachType = BreachTypeKeyValues
-		b.CheckType = checkType
-		b.CheckName = checkName
-		b.Severity = severity
-		*bIfc = b
-	}
-}
-
-func BreachGetBreachType(bIfc Breach) BreachType {
-	if _, ok := bIfc.(ValueBreach); ok {
-		return BreachTypeValue
-	} else if _, ok := bIfc.(KeyValueBreach); ok {
-		return BreachTypeKeyValue
-	} else if _, ok := bIfc.(KeyValuesBreach); ok {
-		return BreachTypeKeyValues
-	}
-	return ""
-}
-
-func BreachGetCheckType(bIfc Breach) string {
-	if b, ok := bIfc.(ValueBreach); ok {
-		return b.CheckType
-	} else if b, ok := bIfc.(KeyValueBreach); ok {
-		return b.CheckType
-	} else if b, ok := bIfc.(KeyValuesBreach); ok {
-		return b.CheckType
-	}
-	return ""
-}
-
-func BreachGetCheckName(bIfc Breach) string {
-	if b, ok := bIfc.(ValueBreach); ok {
-		return b.CheckName
-	} else if b, ok := bIfc.(KeyValueBreach); ok {
-		return b.CheckName
-	} else if b, ok := bIfc.(KeyValuesBreach); ok {
-		return b.CheckName
-	}
-	return ""
-}
-
-func BreachGetSeverity(bIfc Breach) string {
-	if b, ok := bIfc.(ValueBreach); ok {
-		return b.Severity
-	} else if b, ok := bIfc.(KeyValueBreach); ok {
-		return b.Severity
-	} else if b, ok := bIfc.(KeyValuesBreach); ok {
-		return b.Severity
-	}
-	return ""
-}
-
 func BreachGetKeyLabel(bIfc Breach) string {
-	if b, ok := bIfc.(KeyValueBreach); ok {
+	if b, ok := bIfc.(*KeyValueBreach); ok {
 		return b.KeyLabel
-	} else if b, ok := bIfc.(KeyValuesBreach); ok {
+	} else if b, ok := bIfc.(*KeyValuesBreach); ok {
 		return b.KeyLabel
 	}
 	return ""
 }
 
 func BreachGetKey(bIfc Breach) string {
-	if b, ok := bIfc.(KeyValueBreach); ok {
+	if b, ok := bIfc.(*KeyValueBreach); ok {
 		return b.Key
-	} else if b, ok := bIfc.(KeyValuesBreach); ok {
+	} else if b, ok := bIfc.(*KeyValuesBreach); ok {
 		return b.Key
 	}
 	return ""
 }
 
 func BreachGetValueLabel(bIfc Breach) string {
-	if b, ok := bIfc.(ValueBreach); ok {
+	if b, ok := bIfc.(*ValueBreach); ok {
 		return b.ValueLabel
-	} else if b, ok := bIfc.(KeyValueBreach); ok {
+	} else if b, ok := bIfc.(*KeyValueBreach); ok {
 		return b.ValueLabel
-	} else if b, ok := bIfc.(KeyValuesBreach); ok {
+	} else if b, ok := bIfc.(*KeyValuesBreach); ok {
 		return b.ValueLabel
 	}
 	return ""
 }
 
 func BreachGetValue(bIfc Breach) string {
-	if b, ok := bIfc.(ValueBreach); ok {
+	if b, ok := bIfc.(*ValueBreach); ok {
 		return b.Value
-	} else if b, ok := bIfc.(KeyValueBreach); ok {
+	} else if b, ok := bIfc.(*KeyValueBreach); ok {
 		return b.Value
 	}
 	return ""
 }
 
 func BreachGetValues(bIfc Breach) []string {
-	if b, ok := bIfc.(KeyValuesBreach); ok {
+	if b, ok := bIfc.(*KeyValuesBreach); ok {
 		return b.Values
 	}
 	return []string(nil)
 }
 
 func BreachGetExpectedValue(bIfc Breach) string {
-	if b, ok := bIfc.(ValueBreach); ok {
+	if b, ok := bIfc.(*ValueBreach); ok {
 		return b.ExpectedValue
-	} else if b, ok := bIfc.(KeyValueBreach); ok {
+	} else if b, ok := bIfc.(*KeyValueBreach); ok {
 		return b.ExpectedValue
 	}
 	return ""

--- a/pkg/result/breach.go
+++ b/pkg/result/breach.go
@@ -13,6 +13,7 @@ type Breach interface {
 	GetSeverity() string
 	GetType() BreachType
 	SetCommonValues(checkType string, checkName string, severity string)
+	SetRemediation(status RemediationStatus, msg string)
 	String() string
 }
 

--- a/pkg/result/breach_test.go
+++ b/pkg/result/breach_test.go
@@ -18,7 +18,7 @@ func TestBreachValueBreachStringer(t *testing.T) {
 	}{
 		{
 			name: "value-breach",
-			breach: ValueBreach{
+			breach: &ValueBreach{
 				ValueLabel: "file not found",
 				Value:      "foo.ext",
 			},
@@ -43,7 +43,7 @@ func TestBreachKeyValueBreachStringer(t *testing.T) {
 	}{
 		{
 			name: "key-value-breach-1",
-			breach: KeyValueBreach{
+			breach: &KeyValueBreach{
 				KeyLabel:   "config",
 				Key:        "clamav.settings",
 				ValueLabel: "key not found",
@@ -53,7 +53,7 @@ func TestBreachKeyValueBreachStringer(t *testing.T) {
 		},
 		{
 			name: "key-value-breach-2",
-			breach: KeyValueBreach{
+			breach: &KeyValueBreach{
 				KeyLabel:      "clamav.settings",
 				Key:           "enabled",
 				Value:         "false",
@@ -80,7 +80,7 @@ func TestBreachKeyValuesBreachStringers(t *testing.T) {
 	}{
 		{
 			name: "KeyValuesBreach",
-			breach: KeyValuesBreach{
+			breach: &KeyValuesBreach{
 				KeyLabel:   "role",
 				Key:        "admin",
 				ValueLabel: "disallowed permissions",
@@ -98,6 +98,25 @@ func TestBreachKeyValuesBreachStringers(t *testing.T) {
 }
 
 type bogusBreach struct{}
+
+func (b bogusBreach) GetCheckName() string {
+	return ""
+}
+
+func (b bogusBreach) GetCheckType() string {
+	return ""
+}
+
+func (b bogusBreach) GetSeverity() string {
+	return ""
+}
+
+func (b bogusBreach) GetType() BreachType {
+	return ""
+}
+
+func (b bogusBreach) SetCommonValues(checkType string, checkName string, severity string) {
+}
 
 func (b bogusBreach) String() string {
 	return ""
@@ -117,7 +136,7 @@ func TestBreachSetCommonValues(t *testing.T) {
 	}{
 		{
 			name:               "ValueBreach",
-			breach:             ValueBreach{},
+			breach:             &ValueBreach{},
 			expectedBreachType: BreachTypeValue,
 			expectedCheckType:  "ctvb",
 			expectedCheckName:  "valuebreachcheck",
@@ -125,7 +144,7 @@ func TestBreachSetCommonValues(t *testing.T) {
 		},
 		{
 			name:               "KeyValueBreach",
-			breach:             KeyValueBreach{},
+			breach:             &KeyValueBreach{},
 			expectedBreachType: BreachTypeKeyValue,
 			expectedCheckType:  "ctkvb",
 			expectedCheckName:  "keyvaluebreachcheck",
@@ -133,7 +152,7 @@ func TestBreachSetCommonValues(t *testing.T) {
 		},
 		{
 			name:               "KeyValuesBreach",
-			breach:             KeyValuesBreach{},
+			breach:             &KeyValuesBreach{},
 			expectedBreachType: BreachTypeKeyValues,
 			expectedCheckType:  "ctkvsb",
 			expectedCheckName:  "keyvaluesbreachcheck",
@@ -141,7 +160,7 @@ func TestBreachSetCommonValues(t *testing.T) {
 		},
 		{
 			name:               "BogusBreach",
-			breach:             bogusBreach{},
+			breach:             &bogusBreach{},
 			expectedBreachType: "",
 			expectedCheckType:  "ctbb",
 			expectedCheckName:  "bogusbreachcheck",
@@ -152,18 +171,18 @@ func TestBreachSetCommonValues(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			BreachSetCommonValues(&test.breach, test.expectedCheckType, test.expectedCheckName,
+			test.breach.SetCommonValues(test.expectedCheckType, test.expectedCheckName,
 				test.expectedSeverity)
 			if !test.empty {
-				assert.Equal(test.expectedBreachType, BreachGetBreachType(test.breach))
-				assert.Equal(test.expectedCheckName, BreachGetCheckName(test.breach))
-				assert.Equal(test.expectedCheckType, BreachGetCheckType(test.breach))
-				assert.Equal(test.expectedSeverity, BreachGetSeverity(test.breach))
+				assert.Equal(test.expectedBreachType, test.breach.GetType())
+				assert.Equal(test.expectedCheckName, test.breach.GetCheckName())
+				assert.Equal(test.expectedCheckType, test.breach.GetCheckType())
+				assert.Equal(test.expectedSeverity, test.breach.GetSeverity())
 			} else {
-				assert.Equal(BreachType(""), BreachGetBreachType(test.breach))
-				assert.Equal("", BreachGetCheckName(test.breach))
-				assert.Equal("", BreachGetCheckType(test.breach))
-				assert.Equal("", BreachGetSeverity(test.breach))
+				assert.Equal(BreachType(""), test.breach.GetType())
+				assert.Equal("", test.breach.GetCheckName())
+				assert.Equal("", test.breach.GetCheckType())
+				assert.Equal("", test.breach.GetSeverity())
 			}
 		})
 	}
@@ -184,7 +203,7 @@ func TestBreachGetters(t *testing.T) {
 	}{
 		{
 			name: "ValueBreach",
-			breach: ValueBreach{
+			breach: &ValueBreach{
 				ValueLabel:    "vbvl",
 				Value:         "vbv",
 				ExpectedValue: "vbve",
@@ -198,7 +217,7 @@ func TestBreachGetters(t *testing.T) {
 		},
 		{
 			name: "KeyValueBreach",
-			breach: KeyValueBreach{
+			breach: &KeyValueBreach{
 				KeyLabel:      "kvbklbl",
 				Key:           "kvbk",
 				ValueLabel:    "kvbvl",
@@ -214,7 +233,7 @@ func TestBreachGetters(t *testing.T) {
 		},
 		{
 			name: "KeyValuesBreach",
-			breach: KeyValuesBreach{
+			breach: &KeyValuesBreach{
 				KeyLabel:   "kvsbklbl",
 				Key:        "kvsbk",
 				ValueLabel: "kvsbvl",

--- a/pkg/result/breach_test.go
+++ b/pkg/result/breach_test.go
@@ -107,6 +107,10 @@ func (b bogusBreach) GetCheckType() string {
 	return ""
 }
 
+func (b bogusBreach) GetRemediation() *Remediation {
+	return &Remediation{}
+}
+
 func (b bogusBreach) GetSeverity() string {
 	return ""
 }

--- a/pkg/result/breach_test.go
+++ b/pkg/result/breach_test.go
@@ -126,6 +126,8 @@ func (b bogusBreach) String() string {
 	return ""
 }
 
+func (b bogusBreach) SetRemediation(status RemediationStatus, msg string) {}
+
 func TestBreachSetCommonValues(t *testing.T) {
 	assert := assert.New(t)
 

--- a/pkg/result/remediation.go
+++ b/pkg/result/remediation.go
@@ -1,0 +1,15 @@
+package result
+
+type RemediationStatus string
+
+const (
+	RemediationStatusNoSupport RemediationStatus = "no-support"
+	RemediationStatusSuccess   RemediationStatus = "success"
+	RemediationStatusFailed    RemediationStatus = "failed"
+	RemediationStatusPartial   RemediationStatus = "partial"
+)
+
+type Remediation struct {
+	Status   RemediationStatus
+	Messages []string
+}

--- a/pkg/result/result.go
+++ b/pkg/result/result.go
@@ -13,14 +13,14 @@ const (
 
 // Result provides the structure for a Check's outcome.
 type Result struct {
-	Name         string   `json:"name"`
-	Severity     string   `json:"severity"`
-	CheckType    string   `json:"check-type"`
-	Status       Status   `json:"status"`
-	Passes       []string `json:"passes"`
-	Breaches     []Breach `json:"breaches"`
-	Warnings     []string `json:"warnings"`
-	Remediations []string `json:"remediations"`
+	Name              string            `json:"name"`
+	Severity          string            `json:"severity"`
+	CheckType         string            `json:"check-type"`
+	Passes            []string          `json:"passes"`
+	Breaches          []Breach          `json:"breaches"`
+	Warnings          []string          `json:"warnings"`
+	Status            Status            `json:"status"`
+	RemediationStatus RemediationStatus `json:"remediation-status"`
 }
 
 // Sort reorders the Passes & Failures in order to get consistent output.
@@ -42,4 +42,62 @@ func (r *Result) Sort() {
 			return r.Warnings[i] < r.Warnings[j]
 		})
 	}
+}
+
+// RemediationsCount returns the number of unsupported, successful, failed and
+// partial for all attempted remediations.
+func (r *Result) RemediationsCount() (uint32, uint32, uint32, uint32) {
+	unsupported := uint32(0)
+	successful := uint32(0)
+	failed := uint32(0)
+	partial := uint32(0)
+	for _, b := range r.Breaches {
+		switch b.GetRemediation().Status {
+		case RemediationStatusNoSupport:
+			unsupported++
+		case RemediationStatusSuccess:
+			successful++
+		case RemediationStatusFailed:
+			failed++
+		case RemediationStatusPartial:
+			partial++
+		}
+	}
+	return unsupported, successful, failed, partial
+}
+
+// DetermineResultStatus determines the overall status of the result based on
+// the breaches and remediation status.
+func (r *Result) DetermineResultStatus(remediationPerformed bool) {
+	r.Sort()
+
+	// Remediation status.
+	if remediationPerformed {
+		unsupported, success, failed, partial := r.RemediationsCount()
+		if partial > 0 || (success > 0 && (failed > 0 || unsupported > 0)) {
+			r.RemediationStatus = RemediationStatusPartial
+			r.Status = Fail
+			return
+		}
+		if unsupported > 0 && success == 0 && failed == 0 && partial == 0 {
+			r.RemediationStatus = RemediationStatusNoSupport
+			r.Status = Fail
+			return
+		}
+		if failed > 0 && success == 0 && unsupported == 0 && partial == 0 {
+			r.RemediationStatus = RemediationStatusFailed
+			r.Status = Fail
+			return
+		}
+		r.RemediationStatus = RemediationStatusSuccess
+		r.Status = Pass
+		return
+	}
+
+	// Overall status.
+	if len(r.Breaches) > 0 {
+		r.Status = Fail
+		return
+	}
+	r.Status = Pass
 }

--- a/pkg/result/result.go
+++ b/pkg/result/result.go
@@ -27,7 +27,7 @@ type Result struct {
 func (r *Result) Sort() {
 	if len(r.Breaches) > 0 {
 		sort.Slice(r.Breaches, func(i int, j int) bool {
-			return BreachGetCheckName(r.Breaches[i]) < BreachGetCheckName(r.Breaches[j])
+			return r.Breaches[i].GetCheckName() < r.Breaches[j].GetCheckName()
 		})
 	}
 

--- a/pkg/result/result_test.go
+++ b/pkg/result/result_test.go
@@ -14,10 +14,10 @@ func TestResultSort(t *testing.T) {
 	r := Result{
 		Passes: []string{"z pass", "g pass", "a pass", "b pass"},
 		Breaches: []Breach{
-			ValueBreach{CheckName: "x", Value: "breach 1"},
-			ValueBreach{CheckName: "h", Value: "breach 2"},
-			ValueBreach{CheckName: "v", Value: "breach 3"},
-			ValueBreach{CheckName: "f", Value: "breach 4"},
+			&ValueBreach{CheckName: "x", Value: "breach 1"},
+			&ValueBreach{CheckName: "h", Value: "breach 2"},
+			&ValueBreach{CheckName: "v", Value: "breach 3"},
+			&ValueBreach{CheckName: "f", Value: "breach 4"},
 		},
 		Warnings: []string{"y warn", "i warn", "u warn", "c warn"},
 	}
@@ -26,10 +26,10 @@ func TestResultSort(t *testing.T) {
 	assert.EqualValues(Result{
 		Passes: []string{"a pass", "b pass", "g pass", "z pass"},
 		Breaches: []Breach{
-			ValueBreach{CheckName: "f", Value: "breach 4"},
-			ValueBreach{CheckName: "h", Value: "breach 2"},
-			ValueBreach{CheckName: "v", Value: "breach 3"},
-			ValueBreach{CheckName: "x", Value: "breach 1"},
+			&ValueBreach{CheckName: "f", Value: "breach 4"},
+			&ValueBreach{CheckName: "h", Value: "breach 2"},
+			&ValueBreach{CheckName: "v", Value: "breach 3"},
+			&ValueBreach{CheckName: "x", Value: "breach 1"},
 		},
 		Warnings: []string{"c warn", "i warn", "u warn", "y warn"},
 	}, r)

--- a/pkg/result/result_test.go
+++ b/pkg/result/result_test.go
@@ -34,3 +34,249 @@ func TestResultSort(t *testing.T) {
 		Warnings: []string{"c warn", "i warn", "u warn", "y warn"},
 	}, r)
 }
+
+func TestResultRemediationsCount(t *testing.T) {
+	assert := assert.New(t)
+
+	r := Result{
+		Breaches: []Breach{
+			&ValueBreach{CheckName: "x", Remediation: Remediation{Status: RemediationStatusNoSupport}},
+			&ValueBreach{CheckName: "h", Remediation: Remediation{Status: RemediationStatusSuccess}},
+			&ValueBreach{CheckName: "i", Remediation: Remediation{Status: RemediationStatusSuccess}},
+			&ValueBreach{CheckName: "v", Remediation: Remediation{Status: RemediationStatusFailed}},
+			&ValueBreach{CheckName: "w", Remediation: Remediation{Status: RemediationStatusFailed}},
+			&ValueBreach{CheckName: "x", Remediation: Remediation{Status: RemediationStatusFailed}},
+			&ValueBreach{CheckName: "f", Remediation: Remediation{Status: RemediationStatusPartial}},
+			&ValueBreach{CheckName: "e", Remediation: Remediation{Status: RemediationStatusPartial}},
+			&ValueBreach{CheckName: "d", Remediation: Remediation{Status: RemediationStatusPartial}},
+			&ValueBreach{CheckName: "c", Remediation: Remediation{Status: RemediationStatusPartial}},
+		},
+	}
+	unsupported, successful, failed, partial := r.RemediationsCount()
+	assert.EqualValues(1, unsupported)
+	assert.EqualValues(2, successful)
+	assert.EqualValues(3, failed)
+	assert.EqualValues(4, partial)
+}
+
+func TestResultDetermineResultStatus(t *testing.T) {
+	tt := []struct {
+		name                      string
+		remediationPerformed      bool
+		breaches                  []Breach
+		expectedStatus            Status
+		expectedRemediationStatus RemediationStatus
+	}{
+		{
+			name:                      "noBreach",
+			remediationPerformed:      false,
+			breaches:                  []Breach{},
+			expectedStatus:            Pass,
+			expectedRemediationStatus: "",
+		},
+		{
+			name:                      "noBreachRemediation",
+			remediationPerformed:      true,
+			breaches:                  []Breach{},
+			expectedStatus:            Pass,
+			expectedRemediationStatus: RemediationStatusSuccess,
+		},
+
+		// Single breach.
+		{
+			name:                 "singleBreach",
+			remediationPerformed: false,
+			breaches: []Breach{
+				&ValueBreach{CheckName: "x", Value: "breach 1"},
+			},
+			expectedStatus:            Fail,
+			expectedRemediationStatus: "",
+		},
+		{
+			name:                 "singleBreachRemediationNotSupported",
+			remediationPerformed: true,
+			breaches: []Breach{
+				&ValueBreach{
+					CheckName:   "x",
+					Value:       "breach 1",
+					Remediation: Remediation{Status: RemediationStatusNoSupport},
+				},
+			},
+			expectedStatus:            Fail,
+			expectedRemediationStatus: RemediationStatusNoSupport,
+		},
+		{
+			name:                 "singleBreachRemediationSuccess",
+			remediationPerformed: true,
+			breaches: []Breach{
+				&ValueBreach{
+					CheckName:   "x",
+					Value:       "breach 1",
+					Remediation: Remediation{Status: RemediationStatusSuccess},
+				},
+			},
+			expectedStatus:            Pass,
+			expectedRemediationStatus: RemediationStatusSuccess,
+		},
+		{
+			name:                 "singleBreachRemediationFailed",
+			remediationPerformed: true,
+			breaches: []Breach{
+				&ValueBreach{
+					CheckName:   "x",
+					Value:       "breach 1",
+					Remediation: Remediation{Status: RemediationStatusFailed},
+				},
+			},
+			expectedStatus:            Fail,
+			expectedRemediationStatus: RemediationStatusFailed,
+		},
+		{
+			name:                 "singleBreachRemediationPartial",
+			remediationPerformed: true,
+			breaches: []Breach{
+				&ValueBreach{
+					CheckName:   "x",
+					Value:       "breach 1",
+					Remediation: Remediation{Status: RemediationStatusPartial},
+				},
+			},
+			expectedStatus:            Fail,
+			expectedRemediationStatus: RemediationStatusPartial,
+		},
+
+		// Multiple breaches.
+		{
+			name:                 "multipleBreaches",
+			remediationPerformed: false,
+			breaches: []Breach{
+				&ValueBreach{CheckName: "x", Value: "breach 1"},
+				&ValueBreach{CheckName: "f", Value: "breach 2"},
+			},
+			expectedStatus:            Fail,
+			expectedRemediationStatus: "",
+		},
+		{
+			name:                 "multipleBreachesRemediationFailed",
+			remediationPerformed: true,
+			breaches: []Breach{
+				&ValueBreach{
+					CheckName:   "x",
+					Value:       "breach 1",
+					Remediation: Remediation{Status: RemediationStatusFailed},
+				},
+				&ValueBreach{
+					CheckName:   "f",
+					Value:       "breach 2",
+					Remediation: Remediation{Status: RemediationStatusFailed},
+				},
+			},
+			expectedStatus:            Fail,
+			expectedRemediationStatus: RemediationStatusFailed,
+		},
+		{
+			name:                 "multipleBreachesRemediationUnsupported",
+			remediationPerformed: true,
+			breaches: []Breach{
+				&ValueBreach{
+					CheckName:   "x",
+					Value:       "breach 1",
+					Remediation: Remediation{Status: RemediationStatusNoSupport},
+				},
+				&ValueBreach{
+					CheckName:   "f",
+					Value:       "breach 2",
+					Remediation: Remediation{Status: RemediationStatusNoSupport},
+				},
+			},
+			expectedStatus:            Fail,
+			expectedRemediationStatus: RemediationStatusNoSupport,
+		},
+
+		// Multiple breaches with partial remediation.
+		{
+			name:                 "multipleBreachesRemediationPartial",
+			remediationPerformed: true,
+			breaches: []Breach{
+				&ValueBreach{
+					CheckName:   "x",
+					Value:       "breach 1",
+					Remediation: Remediation{Status: RemediationStatusSuccess},
+				},
+				&ValueBreach{
+					CheckName:   "f",
+					Value:       "breach 2",
+					Remediation: Remediation{Status: RemediationStatusFailed},
+				},
+			},
+			expectedStatus:            Fail,
+			expectedRemediationStatus: RemediationStatusPartial,
+		},
+		{
+			name:                 "multipleBreachesRemediationPartial",
+			remediationPerformed: true,
+			breaches: []Breach{
+				&ValueBreach{
+					CheckName:   "x",
+					Value:       "breach 1",
+					Remediation: Remediation{Status: RemediationStatusSuccess},
+				},
+				&ValueBreach{
+					CheckName:   "f",
+					Value:       "breach 2",
+					Remediation: Remediation{Status: RemediationStatusFailed},
+				},
+			},
+			expectedStatus:            Fail,
+			expectedRemediationStatus: RemediationStatusPartial,
+		},
+		{
+			name:                 "multipleBreachesRemediationPartial",
+			remediationPerformed: true,
+			breaches: []Breach{
+				&ValueBreach{
+					CheckName:   "x",
+					Value:       "breach 1",
+					Remediation: Remediation{Status: RemediationStatusPartial},
+				},
+				&ValueBreach{
+					CheckName:   "f",
+					Value:       "breach 2",
+					Remediation: Remediation{Status: RemediationStatusPartial},
+				},
+			},
+			expectedStatus:            Fail,
+			expectedRemediationStatus: RemediationStatusPartial,
+		},
+		{
+			name:                 "multipleBreachesRemediationPartial",
+			remediationPerformed: true,
+			breaches: []Breach{
+				&ValueBreach{
+					CheckName:   "x",
+					Value:       "breach 1",
+					Remediation: Remediation{Status: RemediationStatusSuccess},
+				},
+				&ValueBreach{
+					CheckName:   "f",
+					Value:       "breach 2",
+					Remediation: Remediation{Status: RemediationStatusNoSupport},
+				},
+			},
+			expectedStatus:            Fail,
+			expectedRemediationStatus: RemediationStatusPartial,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			r := Result{Breaches: tc.breaches}
+			r.DetermineResultStatus(tc.remediationPerformed)
+
+			assert.Equal(tc.expectedStatus, r.Status)
+			assert.Equal(tc.expectedRemediationStatus, r.RemediationStatus)
+		})
+	}
+}

--- a/pkg/result/resultlist.go
+++ b/pkg/result/resultlist.go
@@ -90,19 +90,19 @@ func (rl *ResultList) RemediationStatus() RemediationStatus {
 	}
 
 	if rl.RemediationTotals["partial"] > 0 ||
-		(rl.RemediationTotals["success"] > 0 &&
+		(rl.RemediationTotals["successful"] > 0 &&
 			(rl.RemediationTotals["failed"] > 0 ||
 				rl.RemediationTotals["unsupported"] > 0)) {
 		return RemediationStatusPartial
 	}
 	if rl.RemediationTotals["unsupported"] > 0 &&
-		rl.RemediationTotals["success"] == 0 &&
+		rl.RemediationTotals["successful"] == 0 &&
 		rl.RemediationTotals["failed"] == 0 &&
 		rl.RemediationTotals["partial"] == 0 {
 		return RemediationStatusNoSupport
 	}
 	if rl.RemediationTotals["failed"] > 0 &&
-		rl.RemediationTotals["success"] == 0 &&
+		rl.RemediationTotals["successful"] == 0 &&
 		rl.RemediationTotals["unsupported"] == 0 &&
 		rl.RemediationTotals["partial"] == 0 {
 		return RemediationStatusFailed

--- a/pkg/result/resultlist_test.go
+++ b/pkg/result/resultlist_test.go
@@ -99,11 +99,11 @@ func TestResultListAddResult(t *testing.T) {
 		Severity:  "high",
 		CheckType: string(testCheckType),
 		Breaches: []Breach{
-			ValueBreach{Value: "fail1"},
-			ValueBreach{Value: "fail2"},
-			ValueBreach{Value: "fail3"},
-			ValueBreach{Value: "fail4"},
-			ValueBreach{Value: "fail5"},
+			&ValueBreach{Value: "fail1"},
+			&ValueBreach{Value: "fail2"},
+			&ValueBreach{Value: "fail3"},
+			&ValueBreach{Value: "fail4"},
+			&ValueBreach{Value: "fail5"},
 		},
 		Remediations: []string{"fixed1"},
 	})
@@ -117,11 +117,11 @@ func TestResultListAddResult(t *testing.T) {
 		Severity:  "critical",
 		CheckType: string(testCheck2Type),
 		Breaches: []Breach{
-			ValueBreach{Value: "fail1"},
-			ValueBreach{Value: "fail2"},
-			ValueBreach{Value: "fail3"},
-			ValueBreach{Value: "fail4"},
-			ValueBreach{Value: "fail5"},
+			&ValueBreach{Value: "fail1"},
+			&ValueBreach{Value: "fail2"},
+			&ValueBreach{Value: "fail3"},
+			&ValueBreach{Value: "fail4"},
+			&ValueBreach{Value: "fail5"},
 		},
 	})
 	assert.Equal(10, int(rl.TotalBreaches))
@@ -141,12 +141,12 @@ func TestResultListAddResult(t *testing.T) {
 			rl.AddResult(Result{
 				Severity:  "high",
 				CheckType: string(testCheckType),
-				Breaches:  []Breach{ValueBreach{Value: "fail6"}},
+				Breaches:  []Breach{&ValueBreach{Value: "fail6"}},
 			})
 			rl.AddResult(Result{
 				Severity:     "critical",
 				CheckType:    string(testCheck2Type),
-				Breaches:     []Breach{ValueBreach{Value: "fail7"}},
+				Breaches:     []Breach{&ValueBreach{Value: "fail7"}},
 				Remediations: []string{"fixed2", "fixed3"},
 			})
 		}()
@@ -170,29 +170,29 @@ func TestResultListGetBreachesByCheckName(t *testing.T) {
 			{
 				Name: "check1",
 				Breaches: []Breach{
-					ValueBreach{Value: "failure1"},
-					ValueBreach{Value: "failure 2"},
+					&ValueBreach{Value: "failure1"},
+					&ValueBreach{Value: "failure 2"},
 				},
 			},
 			{
 				Name: "check2",
 				Breaches: []Breach{
-					ValueBreach{Value: "failure3"},
-					ValueBreach{Value: "failure 4"},
+					&ValueBreach{Value: "failure3"},
+					&ValueBreach{Value: "failure 4"},
 				},
 			},
 		},
 	}
 	assert.EqualValues(
 		[]Breach{
-			ValueBreach{Value: "failure1"},
-			ValueBreach{Value: "failure 2"},
+			&ValueBreach{Value: "failure1"},
+			&ValueBreach{Value: "failure 2"},
 		},
 		rl.GetBreachesByCheckName("check1"))
 	assert.EqualValues(
 		[]Breach{
-			ValueBreach{Value: "failure3"},
-			ValueBreach{Value: "failure 4"},
+			&ValueBreach{Value: "failure3"},
+			&ValueBreach{Value: "failure 4"},
 		},
 		rl.GetBreachesByCheckName("check2"))
 }
@@ -205,29 +205,29 @@ func TestResultListGetBreachesBySeverity(t *testing.T) {
 			{
 				Severity: "high",
 				Breaches: []Breach{
-					ValueBreach{Value: "failure1"},
-					ValueBreach{Value: "failure 2"},
+					&ValueBreach{Value: "failure1"},
+					&ValueBreach{Value: "failure 2"},
 				},
 			},
 			{
 				Severity: "normal",
 				Breaches: []Breach{
-					ValueBreach{Value: "failure3"},
-					ValueBreach{Value: "failure 4"},
+					&ValueBreach{Value: "failure3"},
+					&ValueBreach{Value: "failure 4"},
 				},
 			},
 		},
 	}
 	assert.EqualValues(
 		[]Breach{
-			ValueBreach{Value: "failure1"},
-			ValueBreach{Value: "failure 2"},
+			&ValueBreach{Value: "failure1"},
+			&ValueBreach{Value: "failure 2"},
 		},
 		rl.GetBreachesBySeverity("high"))
 	assert.EqualValues(
 		[]Breach{
-			ValueBreach{Value: "failure3"},
-			ValueBreach{Value: "failure 4"},
+			&ValueBreach{Value: "failure3"},
+			&ValueBreach{Value: "failure 4"},
 		},
 		rl.GetBreachesBySeverity("normal"))
 }

--- a/pkg/shipshape/output_test.go
+++ b/pkg/shipshape/output_test.go
@@ -124,7 +124,6 @@ func TestSimpleDisplay(t *testing.T) {
 				&result.ValueBreach{Value: "Fail b"},
 			},
 		})
-		buf = bytes.Buffer{}
 		SimpleDisplay(w)
 		assert.Equal("# Breaches were detected\n\n  ### b\n     -- Fail b\n\n", buf.String())
 	})
@@ -135,56 +134,93 @@ func TestSimpleDisplay(t *testing.T) {
 		w := bufio.NewWriter(&buf)
 		RunResultList.Results = append(RunResultList.Results, result.Result{
 			Name: "a", Status: result.Pass})
-		buf = bytes.Buffer{}
 		SimpleDisplay(w)
 		assert.Equal("Ship is in top shape; no breach detected!\n", buf.String())
 	})
 
 	t.Run("allBreachesRemediated", func(t *testing.T) {
-		RunResultList = result.ResultList{RemediationPerformed: true}
+		RunResultList = result.ResultList{
+			Results: []result.Result{{
+				Name: "a",
+				Breaches: []result.Breach{
+					&result.ValueBreach{
+						Remediation: result.Remediation{
+							Status:   result.RemediationStatusSuccess,
+							Messages: []string{"fixed 1"},
+						},
+					},
+				}}},
+			TotalBreaches:        1,
+			RemediationPerformed: true,
+			RemediationTotals:    map[string]uint32{"successful": 1},
+		}
+
 		var buf bytes.Buffer
 		w := bufio.NewWriter(&buf)
-		RunResultList.TotalRemediations = 1
-		RunResultList.Results = append(RunResultList.Results, result.Result{
-			Name: "a", Status: result.Pass, Remediations: []string{"fixed 1"}})
-		buf = bytes.Buffer{}
 		SimpleDisplay(w)
 		assert.Equal("Breaches were detected but were all fixed successfully!\n\n"+
 			"  ### a\n     -- fixed 1\n\n", buf.String())
 	})
 
 	t.Run("someBreachesRemediated", func(t *testing.T) {
-		RunResultList = result.ResultList{RemediationPerformed: true}
+		RunResultList = result.ResultList{
+			Results: []result.Result{{
+				Name: "a",
+				Breaches: []result.Breach{
+					&result.ValueBreach{
+						Value: "Fail a",
+						Remediation: result.Remediation{
+							Status:   result.RemediationStatusSuccess,
+							Messages: []string{"fixed 1"},
+						},
+					},
+					&result.ValueBreach{
+						Value: "Fail b",
+						Remediation: result.Remediation{
+							Status:   result.RemediationStatusFailed,
+							Messages: []string{"not fixed 1"},
+						},
+					},
+				}}},
+			TotalBreaches:        2,
+			RemediationPerformed: true,
+			RemediationTotals:    map[string]uint32{"successful": 1, "failed": 1},
+		}
+
 		var buf bytes.Buffer
 		w := bufio.NewWriter(&buf)
-		RunResultList.TotalRemediations = 1
-		RunResultList.TotalBreaches = 1
-		RunResultList.Results = append(RunResultList.Results, result.Result{
-			Name: "a", Status: result.Fail, Remediations: []string{"fixed 1"}})
-		buf = bytes.Buffer{}
 		SimpleDisplay(w)
 		assert.Equal("Breaches were detected but not all of them could be "+
 			"fixed as they are either not supported yet or there were errors "+
 			"when trying to remediate.\n\n"+
 			"# Remediations\n\n  ### a\n     -- fixed 1\n\n"+
-			"# Non-remediated breaches\n\n", buf.String())
+			"# Non-remediated breaches\n\n  ### a\n     -- Fail b\n\n", buf.String())
 	})
 
 	t.Run("noBreachRemediated", func(t *testing.T) {
-		RunResultList = result.ResultList{RemediationPerformed: true}
+		RunResultList = result.ResultList{
+			Results: []result.Result{{
+				Name: "a",
+				Breaches: []result.Breach{
+					&result.ValueBreach{
+						Remediation: result.Remediation{
+							Status:   result.RemediationStatusFailed,
+							Messages: []string{"failed 1"},
+						},
+					},
+				}}},
+			TotalBreaches:        1,
+			RemediationPerformed: true,
+			RemediationTotals:    map[string]uint32{"failed": 1},
+		}
+
 		var buf bytes.Buffer
 		w := bufio.NewWriter(&buf)
-		RunResultList.TotalBreaches = 1
-		RunResultList.TotalRemediations = 0
-		RunResultList.Results = append(RunResultList.Results, result.Result{
-			Name: "a", Status: result.Fail})
-		buf = bytes.Buffer{}
 		SimpleDisplay(w)
-		assert.Equal("Breaches were detected but not all of them could be "+
-			"fixed as they are either not supported yet or there were errors "+
-			"when trying to remediate.\n\n"+
-			"# Remediations\n\n"+
-			"# Non-remediated breaches\n\n", buf.String())
+		assert.Equal("Breaches were detected but none of them could be "+
+			"fixed as there were errors when trying to remediate.\n\n"+
+			"# Non-remediated breaches\n\n"+
+			"  ### a\n     -- \n\n", buf.String())
 	})
 }
 

--- a/pkg/shipshape/output_test.go
+++ b/pkg/shipshape/output_test.go
@@ -62,8 +62,8 @@ func TestTableDisplay(t *testing.T) {
 				Name:   "c",
 				Status: result.Fail,
 				Breaches: []result.Breach{
-					result.ValueBreach{Value: "Fail c"},
-					result.ValueBreach{Value: "Fail cb"},
+					&result.ValueBreach{Value: "Fail c"},
+					&result.ValueBreach{Value: "Fail cb"},
 				},
 			},
 			{
@@ -71,8 +71,8 @@ func TestTableDisplay(t *testing.T) {
 				Status: result.Fail,
 				Passes: []string{"Pass d", "Pass db"},
 				Breaches: []result.Breach{
-					result.ValueBreach{Value: "Fail c"},
-					result.ValueBreach{Value: "Fail cb"},
+					&result.ValueBreach{Value: "Fail c"},
+					&result.ValueBreach{Value: "Fail cb"},
 				},
 			},
 		},
@@ -121,7 +121,7 @@ func TestSimpleDisplay(t *testing.T) {
 			Name:   "b",
 			Status: result.Fail,
 			Breaches: []result.Breach{
-				result.ValueBreach{Value: "Fail b"},
+				&result.ValueBreach{Value: "Fail b"},
 			},
 		})
 		buf = bytes.Buffer{}
@@ -225,7 +225,7 @@ func TestJUnit(t *testing.T) {
 		Name:   "b",
 		Status: result.Fail,
 		Breaches: []result.Breach{
-			result.ValueBreach{Value: "Fail b"},
+			&result.ValueBreach{Value: "Fail b"},
 		},
 	})
 	buf = bytes.Buffer{}

--- a/pkg/shipshape/shipshape.go
+++ b/pkg/shipshape/shipshape.go
@@ -198,6 +198,15 @@ func ProcessCheck(rl *result.ResultList, c config.Check) {
 	if len(c.GetResult().Breaches) == 0 && len(c.GetResult().Passes) == 0 {
 		contextLogger.Print("running check")
 		c.RunCheck()
+		if len(c.GetResult().Breaches) > 0 {
+			if !c.ShouldPerformRemediation() {
+				c.GetResult().Status = result.Fail
+			} else {
+				c.Remediate()
+			}
+		} else {
+			c.GetResult().Status = result.Pass
+		}
 		c.GetResult().Sort()
 	}
 	rl.AddResult(*c.GetResult())

--- a/pkg/shipshape/shipshape.go
+++ b/pkg/shipshape/shipshape.go
@@ -198,11 +198,14 @@ func ProcessCheck(rl *result.ResultList, c config.Check) {
 	if len(c.GetResult().Breaches) == 0 && len(c.GetResult().Passes) == 0 {
 		contextLogger.Print("running check")
 		c.RunCheck()
-		if len(c.GetResult().Breaches) > 0 && c.ShouldPerformRemediation() {
-			contextLogger.Print("performing remediation")
-			c.Remediate()
-		}
+	}
+	if len(c.GetResult().Breaches) > 0 && c.ShouldPerformRemediation() {
+		contextLogger.Print("performing remediation")
+		c.Remediate()
 	}
 	c.GetResult().DetermineResultStatus(c.ShouldPerformRemediation())
+	contextLogger.
+		WithFields(log.Fields{"result": c.GetResult()}).
+		Print("check processed")
 	rl.AddResult(*c.GetResult())
 }

--- a/pkg/shipshape/shipshape_test.go
+++ b/pkg/shipshape/shipshape_test.go
@@ -134,6 +134,10 @@ checks:
 }
 
 func TestRunChecks(t *testing.T) {
+	currLogOut := logrus.StandardLogger().Out
+	defer logrus.SetOutput(currLogOut)
+	logrus.SetOutput(io.Discard)
+
 	assert := assert.New(t)
 
 	test1stCheck := &testchecks.TestCheck1Check{}
@@ -149,13 +153,14 @@ func TestRunChecks(t *testing.T) {
 		},
 	}
 
-	rl := RunChecks()
-	assert.Equal(uint32(2), rl.TotalChecks)
-	assert.Equal(uint32(2), rl.TotalBreaches)
+	RunResultList = result.NewResultList(false)
+	RunChecks()
+	assert.Equal(uint32(2), RunResultList.TotalChecks)
+	assert.Equal(uint32(2), RunResultList.TotalBreaches)
 	assert.EqualValues(map[string]int{
 		string(testchecks.TestCheck1): 1,
 		string(testchecks.TestCheck2): 1,
-	}, rl.BreachCountByType)
+	}, RunResultList.BreachCountByType)
 	assert.ElementsMatch([]result.Result{
 		{
 			Name:      "test1stcheck",
@@ -187,5 +192,5 @@ func TestRunChecks(t *testing.T) {
 			}},
 			Warnings: []string(nil),
 		}},
-		rl.Results)
+		RunResultList.Results)
 }

--- a/pkg/shipshape/shipshape_test.go
+++ b/pkg/shipshape/shipshape_test.go
@@ -163,7 +163,7 @@ func TestRunChecks(t *testing.T) {
 			CheckType: "test-check-1",
 			Status:    "Fail",
 			Passes:    []string(nil),
-			Breaches: []result.Breach{result.ValueBreach{
+			Breaches: []result.Breach{&result.ValueBreach{
 				BreachType: "value",
 				CheckType:  "test-check-1",
 				CheckName:  "test1stcheck",
@@ -178,7 +178,7 @@ func TestRunChecks(t *testing.T) {
 			CheckType: "test-check-2",
 			Status:    "Fail",
 			Passes:    []string(nil),
-			Breaches: []result.Breach{result.ValueBreach{
+			Breaches: []result.Breach{&result.ValueBreach{
 				BreachType: "value",
 				CheckType:  "test-check-2",
 				CheckName:  "test2ndcheck",


### PR DESCRIPTION
Another big PR, which introduces a number of changes:

- Breach is now an interface, with a generator for the common functions.
  - This allows for better handling remediations and the result for a check in general.
  - It also opens up future possibilities of having custom `Breach` types per `Check` and so on.
- Added a `Remediation` struct and included it in the `Result` struct.
- Updated the `Remediate()` signature in the Check interface to be more generic and without a return value.
  - It now expects the Check's Remediate implementation to loop through all the breaches and update the `Remediation`  inside each one.
 - Updated the logic in `ProcessCheck` to call `Remediate()` for each Check after `RunCheck()` has been called.
   - Also added a `DetermineResultStatus()` to `Result` so we can have better logic outside of `RunCheck()` which determines the result based on the Breaches detected and Remediations performed.
     - This allows for a Check to focus on just analysing the data and reporting Breaches.
     - It also means that almost all tests had to be updated to reflect that change, since the `Result.Status` is not being manually set in different places now.
  - Finally, added two new attributes to the `drush-yaml` check, `remediate-command` & `remediate-msg`, along with the corresponding `Remediate()` logic. This allows us to define a check like below:

     ```yaml
     checks:
       drush-yaml:
         - name: '[DATABASE] Ensure clamav is enabled'
           severity: high
           command: 'config:get clamav.settings'
           config-name: clamav.settings
           values:
             - key: enabled
               value: true
               truthy: true
           remediate-command: |
             #!/bin/bash
             set -eu
             drush config:set clamav.settings enabled true
           remediate-msg: ClamAV config was remediated by enabling it
     ```
      Shipshape will use the command specified to fix the issue and on success output the message specified:
      ```
      # Remediations

        ### [DATABASE] Ensure clamav is enabled
          -- ClamAV config was remediated by enabling it
      ```