### PR TITLE
docs: add 1.x guide, 0.x reference, and README config-versions announcement

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,21 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  gh-pages:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@main
+
+      - name: vuepress-deploy
+        uses: jenkey2011/vuepress-deploy@master
+        env:
+          ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUILD_SCRIPT: cd docs && npm install && npm run build
+          BUILD_DIR: src/.vuepress/dist/main
+
+  quantcdn:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,28 @@
 [![Coverage Status](https://coveralls.io/repos/github/salsadigitalauorg/shipshape/badge.svg?branch=1.x)](https://coveralls.io/github/salsadigitalauorg/shipshape?branch=1.x)
 [![Release](https://img.shields.io/github/v/release/salsadigitalauorg/shipshape)](https://github.com/salsadigitalauorg/shipshape/releases/latest)
 
+## Config versions
+
+Shipshape has two configuration formats, and the same binary runs both.
+
+- **1.x — recommended.** The composable pipeline (`collect` / `analyse` /
+  `output`) is the format to use going forward. It's used in production and is
+  where new capabilities land.
+- **0.x — fully supported.** The legacy `checks:` format continues to run
+  without changes. There is no forced migration — migrate when it suits you.
+
+1.x takes a compose-don't-port approach: instead of one dedicated check per
+task, you wire a small set of general-purpose plugins together to get the same
+outcome.
+
+> **Closing the gaps:** a few 0.x checks don't have a documented 1.x recipe
+> yet. We're actively closing that gap. See the
+> [gaps matrix](https://salsadigitalauorg.github.io/shipshape/1.x/guide/gaps.html)
+> for what's covered today and the
+> [roadmap](https://salsadigitalauorg.github.io/shipshape/1.x/guide/roadmap.html)
+> for what's coming. Full comparison:
+> [Config versions](https://salsadigitalauorg.github.io/shipshape/1.x/guide/versions.html).
+
 ## Installation
 
 ### MacOS

--- a/docs/src/.vuepress/config.js
+++ b/docs/src/.vuepress/config.js
@@ -71,6 +71,10 @@ module.exports = {
             'analyse',
             'remediate',
             'outputs',
+            'versions',
+            '0.x',
+            'gaps',
+            'roadmap',
           ]
         }
       ],
@@ -123,6 +127,31 @@ module.exports = {
               collapsable: false,
               children: [
                 ['/reference/remediate/command', 'command'],
+              ]
+            },
+            {
+              title: 'Checks (0.x)',
+              path: '/reference/checks',
+              collapsable: false,
+              children: [
+                ['/reference/checks/file', 'file'],
+                ['/reference/checks/file-diff', 'file:diff'],
+                ['/reference/checks/yaml', 'yaml'],
+                ['/reference/checks/json', 'json'],
+                ['/reference/checks/drupal-drush-yaml', 'drush-yaml'],
+                ['/reference/checks/drupal-file-module', 'drupal-file-module'],
+                ['/reference/checks/drupal-db-module', 'drupal-db-module'],
+                ['/reference/checks/drupal-admin-user', 'drupal-admin-user'],
+                ['/reference/checks/drupal-db-permissions', 'drupal-db-permissions'],
+                ['/reference/checks/drupal-db-user-tfa', 'drupal-db-user-tfa'],
+                ['/reference/checks/drupal-user-forbidden', 'drupal-user-forbidden'],
+                ['/reference/checks/drupal-role-permissions', 'drupal-role-permissions'],
+                ['/reference/checks/drupal-user-role', 'drupal-user-role'],
+                ['/reference/checks/drupal-tracking-code', 'drupal-tracking-code'],
+                ['/reference/checks/phpstan', 'phpstan'],
+                ['/reference/checks/sca-application-type', 'sca:application_type'],
+                ['/reference/checks/docker-base-image', 'docker:base_image'],
+                ['/reference/checks/crawler', 'crawler'],
               ]
             },
           ]

--- a/docs/src/guide/0.x.md
+++ b/docs/src/guide/0.x.md
@@ -1,0 +1,138 @@
+# 0.x config format
+
+::: tip Which format should I use?
+See [Config versions](versions.md) for a decision guide. 1.x is recommended for
+new configurations. This page documents the 0.x `checks:` format, which is
+fully supported.
+:::
+
+::: tip Moving to 1.x? Compose, don't look for a port
+1.x doesn't ship a dedicated plugin for each 0.x check. Instead you reproduce a
+check by composing general-purpose plugins — for example, `drupal-admin-user`
+becomes `command` + `allowed:list`. The [gaps matrix](gaps.md) lists the plugin
+chain that reproduces each check below.
+:::
+
+## Overview
+
+The 0.x format is a flat YAML file with a single top-level key: `checks`.
+
+```yaml
+checks:
+  <check-type>:
+    - name: Human-readable label
+      severity: normal        # low | normal | high | critical
+      # ... check-specific fields
+```
+
+The binary auto-detects the format. If `checks:` is the only top-level key,
+the 0.x runner is used. If any of `connections`, `collect`, `analyse`, or
+`output` are present, the 1.x runner is used instead. See
+[Config versions](versions.md#how-the-binary-picks-a-format) for the exact rule.
+
+## Common fields
+
+Every check, regardless of type, supports these fields from `CheckBase`:
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `name` | string | required | Human-readable label shown in output |
+| `severity` | string | `normal` | `low`, `normal`, `high`, or `critical` |
+
+The `--fail-severity` CLI flag controls which severity level causes a non-zero
+exit code. Checks below that level still run and report, but do not fail the
+build.
+
+## Running a 0.x config
+
+```sh
+shipshape run -f shipshape.yml
+```
+
+Pass `--fail-severity` to override the exit threshold:
+
+```sh
+shipshape run -f shipshape.yml --fail-severity high
+```
+
+## Checks
+
+The following check types are available in the 0.x format. Each links to its
+full reference page.
+
+### File checks
+
+| Type | What it does |
+|---|---|
+| [`file`](../reference/checks/file.md) | Assert files matching a pattern are absent |
+| [`file:diff`](../reference/checks/file-diff.md) | Assert a file matches a reference template |
+
+### YAML / JSON checks
+
+| Type | What it does |
+|---|---|
+| [`yaml`](../reference/checks/yaml.md) | Assert key-value pairs in YAML files |
+| [`json`](../reference/checks/json.md) | Assert key-value pairs in JSON files |
+
+### Drupal checks
+
+| Type | What it does |
+|---|---|
+| [`drush-yaml`](../reference/checks/drupal-drush-yaml.md) | Assert key-value pairs in Drupal config via Drush |
+| [`drupal-file-module`](../reference/checks/drupal-file-module.md) | Assert modules enabled/disabled via filesystem |
+| [`drupal-db-module`](../reference/checks/drupal-db-module.md) | Assert modules enabled/disabled via database |
+| [`drupal-admin-user`](../reference/checks/drupal-admin-user.md) | Assert UID 1 has only permitted roles |
+| [`drupal-db-permissions`](../reference/checks/drupal-db-permissions.md) | Assert role permissions via database |
+| [`drupal-db-user-tfa`](../reference/checks/drupal-db-user-tfa.md) | Assert all users have TFA configured |
+| [`drupal-user-forbidden`](../reference/checks/drupal-user-forbidden.md) | Assert a specific user account does not exist |
+| [`drupal-role-permissions`](../reference/checks/drupal-role-permissions.md) | Assert required/disallowed permissions on a role |
+| [`drupal-user-role`](../reference/checks/drupal-user-role.md) | Assert users with a given role are on an allow-list |
+| [`drupal-tracking-code`](../reference/checks/drupal-tracking-code.md) | Assert no tracking code is present in Drupal config |
+
+### Code quality checks
+
+| Type | What it does |
+|---|---|
+| [`phpstan`](../reference/checks/phpstan.md) | Run PHPStan and fail on errors |
+| [`sca:application_type`](../reference/checks/sca-application-type.md) | Detect disallowed application frameworks |
+
+### Infrastructure checks
+
+| Type | What it does |
+|---|---|
+| [`docker:base_image`](../reference/checks/docker-base-image.md) | Assert Docker base images are on an allow-list |
+| [`crawler`](../reference/checks/crawler.md) | Crawl a site and assert all pages return 200 |
+
+## Multiple checks of the same type
+
+Each check type takes a list. You can define multiple checks of the same type
+with different names, paths, or severity levels:
+
+```yaml
+checks:
+  yaml:
+    - name: Update interval
+      config-name: update.settings
+      path: config/default
+      values:
+        - key: check.interval_days
+          value: "7"
+    - name: Cron interval
+      config-name: automated_cron.settings
+      path: config/default
+      values:
+        - key: interval
+          value: "10800"
+```
+
+## Merging configs
+
+The `-e` flag merges a second config file on top of the first. Fields in the
+second file override the first; list fields are appended.
+
+```sh
+shipshape run -f base.yml -e overrides.yml
+```
+
+This is useful for environment-specific overrides without duplicating the full
+config.

--- a/docs/src/guide/README.md
+++ b/docs/src/guide/README.md
@@ -29,6 +29,15 @@ Or add to your docker image:
 COPY --from=ghcr.io/salsadigitalauorg/shipshape:latest /usr/local/bin/shipshape /usr/local/bin/shipshape
 ```
 
+::: tip Which config format?
+Shipshape supports two configuration formats. The **1.x pipeline** (`collect` /
+`analyse` / `output`) is the recommended format and is used in production. The
+**0.x `checks:` format** is fully supported and continues to run without changes.
+
+See [Config versions](versions.md) for a full comparison and a guide on which
+to use.
+:::
+
 ## Usage
 
 The basic layout of the config file is as follows:

--- a/docs/src/guide/gaps.md
+++ b/docs/src/guide/gaps.md
@@ -1,0 +1,240 @@
+# 0.x to 1.x recipe catalogue
+
+1.x does not provide a dedicated plugin for each 0.x check. Instead, you
+reproduce a 0.x check by **composing general-purpose `collect` and `analyse`
+plugins**. This page is the recipe catalogue: for every 0.x check it shows the
+plugin chain that achieves the same outcome in 1.x.
+
+See [The 1.x way: compose, don't port](versions.md#the-1-x-way-compose-don-t-port)
+for the reasoning behind this approach.
+
+::: tip Reading this table
+None of the statuses below mean "waiting for a one-to-one port". Almost every
+0.x check is reproducible today by composing plugins that already exist.
+
+- **Achievable now** — a documented recipe and a working example in `examples/`
+  exist. Copy the example and adapt it.
+- **Achievable, undocumented** — the same plugins reproduce the check, but no
+  worked example is published yet. The plugin chain is listed so you can build
+  it; a published recipe is [on the roadmap](roadmap.md).
+- **Needs new capability** — no existing building block collects the required
+  data. The 1.x direction is still to be determined (TBD).
+:::
+
+## File checks
+
+| 0.x check | Status | 1.x plugin chain |
+|---|---|---|
+| [`file`](../reference/checks/file.md) | Achievable now | `file:lookup` + `not:empty` — see `examples/files.yml` |
+| [`file:diff`](../reference/checks/file-diff.md) | Needs new capability | TBD |
+
+### Recipe: file
+
+```yaml
+collect:
+  disallowed-php-scripts:
+    file:lookup:
+      path: web
+      pattern: '^(adminer|phpmyadmin|bigdump)?\.php$'
+
+analyse:
+  disallowed-php-scripts-found:
+    not:empty:
+      description: Disallowed PHP scripts found
+      input: disallowed-php-scripts
+```
+
+Source: `examples/files.yml`
+
+## YAML / JSON checks
+
+| 0.x check | Status | 1.x plugin chain |
+|---|---|---|
+| [`yaml`](../reference/checks/yaml.md) | Achievable now | `file:read` + `yaml:key` + `equals` / `allowed:list` — see `examples/drupal-config.yml` |
+| [`json`](../reference/checks/json.md) | Achievable, undocumented | `file:read` + `yaml:key` (parses JSON) + `equals` / `allowed:list` |
+
+### Recipe: yaml
+
+```yaml
+collect:
+  extension-file:
+    file:read:
+      path: core.extension.yml
+
+  modules:
+    yaml:key:
+      input: extension-file
+      path: module
+      keys-only: true
+
+analyse:
+  required-modules:
+    allowed:list:
+      description: Required modules are not enabled
+      input: modules
+      required:
+        - seckit
+        - lagoon_logs
+```
+
+Source: `examples/drupal-config.yml`
+
+## Drupal checks
+
+Every Drush-based Drupal check follows the same pattern: run a `command` (or
+`docker:command`) to fetch data, parse it with `yaml:key` where needed, then
+assert with `allowed:list` or `equals`. See the
+[worked recipe](#recipe-drupal-admin-user-the-composition-pattern) below.
+
+| 0.x check | Status | 1.x plugin chain |
+|---|---|---|
+| [`drush-yaml`](../reference/checks/drupal-drush-yaml.md) | Achievable now | `docker:command` + `yaml:key` + `equals` — see `examples/drush-over-docker.yml` |
+| [`drupal-file-module`](../reference/checks/drupal-file-module.md) | Achievable now | `file:read` + `yaml:key` + `allowed:list` — see `examples/drupal-config.yml` |
+| [`drupal-db-module`](../reference/checks/drupal-db-module.md) | Achievable, undocumented | `command` + `allowed:list` |
+| [`drupal-db-permissions`](../reference/checks/drupal-db-permissions.md) | Achievable, undocumented | `command` / `database:search` + `allowed:list` |
+| [`drupal-db-user-tfa`](../reference/checks/drupal-db-user-tfa.md) | Achievable, undocumented | `command` + `equals` — pattern shown in `examples/remediation.yml` |
+| [`drupal-admin-user`](../reference/checks/drupal-admin-user.md) | Achievable, undocumented | `command` + `yaml:key` + `allowed:list` |
+| [`drupal-user-forbidden`](../reference/checks/drupal-user-forbidden.md) | Achievable, undocumented | `command` + `not:empty` / `equals` |
+| [`drupal-role-permissions`](../reference/checks/drupal-role-permissions.md) | Achievable, undocumented | `command` + `allowed:list` |
+| [`drupal-user-role`](../reference/checks/drupal-user-role.md) | Achievable, undocumented | `command` + `allowed:list` |
+| [`drupal-tracking-code`](../reference/checks/drupal-tracking-code.md) | Achievable, undocumented | `command` + `regex:match` / `not:empty` |
+
+### Recipe: drush-yaml via Docker
+
+```yaml
+connections:
+  docker-cli:
+    docker:exec:
+      container: my-app
+
+collect:
+  tfa-config:
+    docker:command:
+      connection: docker-cli
+      command: ["/app/vendor/bin/drush", "config:get", "tfa.settings"]
+
+  tfa-status:
+    yaml:key:
+      input: tfa-config
+      path: enabled
+
+analyse:
+  tfa-enabled:
+    equals:
+      description: TFA must be enabled
+      input: tfa-status
+      value: "true"
+```
+
+Source: `examples/drush-over-docker.yml`
+
+### Recipe: drupal-admin-user — the composition pattern
+
+This is the template for the "Achievable, undocumented" Drupal checks above.
+The 0.x `drupal-admin-user` check asserts that UID 1 holds only permitted
+roles. In 1.x you compose the same three building blocks — collect, parse,
+assert — that every other Drush check uses:
+
+```yaml
+collect:
+  # 1. Collect: run drush to fetch UID 1's account information as YAML.
+  admin-user:
+    command:
+      cmd: drush
+      args: ["user:information", "1", "--format=yaml"]
+
+  # 2. Parse: extract the roles field from the command output.
+  admin-user-roles:
+    yaml:key:
+      input: admin-user
+      path: roles
+
+analyse:
+  # 3. Assert: fail if any role outside the allowed set is present.
+  admin-user-roles-allowed:
+    allowed:list:
+      description: UID 1 has a disallowed role
+      input: admin-user-roles
+      allowed:
+        - authenticated
+```
+
+Swap the `command` and the `allowed:list` / `equals` assertion to reproduce any
+of the other Drush-based checks — the shape stays the same.
+
+## Code quality checks
+
+| 0.x check | Status | 1.x plugin chain |
+|---|---|---|
+| [`phpstan`](../reference/checks/phpstan.md) | Achievable now | `static-analysis` + `static-analysis:breaches` — see `examples/phpstan.yml` |
+| [`sca:application_type`](../reference/checks/sca-application-type.md) | Needs new capability | TBD |
+
+### Recipe: phpstan
+
+```yaml
+collect:
+  phpstan-check:
+    static-analysis:
+      tool: phpstan
+      config: phpstan.neon
+      paths: [web/modules/custom]
+
+analyse:
+  phpstan-issues:
+    static-analysis:breaches:
+      description: PHPStan found code quality issues
+      input: phpstan-check
+      max-issues: 0
+```
+
+Source: `examples/phpstan.yml`
+
+## Infrastructure checks
+
+| 0.x check | Status | 1.x plugin chain |
+|---|---|---|
+| [`docker:base_image`](../reference/checks/docker-base-image.md) | Achievable now | `docker:images` + `allowed:list` — see `examples/docker.yml` |
+| [`crawler`](../reference/checks/crawler.md) | Needs new capability | TBD |
+
+### Recipe: docker:base_image
+
+```yaml
+collect:
+  dockerfile-paths:
+    yaml:key:
+      input: compose-services-nodes
+      path: build.dockerfile
+
+  dockerfiles:
+    file:read:multiple:
+      input: dockerfile-paths
+
+  base-images:
+    docker:images:
+      input: dockerfiles
+      no-tag: true
+
+analyse:
+  disallowed-base-image:
+    allowed:list:
+      description: Disallowed base image found in Dockerfiles
+      input: base-images
+      allowed:
+        - uselagoon/php-8.2-fpm
+        - uselagoon/nginx-drupal
+      deprecated:
+        - uselagoon/php-8.1-fpm
+```
+
+Source: `examples/docker.yml`
+
+## Summary
+
+| Status | Count |
+|---|---|
+| Achievable now | 6 |
+| Achievable, undocumented | 9 |
+| Needs new capability | 3 |
+
+The plan for publishing the undocumented recipes and deciding the direction for
+the remaining capabilities is on the [roadmap](roadmap.md) page.

--- a/docs/src/guide/roadmap.md
+++ b/docs/src/guide/roadmap.md
@@ -1,0 +1,95 @@
+# Roadmap to 1.x parity
+
+::: warning Direction, not a guarantee
+This page describes the intended direction for reaching parity between the 0.x
+`checks:` format and the 1.x pipeline. Scope and sequencing may change as
+priorities shift and contributors engage.
+
+- **1.x is already recommended for production.** See [Config versions](versions.md).
+- **0.x is fully supported** while this work progresses. Nothing will break.
+- The current recipe catalogue is on the [gaps matrix](gaps.md).
+:::
+
+## The direction: recipes, not plugin ports
+
+1.x reaches parity by **documenting composition recipes**, not by building a
+dedicated plugin for each 0.x check. Almost every 0.x check is already
+reproducible today by wiring together general-purpose `collect` and `analyse`
+plugins — see the [gaps matrix](gaps.md) for the plugin chain per check.
+
+So most of the remaining work is **writing docs and examples**, not writing
+code. Building a new plugin is the exception, reserved for the few checks where
+no existing building block can collect the required data.
+
+## What "parity" means
+
+Parity is reached when every 0.x check has a documented, tested recipe composed
+from general-purpose plugins — and, where the 0.x check supported it, a
+[remediation](remediate.md) path. A recipe counts as complete when it is
+documented in the reference and backed by a working file in `examples/`.
+
+The [gaps matrix](gaps.md) is the authoritative record of current status.
+
+## Recipes to document
+
+These checks are already reproducible with existing plugins (status
+**Achievable, undocumented** on the gaps matrix). They need **no new code** —
+only a published recipe and a worked example.
+
+Each shares the collect → parse → assert composition pattern shown in the
+[`drupal-admin-user` recipe](gaps.md#recipe-drupal-admin-user-the-composition-pattern).
+
+| 0.x check | Recipe to publish |
+|---|---|
+| `json` | `file:read` + `yaml:key` + `equals` / `allowed:list` |
+| `drupal-db-module` | `command` + `allowed:list` |
+| `drupal-db-permissions` | `command` / `database:search` + `allowed:list` |
+| `drupal-db-user-tfa` | `command` + `equals` |
+| `drupal-admin-user` | `command` + `yaml:key` + `allowed:list` |
+| `drupal-user-forbidden` | `command` + `not:empty` / `equals` |
+| `drupal-role-permissions` | `command` + `allowed:list` |
+| `drupal-user-role` | `command` + `allowed:list` |
+| `drupal-tracking-code` | `command` + `regex:match` / `not:empty` |
+
+For each item, "done" means: a worked recipe in `examples/`, reference
+documentation for the recipe, and the gaps matrix row flipped to
+**Achievable now**.
+
+## New general-purpose capabilities (deferred)
+
+These checks have no existing plugin that can collect the data they need
+(status **Needs new capability** on the gaps matrix). The intended direction is
+to add a **general-purpose, reusable** collect plugin — not a check-specific
+one — so that the new capability serves future recipes too. The exact approach
+for each is **to be determined (TBD)**.
+
+| 0.x check | Missing capability | Direction |
+|---|---|---|
+| `file:diff` | Compare a file against a rendered template and surface the difference | TBD |
+| `crawler` | Crawl a site and collect non-200 responses | TBD |
+| `sca:application_type` | Scan a codebase for framework markers and dependencies | TBD |
+
+These are deferred with no committed timeline.
+
+## How to contribute
+
+The [gaps matrix](gaps.md) is the source of truth for what remains open.
+
+To pick up an item:
+
+1. Check the [issue tracker](https://github.com/salsadigitalauorg/shipshape/issues)
+   for an existing issue before opening a new one.
+2. Reference the 0.x check type (e.g. `drupal-admin-user`) in the issue title
+   so it stays traceable to this roadmap.
+
+An item is **done** when:
+
+- **Recipe items** — the recipe is documented in `docs/src/reference/`, a
+  working file exists in `examples/`, and the gaps matrix row is updated to
+  **Achievable now**.
+- **Capability items** — a new **general-purpose** collect plugin is registered
+  and documented (not a check-specific plugin), with a recipe showing how it
+  reproduces the 0.x check.
+
+Contributions to either group are welcome. There is no strict ordering — pick
+whatever is most useful to you first.

--- a/docs/src/guide/versions.md
+++ b/docs/src/guide/versions.md
@@ -1,0 +1,95 @@
+# Config versions
+
+Shipshape has two configuration formats. The same binary runs both.
+
+::: tip 1.x is the recommended format
+The 1.x pipeline (`collect` / `analyse` / `output`) is used in production and
+is the recommended format for new configurations. The 0.x `checks:` format is
+fully supported and continues to run without changes.
+
+Not sure if 1.x covers everything you need? Check the
+[gaps matrix](gaps.md) to see how each 0.x check is reproduced in 1.x, and the
+[roadmap](roadmap.md) to see what's coming.
+:::
+
+## Which format should I use?
+
+- **Starting a new configuration** — use 1.x.
+- **Running an existing 0.x config** — it still runs as-is. Migrate to 1.x
+  when convenient; there is no forced migration.
+- **Relying on a check that isn't ported yet** — check the
+  [gaps matrix](gaps.md). If the 1.x equivalent isn't there yet, keep using
+  the 0.x check until it lands.
+
+## How the binary picks a format
+
+When Shipshape reads a config file it tries to parse it as a 1.x config first.
+If any of the top-level 1.x keys (`connections`, `collect`, `analyse`,
+`output`) are present, the file is treated as 1.x and the pipeline runner is
+used. If none of those keys are found, the file is treated as 0.x and the
+checks runner is used.
+
+The distinguishing key is the top-level block name:
+
+```yaml
+# 0.x — identified by the top-level "checks:" key
+checks:
+  file:
+    - name: Illegal files
+      path: web
+      disallowed-pattern: '^(adminer|phpmyadmin|bigdump)?\.php$'
+```
+
+```yaml
+# 1.x — identified by any of: connections, collect, analyse, output
+collect:
+  disallowed-php-scripts:
+    file:lookup:
+      path: web
+      pattern: '^(adminer|phpmyadmin|bigdump)?\.php$'
+
+analyse:
+  disallowed-php-scripts-found:
+    not:empty:
+      description: 'Disallowed php scripts found'
+      input: disallowed-php-scripts
+      severity: high
+```
+
+If a file contains both a `checks:` key and a 1.x key, the 1.x runner takes
+precedence.
+
+## Format overview
+
+| | 0.x | 1.x |
+|---|---|---|
+| Top-level key | `checks:` | `collect:` / `analyse:` / `output:` |
+| Config struct | `Config` | `ConfigV2` |
+| Runner | `RunConfig` | `RunV2` |
+| Model | One check per concern — collection, evaluation, and optional remediation bundled together | Composable pipeline — collect data with one plugin, analyse it with another |
+| Status | Fully supported | Recommended |
+
+## What's the difference?
+
+A 0.x check is a single, opinionated unit: it knows how to collect the data it
+needs, evaluate it, and (for some checks) fix problems it finds. A 1.x config
+separates those steps — a `collect` plugin gathers raw data, an `analyse`
+plugin evaluates it. This makes the pieces reusable and composable, at the cost
+of needing more explicit wiring.
+
+The [gaps matrix](gaps.md) shows which 0.x checks have a full 1.x equivalent
+today, and the [0.x config guide](0.x.md) documents the `checks:` format in
+full.
+
+## The 1.x way: compose, don't port
+
+0.x gave you one dedicated check type per task. 1.x takes a different approach:
+a small set of general-purpose `collect` and `analyse` plugins that you wire
+together to achieve the same outcome. You won't find a one-to-one replacement
+plugin for each 0.x check — instead you compose the same handful of building
+blocks (for example `command` + `allowed:list`, or `file:read` + `yaml:key` +
+`equals`) in different ways. The building blocks are reusable across many
+checks, so learning a few covers a lot of ground.
+
+The [gaps matrix](gaps.md) is the recipe catalogue: for each 0.x check it shows
+the plugin chain that reproduces it in 1.x.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -10,3 +10,5 @@ features:
   details: Choose between simple (for humans), json, junit or table, according to your needs
 footer: Made by Salsa Digital with ❤️
 ---
+
+Shipshape supports two configuration formats — the 1.x pipeline (`collect` / `analyse` / `output`) and the legacy 0.x `checks:` format. The same binary runs both. See [Config versions](guide/versions.md).

--- a/docs/src/reference/checks/crawler.md
+++ b/docs/src/reference/checks/crawler.md
@@ -1,0 +1,40 @@
+# crawler
+
+Crawls a website and reports any page that does not return HTTP 200. Use this
+to detect broken pages or missing routes before a deployment is considered
+healthy.
+
+**Check type:** `crawler`
+
+## Fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Label shown in output |
+| `severity` | string | no | `low`, `normal`, `high`, or `critical` (default: `normal`) |
+| `domain` | string | yes | Base URL to crawl (e.g. `https://example.com`) |
+| `extra_domains` | list | no | Additional domains to follow links to |
+| `include_urls` | list | no | Specific URLs to include in the crawl regardless of discovery |
+| `limit` | int | no | Maximum number of pages to crawl (0 = unlimited) |
+
+## Example
+
+```yaml
+checks:
+  crawler:
+    - name: Site health check
+      domain: https://example.com
+      limit: 500
+```
+
+## Behaviour
+
+Shipshape uses [Colly](https://github.com/gocolly/colly) to crawl the site
+starting from `domain`. It follows links that stay within `domain` and any
+`extra_domains`. Any URL that returns a non-200 HTTP status is reported as a
+breach, including the URL and the status code received.
+
+## Remediation
+
+This check does not support automatic remediation. Investigate and fix the
+pages returning non-200 responses.

--- a/docs/src/reference/checks/docker-base-image.md
+++ b/docs/src/reference/checks/docker-base-image.md
@@ -1,0 +1,46 @@
+# docker:base_image
+
+Checks that Docker base images used in a project are on an explicit allow-list.
+Use this to prevent use of untrusted or deprecated base images.
+
+**Check type:** `docker:base_image`
+
+## Fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Label shown in output |
+| `severity` | string | no | `low`, `normal`, `high`, or `critical` (default: `normal`) |
+| `allowed` | list | yes | Image names (or prefixes) that are permitted |
+| `deprecated` | list | no | Image names that are permitted but should be replaced — reported as warnings |
+| `exclude` | list | no | File paths to exclude from the scan |
+| `pattern` | list | no | Glob patterns to locate Dockerfile files (default: `**/Dockerfile*`) |
+| `paths` | list | no | Directories to search for Dockerfiles |
+
+## Example
+
+```yaml
+checks:
+  docker:base_image:
+    - name: Approved base images
+      severity: high
+      allowed:
+        - uselagoon/php-8.2-fpm
+        - uselagoon/nginx-drupal
+      deprecated:
+        - uselagoon/php-8.1-fpm
+```
+
+## Behaviour
+
+Shipshape scans for Dockerfile files using the configured `pattern` and
+`paths`. For each `FROM` instruction found, it checks whether the image name
+matches an entry in `allowed`. Images in `deprecated` are allowed but reported
+separately. Any image not in either list is reported as a breach.
+
+Docker Compose files with `build.dockerfile` entries are also scanned.
+
+## Remediation
+
+This check does not support automatic remediation. Update the `FROM`
+instructions in your Dockerfiles to use an approved base image.

--- a/docs/src/reference/checks/drupal-admin-user.md
+++ b/docs/src/reference/checks/drupal-admin-user.md
@@ -1,0 +1,42 @@
+# drupal-admin-user
+
+Checks that the Drupal UID 1 account has only permitted roles. UID 1 is the
+superuser account and should not hold roles that grant broad administrative
+access in production.
+
+**Check type:** `drupal-admin-user`
+
+## Fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Label shown in output |
+| `severity` | string | no | `low`, `normal`, `high`, or `critical` (default: `normal`) |
+| `drush-path` | string | no | Path to the Drush binary (default: `vendor/drush/drush/drush`) |
+| `alias` | string | no | Drush site alias (e.g. `@prod`) |
+| `allowed-roles` | list | no | Roles that UID 1 is permitted to hold. Any other role is a breach |
+
+## Example
+
+```yaml
+checks:
+  drupal-admin-user:
+    - name: UID 1 roles
+      severity: critical
+      allowed-roles:
+        - authenticated
+```
+
+Source: `tests/e2e/suites/shipshape/drupal-role-isadmin.yml`
+
+## Behaviour
+
+Shipshape runs `drush [alias] user:information 1 --format=json` and inspects
+the roles assigned to UID 1. Any role not in `allowed-roles` is reported as a
+breach.
+
+## Remediation
+
+Shipshape can automatically remove disallowed roles from UID 1 using
+`drush user:role:remove`. Run Shipshape with the `--remediate` flag to enable
+this.

--- a/docs/src/reference/checks/drupal-db-module.md
+++ b/docs/src/reference/checks/drupal-db-module.md
@@ -1,0 +1,42 @@
+# drupal-db-module
+
+Checks which Drupal modules are enabled or disabled by querying the database
+via `drush pm:list`. Use this to verify module state in a running environment
+where exported config may not reflect the live database.
+
+**Check type:** `drupal-db-module`
+
+## Fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Label shown in output |
+| `severity` | string | no | `low`, `normal`, `high`, or `critical` (default: `normal`) |
+| `drush-path` | string | no | Path to the Drush binary (default: `vendor/drush/drush/drush`) |
+| `alias` | string | no | Drush site alias (e.g. `@prod`) |
+| `required` | list | no | Module names that must be enabled |
+| `disallowed` | list | no | Module names that must not be enabled |
+
+## Example
+
+```yaml
+checks:
+  drupal-db-module:
+    - name: Required security modules (live DB)
+      required:
+        - seckit
+        - shield
+      disallowed:
+        - devel
+```
+
+## Behaviour
+
+Shipshape runs `drush [alias] pm:list --status=enabled --format=json` and
+parses the output. Any module in `required` that is not enabled is reported as
+a breach. Any module in `disallowed` that is enabled is reported as a breach.
+
+## Remediation
+
+This check does not support automatic remediation. Enable or disable modules
+using Drush (`drush pm:enable`, `drush pm:uninstall`) or the Drupal UI.

--- a/docs/src/reference/checks/drupal-db-permissions.md
+++ b/docs/src/reference/checks/drupal-db-permissions.md
@@ -1,0 +1,50 @@
+# drupal-db-permissions
+
+Checks role permissions directly from the Drupal database. Use this to assert
+that sensitive permissions have not been granted to any role in a running
+environment.
+
+**Check type:** `drupal-db-permissions`
+
+## Fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Label shown in output |
+| `severity` | string | no | `low`, `normal`, `high`, or `critical` (default: `normal`) |
+| `drush-path` | string | no | Path to the Drush binary (default: `vendor/drush/drush/drush`) |
+| `alias` | string | no | Drush site alias (e.g. `@prod`) |
+| `disallowed` | list | no | Permissions that must not be granted to any role |
+
+## Example
+
+```yaml
+checks:
+  drupal-db-permissions:
+    - name: Disallowed permissions
+      severity: high
+      disallowed:
+        - administer config permissions
+        - administer modules
+        - administer permissions
+        - administer seckit
+        - administer site configuration
+        - administer software updates
+        - import configuration
+        - synchronize configuration
+        - use PHP for google analytics tracking visibility
+```
+
+Source: `tests/e2e/suites/shipshape/drupal-permissions.yml`
+
+## Behaviour
+
+Shipshape queries the `role__permissions` table via Drush and checks each role
+against the `disallowed` list. Any role that holds a disallowed permission is
+reported as a breach, including the role name and the specific permission.
+
+## Remediation
+
+Shipshape can automatically revoke disallowed permissions using
+`drush role:perm:remove`. Run Shipshape with the `--remediate` flag to enable
+this.

--- a/docs/src/reference/checks/drupal-db-user-tfa.md
+++ b/docs/src/reference/checks/drupal-db-user-tfa.md
@@ -1,0 +1,37 @@
+# drupal-db-user-tfa
+
+Checks that all Drupal user accounts have two-factor authentication (TFA)
+configured. Use this to enforce MFA compliance across all accounts in a running
+environment.
+
+**Check type:** `drupal-db-user-tfa`
+
+## Fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Label shown in output |
+| `severity` | string | no | `low`, `normal`, `high`, or `critical` (default: `normal`) |
+| `drush-path` | string | no | Path to the Drush binary (default: `vendor/drush/drush/drush`) |
+| `alias` | string | no | Drush site alias (e.g. `@prod`) |
+
+## Example
+
+```yaml
+checks:
+  drupal-db-user-tfa:
+    - name: All users have TFA configured
+      severity: critical
+```
+
+## Behaviour
+
+Shipshape queries the Drupal database via Drush to retrieve all active user
+accounts and checks whether each has a TFA method configured. Any user without
+TFA is reported as a breach, including their username and UID.
+
+## Remediation
+
+This check does not support automatic remediation. Direct affected users to
+configure TFA via their account settings, or enforce TFA at the role level
+using the TFA module's configuration.

--- a/docs/src/reference/checks/drupal-drush-yaml.md
+++ b/docs/src/reference/checks/drupal-drush-yaml.md
@@ -1,0 +1,62 @@
+# drush-yaml
+
+Reads Drupal configuration via `drush config:get` and asserts key-value pairs.
+Use this when you need to check live Drupal config rather than exported YAML
+files — for example, in a running environment.
+
+**Check type:** `drush-yaml`
+
+## Fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Label shown in output |
+| `severity` | string | no | `low`, `normal`, `high`, or `critical` (default: `normal`) |
+| `drush-path` | string | no | Path to the Drush binary (default: `vendor/drush/drush/drush`) |
+| `alias` | string | no | Drush site alias (e.g. `@prod`) |
+| `config-name` | string | yes | Drupal config object name (e.g. `update.settings`) |
+| `command` | string | no | Drush sub-command override (default: `config:get`) |
+| `remediate-command` | string | no | Drush command to run when remediating a breach |
+| `remediate-msg` | string | no | Message to display after remediation |
+| `values` | list of [KeyValue](#keyvalue-fields) | yes | Assertions to evaluate |
+
+## KeyValue fields
+
+Each entry in `values` supports:
+
+| Field | Type | Description |
+|---|---|---|
+| `key` | string | Dot-separated path to the config key (e.g. `check.interval_days`) |
+| `value` | string | Expected value (exact string match) |
+| `truthy` | bool | If `true`, assert the value is truthy rather than matching `value` |
+| `is-list` | bool | If `true`, treat the value at `key` as a list |
+| `optional` | bool | If `true`, skip the assertion when the key is absent |
+| `disallowed` | list | Values that must not appear at `key` |
+| `allowed` | list | Values that must appear at `key` |
+
+## Example
+
+```yaml
+checks:
+  drush-yaml:
+    - name: Ensure correct update settings
+      config-name: update.settings
+      values:
+        - key: check.interval_days
+          value: "7"
+```
+
+Source: `pkg/config/testdata/shipshape.yml`
+
+## Behaviour
+
+Shipshape runs `drush [alias] config:get <config-name> --format=yaml` and
+parses the output. Each `values` entry is then evaluated against the parsed
+YAML. Any assertion that fails is reported as a breach.
+
+## Remediation
+
+Set `remediate-command` to a Drush command that corrects the breach. When
+Shipshape runs in remediation mode, it executes that command for each failing
+assertion. Set `remediate-msg` to provide a human-readable summary of what was
+changed.

--- a/docs/src/reference/checks/drupal-file-module.md
+++ b/docs/src/reference/checks/drupal-file-module.md
@@ -1,0 +1,45 @@
+# drupal-file-module
+
+Checks which Drupal modules are enabled or disabled by reading the
+`core.extension.yml` file from the filesystem. Use this when you want to verify
+module state from exported config without a running Drupal instance.
+
+**Check type:** `drupal-file-module`
+
+## Fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Label shown in output |
+| `severity` | string | no | `low`, `normal`, `high`, or `critical` (default: `normal`) |
+| `path` | string | yes | Directory containing `core.extension.yml` |
+| `required` | list | no | Module names that must be enabled |
+| `disallowed` | list | no | Module names that must not be enabled |
+
+## Example
+
+```yaml
+checks:
+  drupal-file-module:
+    - name: Required security modules
+      path: config/default
+      required:
+        - seckit
+        - shield
+      disallowed:
+        - devel
+        - webprofiler
+```
+
+Source: `pkg/config/testdata/shipshape.yml`
+
+## Behaviour
+
+Shipshape reads `<path>/core.extension.yml` and checks the `module` key. Any
+module in `required` that is not listed is reported as a breach. Any module in
+`disallowed` that is listed is reported as a breach.
+
+## Remediation
+
+This check does not support automatic remediation. Enable or disable modules
+using Drush or the Drupal UI, then re-export configuration.

--- a/docs/src/reference/checks/drupal-role-permissions.md
+++ b/docs/src/reference/checks/drupal-role-permissions.md
@@ -1,0 +1,44 @@
+# drupal-role-permissions
+
+Checks the permissions assigned to a specific Drupal role. Use this to assert
+that a role has all required permissions and none of the disallowed ones.
+
+**Check type:** `drupal-role-permissions`
+
+## Fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Label shown in output |
+| `severity` | string | no | `low`, `normal`, `high`, or `critical` (default: `normal`) |
+| `drush-path` | string | no | Path to the Drush binary (default: `vendor/drush/drush/drush`) |
+| `alias` | string | no | Drush site alias (e.g. `@prod`) |
+| `rid` | string | yes | Role machine name to check (e.g. `editor`, `administrator`) |
+| `required-permissions` | list | no | Permissions that must be granted to the role |
+| `disallowed-permissions` | list | no | Permissions that must not be granted to the role |
+
+## Example
+
+```yaml
+checks:
+  drupal-role-permissions:
+    - name: Editor role permissions
+      rid: editor
+      required-permissions:
+        - access content
+        - create article content
+      disallowed-permissions:
+        - administer users
+        - administer permissions
+```
+
+## Behaviour
+
+Shipshape queries the role's permissions via Drush. Any permission in
+`required-permissions` that is absent is reported as a breach. Any permission
+in `disallowed-permissions` that is present is reported as a breach.
+
+## Remediation
+
+This check does not support automatic remediation. Update role permissions via
+the Drupal UI or using `drush role:perm:add` / `drush role:perm:remove`.

--- a/docs/src/reference/checks/drupal-tracking-code.md
+++ b/docs/src/reference/checks/drupal-tracking-code.md
@@ -1,0 +1,37 @@
+# drupal-tracking-code
+
+Checks that no third-party tracking code (analytics, tag managers) is embedded
+in Drupal configuration. Use this to prevent accidental inclusion of tracking
+scripts in production environments.
+
+**Check type:** `drupal-tracking-code`
+
+## Fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Label shown in output |
+| `severity` | string | no | `low`, `normal`, `high`, or `critical` (default: `normal`) |
+| `drush-path` | string | no | Path to the Drush binary (default: `vendor/drush/drush/drush`) |
+| `alias` | string | no | Drush site alias (e.g. `@prod`) |
+
+## Example
+
+```yaml
+checks:
+  drupal-tracking-code:
+    - name: No tracking code in Drupal config
+      severity: high
+```
+
+## Behaviour
+
+Shipshape fetches the site URI from `drush status` and then scans Drupal
+configuration for known tracking code patterns (Google Analytics, Google Tag
+Manager, and similar). Any match is reported as a breach.
+
+## Remediation
+
+This check does not support automatic remediation. Remove tracking code from
+Drupal configuration via the relevant module settings page or by editing the
+exported config files.

--- a/docs/src/reference/checks/drupal-user-forbidden.md
+++ b/docs/src/reference/checks/drupal-user-forbidden.md
@@ -1,0 +1,38 @@
+# drupal-user-forbidden
+
+Checks that a specific Drupal user account does not exist. Use this to assert
+that known-bad accounts (for example, a default admin account with a predictable
+username) have been removed.
+
+**Check type:** `drupal-user-forbidden`
+
+## Fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Label shown in output |
+| `severity` | string | no | `low`, `normal`, `high`, or `critical` (default: `normal`) |
+| `drush-path` | string | no | Path to the Drush binary (default: `vendor/drush/drush/drush`) |
+| `alias` | string | no | Drush site alias (e.g. `@prod`) |
+| `uid` | string | yes | UID of the user account to check for |
+
+## Example
+
+```yaml
+checks:
+  drupal-user-forbidden:
+    - name: Default admin account removed
+      severity: critical
+      uid: "1"
+```
+
+## Behaviour
+
+Shipshape runs `drush [alias] user:information <uid> --format=json` and checks
+whether the account exists. If it does, the check reports a breach including
+the username.
+
+## Remediation
+
+Shipshape can automatically block or cancel the forbidden user account using
+Drush. Run Shipshape with the `--remediate` flag to enable this.

--- a/docs/src/reference/checks/drupal-user-role.md
+++ b/docs/src/reference/checks/drupal-user-role.md
@@ -1,0 +1,42 @@
+# drupal-user-role
+
+Checks that all users assigned a given Drupal role are on an explicit
+allow-list. Use this to ensure that privileged roles (for example,
+`administrator`) are held only by known accounts.
+
+**Check type:** `drupal-user-role`
+
+## Fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Label shown in output |
+| `severity` | string | no | `low`, `normal`, `high`, or `critical` (default: `normal`) |
+| `drush-path` | string | no | Path to the Drush binary (default: `vendor/drush/drush/drush`) |
+| `alias` | string | no | Drush site alias (e.g. `@prod`) |
+| `roles` | list | yes | Role machine names to check |
+| `allowed-users` | list of int | no | UIDs that are permitted to hold the listed roles |
+
+## Example
+
+```yaml
+checks:
+  drupal-user-role:
+    - name: Administrator role allow-list
+      severity: critical
+      roles:
+        - administrator
+      allowed-users:
+        - 1
+        - 42
+```
+
+## Behaviour
+
+Shipshape queries all users holding any of the listed `roles` via Drush. Any
+user whose UID is not in `allowed-users` is reported as a breach.
+
+## Remediation
+
+This check does not support automatic remediation. Remove the role from
+unexpected users using `drush user:role:remove` or the Drupal UI.

--- a/docs/src/reference/checks/file-diff.md
+++ b/docs/src/reference/checks/file-diff.md
@@ -1,0 +1,46 @@
+# file:diff
+
+Compares a file on disk against a reference template and reports any
+differences. Use this to ensure configuration files have not drifted from a
+known-good baseline.
+
+**Check type:** `file:diff`
+
+## Fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Label shown in output |
+| `severity` | string | no | `low`, `normal`, `high`, or `critical` (default: `normal`) |
+| `target` | string | yes | Path to the file being checked |
+| `source` | string | yes | Path to the reference (template) file |
+| `source-context` | map | no | Variables injected into the template at render time |
+| `context-lines` | int | no | Number of context lines shown around each diff hunk (default: 3) |
+| `ignore-missing` | bool | no | If `true`, pass silently when `target` does not exist |
+
+## Example
+
+```yaml
+checks:
+  file:diff:
+    - name: Nginx config matches template
+      target: /etc/nginx/nginx.conf
+      source: templates/nginx.conf.j2
+      context-lines: 5
+```
+
+## Behaviour
+
+The `source` file is rendered as a [Gonja](https://github.com/nikolalohinski/gonja)
+template with any values from `source-context` available as template variables.
+The rendered output is then compared against `target` using a unified diff. Any
+difference is reported as a breach.
+
+Set `ignore-missing: true` when the target file is optional — for example, when
+checking an environment-specific override that may not exist in all
+environments.
+
+## Remediation
+
+This check does not support automatic remediation. Update the target file
+manually to match the template.

--- a/docs/src/reference/checks/file.md
+++ b/docs/src/reference/checks/file.md
@@ -1,0 +1,45 @@
+# file
+
+Asserts that no files matching a pattern exist at a given path. Use this to
+detect disallowed files — for example, database admin tools committed to the
+web root.
+
+**Check type:** `file`
+
+## Fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Label shown in output |
+| `severity` | string | no | `low`, `normal`, `high`, or `critical` (default: `normal`) |
+| `path` | string | yes | Directory to search in |
+| `disallowed-pattern` | string | yes | Regular expression. Any matching filename is a breach |
+| `skip-dir` | string | no | Directory name to skip during the search |
+
+## Example
+
+```yaml
+checks:
+  file:
+    - name: Illegal files
+      severity: high
+      path: web
+      disallowed-pattern: '^(adminer|phpmyadmin|bigdump)?\.php$'
+```
+
+Source: `tests/e2e/suites/shipshape/files-illegal.yml`
+
+## Behaviour
+
+Shipshape walks `path` recursively. Any file whose name matches
+`disallowed-pattern` is reported as a breach. The check passes if no matching
+files are found.
+
+Set `skip-dir` to exclude a subdirectory from the walk — for example, to
+ignore a vendor directory that legitimately contains files matching the
+pattern.
+
+## Remediation
+
+This check does not support automatic remediation. Remove disallowed files
+manually.

--- a/docs/src/reference/checks/json.md
+++ b/docs/src/reference/checks/json.md
@@ -1,0 +1,56 @@
+# json
+
+Asserts key-value pairs in JSON files on the filesystem. Supports the same
+assertion model as the [`yaml`](yaml.md) check.
+
+**Check type:** `json`
+
+## Fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Label shown in output |
+| `severity` | string | no | `low`, `normal`, `high`, or `critical` (default: `normal`) |
+| `path` | string | one of path/file/files/pattern | Directory to search in |
+| `file` | string | one of path/file/files/pattern | Single file name |
+| `files` | list | one of path/file/files/pattern | Explicit list of file names |
+| `pattern` | string | one of path/file/files/pattern | Regex pattern to match file names |
+| `exclude-pattern` | string | no | Regex pattern — matching files are skipped |
+| `key-values` | list of [KeyValue](#keyvalue-fields) | yes | Assertions to evaluate |
+
+## KeyValue fields
+
+Each entry in `key-values` supports:
+
+| Field | Type | Description |
+|---|---|---|
+| `key` | string | Dot-separated path to the JSON key |
+| `value` | string | Expected value (exact string match) |
+| `truthy` | bool | If `true`, assert the value is truthy rather than matching `value` |
+| `is-list` | bool | If `true`, treat the value at `key` as a list |
+| `optional` | bool | If `true`, skip the assertion when the key is absent |
+| `disallowed-values` | list | Values that must not appear at `key` |
+| `allowed-values` | list | Values that must appear at `key` |
+
+## Example
+
+```yaml
+checks:
+  json:
+    - name: Composer platform PHP version
+      file: composer.json
+      key-values:
+        - key: config.platform.php
+          value: "8.2"
+```
+
+## Behaviour
+
+Shipshape locates the target file(s) using the supplied path/file/files/pattern
+fields. For each file, it parses the JSON and evaluates every `key-values`
+entry. Any assertion that fails is reported as a breach.
+
+## Remediation
+
+This check does not support automatic remediation. Update the JSON files
+manually.

--- a/docs/src/reference/checks/phpstan.md
+++ b/docs/src/reference/checks/phpstan.md
@@ -1,0 +1,42 @@
+# phpstan
+
+Runs [PHPStan](https://phpstan.org/) static analysis and fails if any errors
+are reported. Use this to enforce code quality standards as part of a
+Shipshape audit.
+
+**Check type:** `phpstan`
+
+## Fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Label shown in output |
+| `severity` | string | no | `low`, `normal`, `high`, or `critical` (default: `normal`) |
+| `binary` | string | no | Path to the PHPStan binary (default: auto-detected) |
+| `configuration` | string | no | Path to the PHPStan config file (e.g. `phpstan.neon`) |
+| `paths` | list | yes | Directories or files to analyse |
+
+## Example
+
+```yaml
+checks:
+  phpstan:
+    - name: PHPStan analysis
+      configuration: phpstan.neon
+      paths:
+        - web/modules/custom
+        - web/themes/custom
+```
+
+Source: `tests/e2e/suites/shipshape/phpstan.yml`
+
+## Behaviour
+
+Shipshape runs PHPStan with `--error-format=json` and parses the output. Any
+file errors or global errors reported by PHPStan are recorded as breaches,
+including the file path, line number, and error message.
+
+## Remediation
+
+This check does not support automatic remediation. Fix the reported PHPStan
+errors in your PHP source code.

--- a/docs/src/reference/checks/sca-application-type.md
+++ b/docs/src/reference/checks/sca-application-type.md
@@ -1,0 +1,44 @@
+# sca:application_type
+
+Detects application frameworks present in a codebase and fails if any
+disallowed framework is found above a configurable threshold. Use this to
+prevent accidental introduction of a second framework into a project.
+
+**Check type:** `sca:application_type`
+
+## Fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Label shown in output |
+| `severity` | string | no | `low`, `normal`, `high`, or `critical` (default: `normal`) |
+| `disallowed` | list | yes | Framework names that must not be detected |
+| `threshold` | int | no | Minimum number of marker matches before a framework is considered present (default: 1) |
+| `entrypoint` | string | no | Root directory to start scanning from |
+| `paths` | list | no | Specific paths to scan |
+| `markers` | map | no | Custom marker strings per framework name |
+| `dirs` | map | no | Directories that indicate a framework's presence |
+| `dependencies` | map | no | Dependency names (from composer.json / package.json) that indicate a framework |
+
+## Example
+
+```yaml
+checks:
+  sca:application_type:
+    - name: No Symfony in Drupal project
+      disallowed:
+        - symfony
+      threshold: 20
+```
+
+## Behaviour
+
+Shipshape scans the codebase for markers associated with each framework in
+`disallowed`. A framework is considered present when the number of marker
+matches meets or exceeds `threshold`. Any detected disallowed framework is
+reported as a breach.
+
+## Remediation
+
+This check does not support automatic remediation. Remove the disallowed
+framework's code and dependencies manually.

--- a/docs/src/reference/checks/yaml.md
+++ b/docs/src/reference/checks/yaml.md
@@ -1,0 +1,79 @@
+# yaml
+
+Asserts key-value pairs in YAML files on the filesystem. Use this to verify
+Drupal exported config, application settings, or any structured YAML without
+needing a running Drupal instance.
+
+**Check type:** `yaml`
+
+## Fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Label shown in output |
+| `severity` | string | no | `low`, `normal`, `high`, or `critical` (default: `normal`) |
+| `path` | string | one of path/file/files/pattern | Directory to search in |
+| `file` | string | one of path/file/files/pattern | Single file name |
+| `files` | list | one of path/file/files/pattern | Explicit list of file names |
+| `pattern` | string | one of path/file/files/pattern | Regex pattern to match file names |
+| `config-name` | string | no | Drupal config name (used with `path` to locate `<config-name>.yml`) |
+| `exclude-pattern` | string | no | Regex pattern — matching files are skipped |
+| `values` | list of [KeyValue](#keyvalue-fields) | yes | Assertions to evaluate |
+
+## KeyValue fields
+
+Each entry in `values` supports:
+
+| Field | Type | Description |
+|---|---|---|
+| `key` | string | Dot-separated path to the YAML key (e.g. `check.interval_days`) |
+| `value` | string | Expected value (exact string match) |
+| `truthy` | bool | If `true`, assert the value is truthy rather than matching `value` |
+| `is-list` | bool | If `true`, treat the value at `key` as a list |
+| `optional` | bool | If `true`, skip the assertion when the key is absent |
+| `disallowed` | list | Values that must not appear at `key` |
+| `allowed` | list | Values that must appear at `key` |
+
+## Example
+
+```yaml
+checks:
+  yaml:
+    - name: File config check
+      config-name: update.settings
+      path: config/default
+      values:
+        - key: check.interval_days
+          value: "7"
+```
+
+Source: `pkg/config/testdata/shipshape.yml`
+
+Multiple assertions in one check:
+
+```yaml
+checks:
+  yaml:
+    - name: Cron and update settings
+      path: config/default
+      config-name: automated_cron.settings
+      values:
+        - key: interval
+          value: "10800"
+        - key: status
+          truthy: true
+```
+
+## Behaviour
+
+Shipshape locates the target file(s) using the supplied path/file/files/pattern
+fields. For each file, it parses the YAML and evaluates every `values` entry.
+Any assertion that fails is reported as a breach.
+
+When `config-name` is set alongside `path`, Shipshape looks for
+`<path>/<config-name>.yml`.
+
+## Remediation
+
+This check does not support automatic remediation. Update the YAML files
+manually.


### PR DESCRIPTION
## Summary
Introduces the 1.x configuration format as the recommended way to use Shipshape, documents the legacy 0.x `checks:` format, and maps the path to parity. The same binary runs both formats — this PR is about **documentation and messaging**, not behaviour changes. It also wires up publishing the docs site under the `/1.x/` base.
## What's changed
**Announcement (README)**
- New `## Config versions` section at the top of `README.md`:
  - **1.x is recommended** — the composable `collect` / `analyse` / `output` pipeline, used in production, where new capabilities land.
  - **0.x is fully supported** — the legacy `checks:` format runs unchanged; no forced migration.
  - Explains the **compose-don't-port** philosophy (wire general-purpose plugins into recipes rather than one dedicated check per task).
  - Flags that a few 0.x checks have no documented 1.x recipe yet and that we're **closing those gaps soon**, linking to the gaps matrix and roadmap.
**New guide pages** (`docs/src/guide/`)
- `versions.md` — the two formats, auto-detection rule, and which to use.
- `0.x.md` — overview of the legacy `checks:` format.
- `gaps.md` — recipe catalogue / coverage matrix (Achievable now · Achievable, undocumented · Needs new capability).
- `roadmap.md` — recipes-not-ports direction and deferred (TBD) capabilities.
**New reference pages** (`docs/src/reference/checks/`)
- 18 pages documenting every registered 0.x check type.
**Navigation & entry points**
- VuePress sidebar updated (`.vuepress/config.js`) with the new guide group and a `Checks (0.x)` reference section.
- `guide/README.md` and `index.md` updated with the versions callout and links.
**CI**
- Docs workflow now publishes the site under the `/1.x/` base (`24782fc`), so the absolute doc links in the README resolve once merged/deployed.
## Notes for reviewers
- **Docs-only** — no Go source changes. Pre-existing LSP/compile errors in `pkg/**` (e.g. `pkg/config/checkbase.go`) are unrelated to this PR.
- Every YAML snippet in the docs is sourced from real `examples/` or `pkg/**/testdata/` files — none invented.
- The three deferred checks (`file:diff`, `crawler`, `sca:application_type`) are marked **TBD** with no external tool names suggested, by design.
- README uses absolute `https://salsadigitalauorg.github.io/shipshape/1.x/guide/*.html` links (it renders on GitHub). These go live once the `/1.x/` publish workflow (`24782fc`) has deployed.
## Follow-ups (out of scope)
- Author the 9 "Achievable, undocumented" recipe `examples/` files.
- Decide direction for the 3 TBD capabilities.