### PR TITLE
Feature/remove lagoon api delete calls

### DIFF
--- a/main.go
+++ b/main.go
@@ -82,16 +82,6 @@ func main() {
 
 	determineLogLevel()
 
-	// simple check to ensure we have everything we need to write to the API if required.
-	if lagoon.PushProblemsToInsightRemote {
-		if lagoonApiBaseUrl == "" {
-			log.Fatal("lagoon api base url not provided")
-		}
-		if lagoonApiToken == "" {
-			log.Fatal("lagoon api token not provided")
-		}
-	}
-
 	for _, f := range checksFiles {
 		if !utils.StringIsUrl(f) {
 			if _, err := os.Stat(f); os.IsNotExist(err) {
@@ -111,9 +101,7 @@ func main() {
 		checkTypesToRun,
 		excludeDb,
 		remediate,
-		logLevel,
-		lagoonApiBaseUrl,
-		lagoonApiToken)
+		logLevel)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -186,7 +174,6 @@ func parseFlags() {
 	pflag.BoolVarP(&debug, "debug", "d", false, "Display debug information - equivalent to --log-level debug")
 	pflag.BoolVarP(&excludeDb, "exclude-db", "x", false, "Exclude checks requiring a database; overrides any db checks specified by '--types'")
 	pflag.BoolVarP(&remediate, "remediate", "r", false, "Run remediation for supported checks")
-	pflag.StringVar(&lagoonApiBaseUrl, "lagoon-api-base-url", "", "Base url for the Lagoon API when pushing problems to API (env: LAGOON_API_BASE_URL)")
 	pflag.StringVar(&lagoonApiToken, "lagoon-api-token", "", "Lagoon API token when pushing problems to API (env: LAGOON_API_TOKEN)")
 	pflag.BoolVar(&lagoon.PushProblemsToInsightRemote, "lagoon-push-problems-to-insights", false, "Push audit facts to Lagoon via Insights Remote")
 	pflag.StringVar(&lagoon.LagoonInsightsRemoteEndpoint, "lagoon-insights-remote-endpoint", "http://lagoon-remote-insights-remote.lagoon.svc/problems", "Insights Remote Problems endpoint")

--- a/pkg/internal/testutils_lagoon.go
+++ b/pkg/internal/testutils_lagoon.go
@@ -35,6 +35,7 @@ func MockLagoonReset() {
 }
 
 type MockInsightsRemoteTestState struct {
+	LastCallMethod   string
 	LastCallBody     string
 	LastCallHeaders  map[string]string
 	LastCallEndpoint string
@@ -44,6 +45,7 @@ type MockInsightsRemoteTestState struct {
 func MockRemoteInsightsServer(state *MockInsightsRemoteTestState) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		state.LastCallEndpoint = r.RequestURI
+		state.LastCallMethod = r.Method
 		requestBody, err := io.ReadAll(r.Body)
 		if err != nil {
 			w.WriteHeader(500)

--- a/pkg/lagoon/lagoon.go
+++ b/pkg/lagoon/lagoon.go
@@ -85,7 +85,7 @@ func ProcessResultList(w *bufio.Writer, list result.ResultList) error {
 		if err != nil {
 			return err
 		}
-		fmt.Fprint(w, "no breach to push to Lagoon; only deleted previous problems")
+		fmt.Fprintln(w, "no breach to push to Lagoon; only deleted previous problems")
 		w.Flush()
 		return nil
 	}
@@ -96,13 +96,11 @@ func ProcessResultList(w *bufio.Writer, list result.ResultList) error {
 		}
 
 		// let's marshal the breaches, they can be attached to the problem in the data field
-		//breachToConvert = r.Breaches
-		//brea
 		breachMapJson, err := json.Marshal(r.Breaches)
 		if err != nil {
 			log.WithError(err).Fatal("Unable to marshal breach information")
 		}
-		fmt.Println(string(breachMapJson))
+
 		problems = append(problems, Problem{
 			Identifier:        r.Name,
 			Version:           "1",

--- a/pkg/lagoon/lagoon.go
+++ b/pkg/lagoon/lagoon.go
@@ -96,8 +96,8 @@ func ProcessResultList(w *bufio.Writer, list result.ResultList) error {
 		}
 
 		// let's marshal the breaches, they can be attached to the problem in the data field
-		breachToConvert := r.Breaches
-		breachToConvert
+		//breachToConvert = r.Breaches
+		//brea
 		breachMapJson, err := json.Marshal(r.Breaches)
 		if err != nil {
 			log.WithError(err).Fatal("Unable to marshal breach information")

--- a/pkg/lagoon/lagoon.go
+++ b/pkg/lagoon/lagoon.go
@@ -3,7 +3,6 @@ package lagoon
 import (
 	"bufio"
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -13,9 +12,7 @@ import (
 	"github.com/salsadigitalauorg/shipshape/pkg/config"
 	"github.com/salsadigitalauorg/shipshape/pkg/result"
 
-	"github.com/hasura/go-graphql-client"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/oauth2"
 )
 
 type Fact struct {
@@ -46,26 +43,11 @@ type Problem struct {
 const SourceName string = "Shipshape"
 const FactMaxValueLength int = 300
 
-var ApiBaseUrl string
-var ApiToken string
 var PushProblemsToInsightRemote bool
 var LagoonInsightsRemoteEndpoint string
 
 var project string
 var environment string
-
-var Client *graphql.Client
-
-func InitClient() {
-	if Client != nil {
-		return
-	}
-	src := oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: ApiToken},
-	)
-	httpClient := oauth2.NewClient(context.Background(), src)
-	Client = graphql.NewClient(ApiBaseUrl+"/graphql", httpClient)
-}
 
 func MustHaveEnvVars() {
 	project = os.Getenv("LAGOON_PROJECT")
@@ -74,26 +56,6 @@ func MustHaveEnvVars() {
 		log.Fatal("project & environment name required; please ensure both " +
 			"LAGOON_PROJECT & LAGOON_ENVIRONMENT are set")
 	}
-}
-
-// GetEnvironmentIdFromEnvVars derives the environment id from shell variables
-// LAGOON_PROJECT & LAGOON_ENVIRONMENT.
-func GetEnvironmentIdFromEnvVars() (int, error) {
-	MustHaveEnvVars()
-
-	ns := project + "-" + environment
-	log.WithField("namespace", ns).Info("fetching environment id")
-	var q struct {
-		EnvironmentByKubernetesNamespaceName struct {
-			Id int
-		} `graphql:"environmentByKubernetesNamespaceName(kubernetesNamespaceName: $ns)"`
-	}
-	variables := map[string]interface{}{"ns": ns}
-	err := Client.Query(context.Background(), &q, variables)
-	if err != nil {
-		return 0, err
-	}
-	return q.EnvironmentByKubernetesNamespaceName.Id, nil
 }
 
 const DefaultLagoonInsightsTokenLocation = "/var/run/secrets/lagoon/dynamic/insights-token/INSIGHTS_TOKEN"
@@ -115,9 +77,11 @@ func GetBearerTokenFromDisk(tokenLocation string) (string, error) {
 func ProcessResultList(w *bufio.Writer, list result.ResultList) error {
 	problems := []Problem{}
 
+	// first, let's try doing this via in-cluster functionality
+	bearerToken, err := GetBearerTokenFromDisk(DefaultLagoonInsightsTokenLocation)
+
 	if list.TotalBreaches == 0 {
-		InitClient()
-		err := DeleteProblems()
+		err := DeleteProblems(LagoonInsightsRemoteEndpoint, bearerToken)
 		if err != nil {
 			return err
 		}
@@ -132,11 +96,13 @@ func ProcessResultList(w *bufio.Writer, list result.ResultList) error {
 		}
 
 		// let's marshal the breaches, they can be attached to the problem in the data field
+		breachToConvert := r.Breaches
+		breachToConvert
 		breachMapJson, err := json.Marshal(r.Breaches)
 		if err != nil {
 			log.WithError(err).Fatal("Unable to marshal breach information")
 		}
-
+		fmt.Println(string(breachMapJson))
 		problems = append(problems, Problem{
 			Identifier:        r.Name,
 			Version:           "1",
@@ -152,9 +118,6 @@ func ProcessResultList(w *bufio.Writer, list result.ResultList) error {
 		})
 	}
 
-	InitClient()
-	// first, let's try doing this via in-cluster functionality
-	bearerToken, err := GetBearerTokenFromDisk(DefaultLagoonInsightsTokenLocation)
 	if err == nil { // we have a token, and so we can proceed via the internal service call
 		err = ProblemsToInsightsRemote(problems, LagoonInsightsRemoteEndpoint, bearerToken)
 		if err != nil {
@@ -190,20 +153,29 @@ func ProblemsToInsightsRemote(problems []Problem, serviceEndpoint string, bearer
 	return nil
 }
 
-func DeleteProblems() error {
-	envId, err := GetEnvironmentIdFromEnvVars()
+func DeleteProblems(serviceEndpoint string, bearerToken string) error {
+
+	deleteEndpoint := fmt.Sprintf("%v/%v", serviceEndpoint, SourceName)
+
+	bodyString, err := json.Marshal("{}")
 	if err != nil {
 		return err
 	}
-	var m struct {
-		DeleteFactsFromSource string `graphql:"deleteProblemsFromSource(input: {environment: $envId, source: $sourceName, service:$service})"`
+
+	req, _ := http.NewRequest(http.MethodDelete, deleteEndpoint, bytes.NewBuffer(bodyString))
+	req.Header.Set("Authorization", bearerToken)
+	req.Header.Set("Content-Type", "application/json")
+	client := &http.Client{}
+	response, err := client.Do(req)
+
+	if err != nil {
+		return err
 	}
-	variables := map[string]interface{}{
-		"envId":      envId,
-		"sourceName": SourceName,
-		"service":    "",
+
+	if response.StatusCode != 200 {
+		return fmt.Errorf("there was an error deleting the problems at '%s' : %s", deleteEndpoint, response.Body)
 	}
-	return Client.Mutate(context.Background(), &m, variables)
+	return nil
 }
 
 // SeverityTranslation will convert a ShipShape severity rating to a Lagoon rating

--- a/pkg/shipshape/shipshape.go
+++ b/pkg/shipshape/shipshape.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 
 	"github.com/salsadigitalauorg/shipshape/pkg/config"
-	"github.com/salsadigitalauorg/shipshape/pkg/lagoon"
 	"github.com/salsadigitalauorg/shipshape/pkg/result"
 	"github.com/salsadigitalauorg/shipshape/pkg/utils"
 
@@ -21,7 +20,7 @@ var RunConfig config.Config
 var RunResultList result.ResultList
 var OutputFormats = []string{"json", "junit", "simple", "table"}
 
-func Init(projectDir string, configFiles []string, checkTypesToRun []string, excludeDb bool, remediate bool, logLevel string, lagoonApiBaseUrl string, lagoonApiToken string) error {
+func Init(projectDir string, configFiles []string, checkTypesToRun []string, excludeDb bool, remediate bool, logLevel string) error {
 	if logLevel == "" {
 		logLevel = "warn"
 	}
@@ -43,15 +42,6 @@ func Init(projectDir string, configFiles []string, checkTypesToRun []string, exc
 	// Remediate is a command-level flag, so we set the value outside of
 	// config parsing.
 	RunConfig.Remediate = remediate
-
-	// Base url can either be provided in the config file or in env var, the
-	// latter being final.
-	if lagoonApiBaseUrl != "" {
-		lagoon.ApiBaseUrl = lagoonApiBaseUrl
-	} else {
-		lagoon.ApiBaseUrl = RunConfig.LagoonApiBaseUrl
-	}
-	lagoon.ApiToken = lagoonApiToken
 
 	log.WithFields(log.Fields{
 		"ProjectDir":    RunConfig.ProjectDir,


### PR DESCRIPTION
This PR prepares for the release of Lagoon 2.18, which incorporates [Insights-Remote v0.0.9](https://github.com/uselagoon/insights-remote/releases/tag/v0.0.9) which adds service endpoints for deleting facts/problems.

This allows us to remove the calls to the Lagoon API completely, as all Problem related functionality can be achieved by writing to insights-remote.