### PR TITLE
Fix severity propagation from YAML configuration to analysis results

### DIFF
--- a/pkg/analyse/base.go
+++ b/pkg/analyse/base.go
@@ -36,6 +36,9 @@ func (p *BaseAnalyser) GetResult() result.Result {
 	if p.Description != "" && p.Result.Name != p.Description {
 		p.Result.Name = p.Description
 	}
+	if p.Severity != "" {
+		p.Result.Severity = p.Severity
+	}
 	return p.Result
 }
 


### PR DESCRIPTION
**Issue Description**
The application was not correctly propagating severity levels from the YAML configuration to the analysis results, which caused several problems:
Severity levels specified in the configuration files were not being applied to the analysis results
The `--error-code` flag combined with the default `--fail-severity=high` setting was not working as expected because the severity levels were not correctly set on the results
Users couldn't effectively filter breaches by severity level in CI/CD pipelines
This meant that even when users had properly configured severity levels in their YAML files and were using the `--error-code` flag with `--fail-severity=high`, the application would either:
Return a non-zero exit code for all breaches regardless of severity, or
Not return a non-zero exit code even for high severity breaches

**Example of the Problem**
In a configuration file like examples/regex-not-match.yml, we could specify severity levels for checks:
```
collect:
  extension-file:
    file:read:
      path: core.extension.yml

  module-lagoon_logs:
    yaml:key:
      input: extension-file
      path: module.lagoon_logs
      ignore-not-found: true

analyse:
  lagoon-logs-check:
    regex:not-match:
      description: Lagoon logs module is not enabled
      input: module-lagoon_logs
      pattern: "^0$"
      severity: high  # This severity was not being propagated to results
```
However, when running the application with `--error-code` `--fail-severity=high` (or just --error-code since high is the default value for --fail-severity), it would not correctly filter breaches based on severity, because the severity information was not being properly propagated from the configuration to the results.