### PR TITLE
feat: added map key lookup

### DIFF
--- a/docs/src/reference/analyse/allowed-list.md
+++ b/docs/src/reference/analyse/allowed-list.md
@@ -4,14 +4,16 @@ The `allowed:list` analyser checks if values in a list or map match against a li
 
 ## Configuration
 
-| Field         | Type     | Required | Description                                                |
-| ------------- | -------- | -------- | ---------------------------------------------------------- |
-| allowed       | []string | No       | List of allowed values                                     |
-| required      | []string | No       | List of values that must be present                        |
-| deprecated    | []string | No       | List of deprecated values to flag                          |
-| exclude-keys  | []string | No       | For map inputs, keys to exclude from validation            |
-| ignore        | []string | No       | List of values to ignore during validation                 |
-| package-match | string   | No       | If set, treats values as packages and matches package names |
+| Field         | Type     | Required | Description                                                       |
+| ------------- | -------- | -------- | ----------------------------------------------------------------- |
+| allowed       | []string | No       | List of allowed values                                            |
+| required      | []string | No       | List of values that must be present                               |
+| deprecated    | []string | No       | List of deprecated values to flag                                 |
+| exclude-keys  | []string | No       | For map inputs, keys to exclude from validation                   |
+| ignore        | []string | No       | List of values to ignore during validation                        |
+| package-match | string   | No       | If set, treats values as packages and matches package names       |
+| key           | string   | No       | For map inputs, uses the value here to lookup the map             |
+| not-strict    | boolean  | No       | When false (default), any value not in the allowed list will fail |
 
 <Content :page-key="$site.pages.find(p => p.path === '/reference/common/analyse.html').key"/>
 


### PR DESCRIPTION
[GOVCMS-12752]

This PR adds two new properties to the `allowed:list` plugin, `key` & `not-strict`. `key` provides the ability to specify a key to lookup a `map[string]` input, and then run the allowed/disallowed/deprecated logic on the string, assumed to be multiline, with one value per line.

This allows us to use the output from a `command` Fact plugin, which returns a map with `stdout`, `code` and `stderr` in the `allowed:list` plugin.