### PR TITLE
 JUnit Output Issue in V2

### DIFF
--- a/pkg/analyse/base.go
+++ b/pkg/analyse/base.go
@@ -32,10 +32,14 @@ func (p *BaseAnalyser) GetBreachTemplate() breach.BreachTemplate {
 	return p.BreachTemplate
 }
 
-func (p *BaseAnalyser) GetResult() result.Result {
-	if p.Description != "" && p.Result.Name != p.Description {
-		p.Result.Name = p.Description
+// SetCheckType sets the CheckType on the Result if it's not already set
+func (p *BaseAnalyser) SetCheckType(checkType string) {
+	if p.Result.CheckType == "" {
+		p.Result.CheckType = checkType
 	}
+}
+
+func (p *BaseAnalyser) GetResult() result.Result {
 	if p.Severity != "" {
 		p.Result.Severity = p.Severity
 	}

--- a/pkg/analyse/manager.go
+++ b/pkg/analyse/manager.go
@@ -49,6 +49,11 @@ func (m *manager) ParseConfig(raw map[string]map[string]interface{}) error {
 				return err
 			}
 
+			// Ensure the CheckType is set on the Result
+			if analyser, ok := plugin.(interface{ SetCheckType(string) }); ok {
+				analyser.SetCheckType(pluginName)
+			}
+
 			log.WithFields(log.Fields{
 				"id":          id,
 				"plugin":      plugin.GetName(),

--- a/pkg/output/file_test.go
+++ b/pkg/output/file_test.go
@@ -155,8 +155,8 @@ func TestFileOutput(t *testing.T) {
 			expected: `<?xml version="1.0" encoding="UTF-8"?>
 <testsuites tests="0" errors="0">
     <testsuite name="test-check" tests="0" errors="0">
-        <testcase name="a" classname="a"></testcase>
-        <testcase name="b" classname="b">
+        <testcase name="a" classname="test-check"></testcase>
+        <testcase name="b" classname="test-check">
             <error message="Fail b"></error>
         </testcase>
     </testsuite>

--- a/pkg/output/stdout.go
+++ b/pkg/output/stdout.go
@@ -219,7 +219,7 @@ func (p *Stdout) JUnit(rl *result.ResultList, w io.Writer) {
 		for _, plc := range policies {
 			tc := JUnitTestCase{
 				Name:      plc,
-				ClassName: plc,
+				ClassName: pplugin,
 				Errors:    []JUnitError{},
 			}
 

--- a/pkg/shipshape/shipshape.go
+++ b/pkg/shipshape/shipshape.go
@@ -154,6 +154,16 @@ func RunV2() {
 	}
 
 	RunResultList = result.NewResultList(Remediate)
+
+	log.Print("mapping policies to plugins and incrementing check counters")
+	RunResultList.Policies = map[string][]string{}
+	for id, pluginConf := range RunConfigV2.Analyse {
+		for pluginName := range pluginConf {
+			RunResultList.Policies[pluginName] = append(RunResultList.Policies[pluginName], id)
+			RunResultList.IncrChecks(pluginName, 1)
+		}
+	}
+
 	log.Print("parsing output config")
 	output.ParseConfig(RunConfigV2.Output, &RunResultList)
 


### PR DESCRIPTION
## JUnit Output Issue Fix

### Problem
The JUnit output was incomplete and missing critical information:

Before fix:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuites tests="0" errors="2"></testsuites>
```

After fix:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuites tests="6" errors="2">
    <testsuite name="regex:not-match" tests="6" errors="2">
        <testcase name="uat-tls-acme-check" classname="regex:not-match"></testcase>
        <testcase name="develop-tls-acme-check" classname="regex:not-match"></testcase>
        <testcase name="lagoon-logs-enabled-check" classname="regex:not-match">
            <error message="lagoon-logs equals &#39;0&#39;"></error>
        </testcase>
        <testcase name="tide-profile-check" classname="regex:not-match">
            <error message="profile is nil"></error>
        </testcase>
        <testcase name="production-tls-acme-check" classname="regex:not-match"></testcase>
        <testcase name="master-tls-acme-check" classname="regex:not-match"></testcase>
    </testsuite>
</testsuites>
```

### Root Causes

1. **Policy and Check Count Initialization**
   - In V2, the `RunResultList.Policies` map was not initialized using plugin names
   - In V2 the check counts `IncrChecks` were not incremented, leading to `tests="0"` in the output

2. **Result Name Override**
   - In `BaseAnalyser.GetResult()`, the Result's Name was being overridden by the Description
   - This caused `GetBreachesByCheckName()` to fail finding breaches since it was looking up by the original check name
   - The lookup failed because the name used for lookup didn't match the overridden name in the results

3. **CheckType Not Set**
   - In V2, the CheckType was not being set in the Result
   - This affected the `BreachCountByType` calculations
   - The missing CheckType prevented proper grouping of breaches by test suite in the JUnit output

### Fix Impact
- Ensures correct policy mapping and check counting in V2
- Preserves Result names for proper breach lookup in JUnit output
- Produces complete XML output with all test cases and their errors
