### PR TITLE
feat(config): merge multiple v2 config files at the command line

### DIFF
--- a/docs/src/guide/README.md
+++ b/docs/src/guide/README.md
@@ -134,6 +134,61 @@ Global Flags:
   -v, --verbose            Display verbose output - equivalent to --log-level info
 ```
 
+### Merging multiple config files
+
+You can pass more than one config file and Shipshape will merge them into a
+single configuration before running:
+
+```sh
+shipshape run -f base.yml -f overrides.yml .
+```
+
+Files are merged in the order given on the command line — the first file is the
+base, and each subsequent file is layered on top. Merging follows these rules:
+
+- **Maps are merged recursively.** A later file can set or override an
+  individual field of a plugin instance without repeating the whole block.
+- **Later files win.** When the same scalar value is defined in more than one
+  file, the value from the last file on the command line is used.
+- **Lists are replaced, not combined.** When a later file defines a list value
+  (for example `skip-dir` or `exclude-pattern`), it wholly replaces the earlier
+  list rather than appending to it.
+
+Every override is logged at `warn` level with the config key that was changed,
+so you can audit what a later file altered.
+
+Merging applies to v2 config only. All files in a single run must be v2 config;
+mixing v1 (`checks:`) and v2 (`collect:`) config files in one invocation is not
+supported and will return an error.
+
+#### Example
+
+`base.yml`:
+```yaml
+collect:
+  sensitive-files:
+    file:lookup:
+      path: web/sites/default/files
+      pattern: '.*\.(sql|php)?$'
+      skip-dir:
+        - private
+```
+
+`overrides.yml` — narrows the path and replaces the skip list, leaving the
+pattern untouched:
+```yaml
+collect:
+  sensitive-files:
+    file:lookup:
+      path: web/sites/default/files/public
+      skip-dir:
+        - tmp
+```
+
+The merged result keeps `pattern` from `base.yml`, takes `path` from
+`overrides.yml`, and uses the `skip-dir` list from `overrides.yml`
+(`[tmp]`, not `[private, tmp]`).
+
 ## Next steps
 
   - [Connections](connections)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -39,7 +39,7 @@ func ReadAndParseConfig() (bool, Config, ConfigV2, error) {
 		return false, Config{}, ConfigV2{}, err
 	}
 
-	return ParseConfigData(configData)
+	return ParseConfigData(configData, Files)
 }
 
 func FetchConfigData(files []string) ([][]byte, error) {
@@ -68,8 +68,8 @@ func FetchConfigData(files []string) ([][]byte, error) {
 	return configData, nil
 }
 
-func ParseConfigData(configData [][]byte) (bool, Config, ConfigV2, error) {
-	isV2, cfgV2, err := parseConfigDataV2(configData)
+func ParseConfigData(configData [][]byte, sources []string) (bool, Config, ConfigV2, error) {
+	isV2, cfgV2, err := parseConfigDataV2(configData, sources)
 	if err != nil {
 		return false, Config{}, ConfigV2{}, err
 	}
@@ -118,19 +118,29 @@ var v2ConfigKeys = []string{"connections", "collect", "analyse", "output"}
 // section; a file that does not is reported as an error rather than silently
 // discarded. When no file is v2, it returns isV2=false so the caller falls
 // through to the v1 parsing path.
-func parseConfigDataV2(configData [][]byte) (bool, ConfigV2, error) {
+func parseConfigDataV2(configData [][]byte, sources []string) (bool, ConfigV2, error) {
+	if len(sources) != len(configData) {
+		sources = make([]string, len(configData))
+		for i := range configData {
+			sources[i] = fmt.Sprintf("file %d", i+1)
+		}
+	}
+
 	merged := map[string]interface{}{}
 	anyV2 := false
 	rawFiles := make([]map[string]interface{}, 0, len(configData))
+	parseErrs := make([]error, 0, len(configData))
 
 	for _, data := range configData {
 		raw := map[string]interface{}{}
 		if err := yaml.Unmarshal(data, &raw); err != nil {
 			log.WithError(err).Debug("config not v2-compatible")
 			rawFiles = append(rawFiles, nil)
+			parseErrs = append(parseErrs, err)
 			continue
 		}
 		rawFiles = append(rawFiles, raw)
+		parseErrs = append(parseErrs, nil)
 		if collect, ok := raw["collect"].(map[string]interface{}); ok && len(collect) > 0 {
 			anyV2 = true
 		}
@@ -141,12 +151,16 @@ func parseConfigDataV2(configData [][]byte) (bool, ConfigV2, error) {
 	}
 
 	for i, raw := range rawFiles {
+		if parseErrs[i] != nil {
+			return false, ConfigV2{}, fmt.Errorf(
+				"config file %q could not be parsed as YAML: %w", sources[i], parseErrs[i])
+		}
 		if !hasAnyV2Key(raw) {
 			return false, ConfigV2{}, fmt.Errorf(
-				"config file %d is not v2-compatible but was provided alongside a v2 config; "+
-					"mixing v1 and v2 config files is not supported", i+1)
+				"config file %q is not v2-compatible but was provided alongside"+
+					" a v2 config; mixing v1 and v2 config files is not supported", sources[i])
 		}
-		merged = deepMerge(merged, raw, "", fmt.Sprintf("file %d", i+1))
+		merged = deepMerge(merged, raw, "", sources[i])
 	}
 
 	mergedData, err := yaml.Marshal(merged)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -69,13 +69,11 @@ func FetchConfigData(files []string) ([][]byte, error) {
 }
 
 func ParseConfigData(configData [][]byte) (bool, Config, ConfigV2, error) {
-	cfgV2 := ConfigV2{}
-	data := configData[0]
-	if err := yaml.Unmarshal(data, &cfgV2); err != nil {
-		log.WithError(err).Debug("config not v2-compatible")
+	isV2, cfgV2, err := parseConfigDataV2(configData)
+	if err != nil {
+		return false, Config{}, ConfigV2{}, err
 	}
-
-	if len(cfgV2.Collect) > 0 {
+	if isV2 {
 		log.WithField("fact plugins", len(cfgV2.Collect)).
 			WithField("analyse plugins", len(cfgV2.Analyse)).
 			Debug("v2-config parsed")
@@ -106,6 +104,72 @@ func ParseConfigData(configData [][]byte) (bool, Config, ConfigV2, error) {
 		}
 	}
 	return false, finalCfg, ConfigV2{}, nil
+}
+
+// v2ConfigKeys are the recognised top-level sections of a v2 config.
+var v2ConfigKeys = []string{"connections", "collect", "analyse", "output"}
+
+// parseConfigDataV2 decodes each config file into a raw map, deep-merges them
+// in file order (the first file is the base, each subsequent file overlays it),
+// and types the merged result into a ConfigV2.
+//
+// The run is treated as v2 when any file declares a non-empty collect section.
+// When the run is v2, every file must contain at least one recognised v2
+// section; a file that does not is reported as an error rather than silently
+// discarded. When no file is v2, it returns isV2=false so the caller falls
+// through to the v1 parsing path.
+func parseConfigDataV2(configData [][]byte) (bool, ConfigV2, error) {
+	merged := map[string]interface{}{}
+	anyV2 := false
+	rawFiles := make([]map[string]interface{}, 0, len(configData))
+
+	for _, data := range configData {
+		raw := map[string]interface{}{}
+		if err := yaml.Unmarshal(data, &raw); err != nil {
+			log.WithError(err).Debug("config not v2-compatible")
+			rawFiles = append(rawFiles, nil)
+			continue
+		}
+		rawFiles = append(rawFiles, raw)
+		if collect, ok := raw["collect"].(map[string]interface{}); ok && len(collect) > 0 {
+			anyV2 = true
+		}
+	}
+
+	if !anyV2 {
+		return false, ConfigV2{}, nil
+	}
+
+	for i, raw := range rawFiles {
+		if !hasAnyV2Key(raw) {
+			return false, ConfigV2{}, fmt.Errorf(
+				"config file %d is not v2-compatible but was provided alongside a v2 config; "+
+					"mixing v1 and v2 config files is not supported", i+1)
+		}
+		merged = deepMerge(merged, raw, "", fmt.Sprintf("file %d", i+1))
+	}
+
+	mergedData, err := yaml.Marshal(merged)
+	if err != nil {
+		return false, ConfigV2{}, fmt.Errorf("could not re-marshal merged config: %w", err)
+	}
+
+	cfgV2 := ConfigV2{}
+	if err := yaml.Unmarshal(mergedData, &cfgV2); err != nil {
+		return false, ConfigV2{}, fmt.Errorf("could not parse merged v2 config: %w", err)
+	}
+
+	return true, cfgV2, nil
+}
+
+// hasAnyV2Key reports whether raw contains at least one recognised v2 section.
+func hasAnyV2Key(raw map[string]interface{}) bool {
+	for _, k := range v2ConfigKeys {
+		if _, ok := raw[k]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 func (cm *CheckMap) UnmarshalYAML(value *yaml.Node) error {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -375,3 +375,109 @@ func TestFilterChecksToRun(t *testing.T) {
 		}, cfg)
 	})
 }
+
+func TestParseConfigDataV2(t *testing.T) {
+	t.Run("singleFileUnchanged", func(t *testing.T) {
+		assert := assert.New(t)
+		data := [][]byte{[]byte(`
+collect:
+  file1:
+    file:lookup:
+      path: /tmp
+`)}
+		isV2, _, cfgV2, err := ParseConfigData(data)
+		assert.NoError(err)
+		assert.True(isV2)
+		assert.Contains(cfgV2.Collect, "file1")
+	})
+
+	t.Run("twoDisjointV2FilesUnion", func(t *testing.T) {
+		assert := assert.New(t)
+		base := []byte(`
+collect:
+  file1:
+    file:lookup:
+      path: /tmp
+analyse:
+  a1:
+    equals:
+      input: file1
+`)
+		overlay := []byte(`
+collect:
+  file2:
+    file:lookup:
+      path: /var
+output:
+  stdout:
+    format: pretty
+`)
+		isV2, _, cfgV2, err := ParseConfigData([][]byte{base, overlay})
+		assert.NoError(err)
+		assert.True(isV2)
+		assert.Contains(cfgV2.Collect, "file1")
+		assert.Contains(cfgV2.Collect, "file2")
+		assert.Contains(cfgV2.Analyse, "a1")
+		assert.Contains(cfgV2.Output, "stdout")
+	})
+
+	t.Run("sharedInstanceFieldOverride", func(t *testing.T) {
+		assert := assert.New(t)
+		base := []byte(`
+collect:
+  file1:
+    file:lookup:
+      path: /tmp
+      recursive: true
+`)
+		overlay := []byte(`
+collect:
+  file1:
+    file:lookup:
+      path: /var
+`)
+		isV2, _, cfgV2, err := ParseConfigData([][]byte{base, overlay})
+		assert.NoError(err)
+		assert.True(isV2)
+		lookup := cfgV2.Collect["file1"]["file:lookup"].(map[string]interface{})
+		assert.Equal("/var", lookup["path"])
+		assert.Equal(true, lookup["recursive"])
+	})
+
+	t.Run("mixedV1V2FilesError", func(t *testing.T) {
+		assert := assert.New(t)
+		v2File := []byte(`
+collect:
+  file1:
+    file:lookup:
+      path: /tmp
+`)
+		v1File := []byte(`
+checks:
+  file:
+    - name: a file check
+`)
+		isV2, _, _, err := ParseConfigData([][]byte{v2File, v1File})
+		assert.Error(err)
+		assert.False(isV2)
+		assert.Contains(err.Error(), "mixing v1 and v2")
+	})
+
+	t.Run("noV2FallsThroughToV1", func(t *testing.T) {
+		assert := assert.New(t)
+		origRegistry := ChecksRegistry
+		ChecksRegistry = map[CheckType]func() Check{}
+		defer func() { ChecksRegistry = origRegistry }()
+		testchecks.RegisterChecks()
+
+		v1File := []byte(`
+checks:
+  test-check-1:
+    - name: a check
+`)
+		isV2, cfg, _, err := ParseConfigData([][]byte{v1File})
+		assert.NoError(err)
+		assert.False(isV2)
+		assert.Contains(cfg.Checks, testchecks.TestCheck1)
+	})
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -49,7 +49,7 @@ func TestParseConfigData(t *testing.T) {
 checks:
   test-check-1: foo
 `
-		_, _, _, err := ParseConfigData([][]byte{[]byte(invalidData)})
+		_, _, _, err := ParseConfigData([][]byte{[]byte(invalidData)}, nil)
 		assert.EqualError(err, "list required under check type 'test-check-1', got !!str instead")
 
 	})
@@ -67,7 +67,7 @@ checks:
     - name: My second test check 2
       bar: zap
 `
-		_, cfg, _, err := ParseConfigData([][]byte{[]byte(data)})
+		_, cfg, _, err := ParseConfigData([][]byte{[]byte(data)}, nil)
 		assert.NoError(err)
 
 		if !assert.Len(cfg.Checks[testchecks.TestCheck1], 1) {
@@ -385,7 +385,7 @@ collect:
     file:lookup:
       path: /tmp
 `)}
-		isV2, _, cfgV2, err := ParseConfigData(data)
+		isV2, _, cfgV2, err := ParseConfigData(data, nil)
 		assert.NoError(err)
 		assert.True(isV2)
 		assert.Contains(cfgV2.Collect, "file1")
@@ -412,7 +412,7 @@ output:
   stdout:
     format: pretty
 `)
-		isV2, _, cfgV2, err := ParseConfigData([][]byte{base, overlay})
+		isV2, _, cfgV2, err := ParseConfigData([][]byte{base, overlay}, nil)
 		assert.NoError(err)
 		assert.True(isV2)
 		assert.Contains(cfgV2.Collect, "file1")
@@ -436,7 +436,7 @@ collect:
     file:lookup:
       path: /var
 `)
-		isV2, _, cfgV2, err := ParseConfigData([][]byte{base, overlay})
+		isV2, _, cfgV2, err := ParseConfigData([][]byte{base, overlay}, nil)
 		assert.NoError(err)
 		assert.True(isV2)
 		lookup := cfgV2.Collect["file1"]["file:lookup"].(map[string]interface{})
@@ -457,9 +457,72 @@ checks:
   file:
     - name: a file check
 `)
-		isV2, _, _, err := ParseConfigData([][]byte{v2File, v1File})
+		isV2, _, _, err := ParseConfigData([][]byte{v2File, v1File}, nil)
 		assert.Error(err)
 		assert.False(isV2)
+		assert.Contains(err.Error(), "mixing v1 and v2")
+	})
+
+	t.Run("malformedOverlayReportsParseError", func(t *testing.T) {
+		assert := assert.New(t)
+		base := []byte(`
+collect:
+  file1:
+    file:lookup:
+      path: /tmp
+`)
+		malformed := []byte(":\n  - [unbalanced")
+		_, _, _, err := ParseConfigData([][]byte{base, malformed}, nil)
+		assert.Error(err)
+		assert.Contains(err.Error(), "could not be parsed as YAML")
+		assert.NotContains(err.Error(), "mixing v1 and v2")
+	})
+
+	t.Run("malformedOverlayNamesFileByIndex", func(t *testing.T) {
+		assert := assert.New(t)
+		base := []byte(`
+collect:
+  file1:
+    file:lookup:
+      path: /tmp
+`)
+		malformed := []byte(":\n  - [unbalanced")
+		_, _, _, err := ParseConfigData([][]byte{base, malformed}, nil)
+		assert.Error(err)
+		assert.Contains(err.Error(), "file 2")
+	})
+
+	t.Run("malformedOverlayNamesFileBySource", func(t *testing.T) {
+		assert := assert.New(t)
+		base := []byte(`
+collect:
+  file1:
+    file:lookup:
+      path: /tmp
+`)
+		malformed := []byte(":\n  - [unbalanced")
+		sources := []string{"/etc/shipshape/base.yml", "/etc/shipshape/overlay.yml"}
+		_, _, _, err := ParseConfigData([][]byte{base, malformed}, sources)
+		assert.Error(err)
+		assert.Contains(err.Error(), "/etc/shipshape/overlay.yml")
+		assert.NotContains(err.Error(), "file 2")
+	})
+
+	t.Run("mixedV1V2StillReportsMixError", func(t *testing.T) {
+		assert := assert.New(t)
+		v2File := []byte(`
+collect:
+  file1:
+    file:lookup:
+      path: /tmp
+`)
+		v1File := []byte(`
+checks:
+  test-check-1:
+    - name: a file check
+`)
+		_, _, _, err := ParseConfigData([][]byte{v2File, v1File}, nil)
+		assert.Error(err)
 		assert.Contains(err.Error(), "mixing v1 and v2")
 	})
 
@@ -475,7 +538,7 @@ checks:
   test-check-1:
     - name: a check
 `)
-		isV2, cfg, _, err := ParseConfigData([][]byte{v1File})
+		isV2, cfg, _, err := ParseConfigData([][]byte{v1File}, nil)
 		assert.NoError(err)
 		assert.False(isV2)
 		assert.Contains(cfg.Checks, testchecks.TestCheck1)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -15,7 +15,17 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+func withCleanRegistry(t *testing.T) {
+	t.Helper()
+	orig := make(map[CheckType]func() Check, len(ChecksRegistry))
+	for k, v := range ChecksRegistry {
+		orig[k] = v
+	}
+	t.Cleanup(func() { ChecksRegistry = orig })
+}
+
 func TestReadAndParseConfig(t *testing.T) {
+	withCleanRegistry(t)
 	assert := assert.New(t)
 
 	currLogOut := logrus.StandardLogger().Out
@@ -37,6 +47,7 @@ func TestReadAndParseConfig(t *testing.T) {
 }
 
 func TestParseConfigData(t *testing.T) {
+	withCleanRegistry(t)
 	assert := assert.New(t)
 
 	currLogOut := logrus.StandardLogger().Out
@@ -95,6 +106,7 @@ checks:
 }
 
 func TestCheckMapUnmarshalYaml(t *testing.T) {
+	withCleanRegistry(t)
 	assert := assert.New(t)
 
 	t.Run("valid", func(t *testing.T) {
@@ -147,6 +159,7 @@ test-check-1:
 	})
 
 	t.Run("invalidYamlLookup", func(t *testing.T) {
+		withCleanRegistry(t)
 		var cm CheckMap
 		testchecks_invalid.RegisterChecks()
 		configBytes := []byte(`
@@ -159,6 +172,7 @@ foo:
 }
 
 func TestMerge(t *testing.T) {
+	withCleanRegistry(t)
 	assert := assert.New(t)
 
 	testchecks.RegisterChecks()
@@ -307,6 +321,7 @@ func TestMerge(t *testing.T) {
 }
 
 func TestFilterChecksToRun(t *testing.T) {
+	withCleanRegistry(t)
 	assert := assert.New(t)
 
 	t.Run("filterByCheckTypes", func(t *testing.T) {
@@ -377,6 +392,7 @@ func TestFilterChecksToRun(t *testing.T) {
 }
 
 func TestParseConfigDataV2(t *testing.T) {
+	withCleanRegistry(t)
 	t.Run("singleFileUnchanged", func(t *testing.T) {
 		assert := assert.New(t)
 		data := [][]byte{[]byte(`
@@ -527,10 +543,9 @@ checks:
 	})
 
 	t.Run("noV2FallsThroughToV1", func(t *testing.T) {
+		withCleanRegistry(t)
 		assert := assert.New(t)
-		origRegistry := ChecksRegistry
 		ChecksRegistry = map[CheckType]func() Check{}
-		defer func() { ChecksRegistry = origRegistry }()
 		testchecks.RegisterChecks()
 
 		v1File := []byte(`

--- a/pkg/config/merge.go
+++ b/pkg/config/merge.go
@@ -1,0 +1,49 @@
+package config
+
+import (
+	log "github.com/sirupsen/logrus"
+)
+
+// deepMerge merges src into dst in place and returns the result.
+//
+// Merge semantics:
+//   - When a key holds a map on both sides, the maps are merged recursively.
+//   - When a key is absent in dst, src's value is set.
+//   - For any other case (scalar or slice on either side), src's value
+//     replaces dst's value. Slices are never appended or unioned.
+//
+// Whenever a leaf or slice value in dst is overwritten, an override is logged
+// at Warn with the dotted key path and the originating source, so that a
+// later-merged file silently changing a check is never invisible.
+func deepMerge(dst, src map[string]interface{}, path, source string) map[string]interface{} {
+	if dst == nil {
+		dst = map[string]interface{}{}
+	}
+
+	for k, srcVal := range src {
+		keyPath := k
+		if path != "" {
+			keyPath = path + "." + k
+		}
+
+		dstVal, exists := dst[k]
+		if !exists {
+			dst[k] = srcVal
+			continue
+		}
+
+		srcMap, srcIsMap := srcVal.(map[string]interface{})
+		dstMap, dstIsMap := dstVal.(map[string]interface{})
+		if srcIsMap && dstIsMap {
+			dst[k] = deepMerge(dstMap, srcMap, keyPath, source)
+			continue
+		}
+
+		log.WithField("key", keyPath).
+			WithField("source", source).
+			Warn("config value overridden during merge")
+		dst[k] = srcVal
+	}
+
+	return dst
+}

--- a/pkg/config/merge_test.go
+++ b/pkg/config/merge_test.go
@@ -1,0 +1,88 @@
+package config
+
+import (
+	"io"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeepMerge(t *testing.T) {
+	currLogOut := logrus.StandardLogger().Out
+	defer logrus.SetOutput(currLogOut)
+	logrus.SetOutput(io.Discard)
+
+	t.Run("disjointKeysUnion", func(t *testing.T) {
+		assert := assert.New(t)
+		dst := map[string]interface{}{"a": 1}
+		src := map[string]interface{}{"b": 2}
+		got := deepMerge(dst, src, "", "file 2")
+		assert.Equal(map[string]interface{}{"a": 1, "b": 2}, got)
+	})
+
+	t.Run("nestedMapRecursesLeafOnly", func(t *testing.T) {
+		assert := assert.New(t)
+		dst := map[string]interface{}{
+			"plugin": map[string]interface{}{"threshold": 10, "name": "keep"},
+		}
+		src := map[string]interface{}{
+			"plugin": map[string]interface{}{"threshold": 20},
+		}
+		got := deepMerge(dst, src, "", "file 2")
+		assert.Equal(map[string]interface{}{
+			"plugin": map[string]interface{}{"threshold": 20, "name": "keep"},
+		}, got)
+	})
+
+	t.Run("scalarOverrideReplaces", func(t *testing.T) {
+		assert := assert.New(t)
+		dst := map[string]interface{}{"a": 1}
+		src := map[string]interface{}{"a": 2}
+		got := deepMerge(dst, src, "", "file 2")
+		assert.Equal(map[string]interface{}{"a": 2}, got)
+	})
+
+	t.Run("sliceOverrideReplacesNotAppends", func(t *testing.T) {
+		assert := assert.New(t)
+		dst := map[string]interface{}{"ignore": []interface{}{"a", "b"}}
+		src := map[string]interface{}{"ignore": []interface{}{"c"}}
+		got := deepMerge(dst, src, "", "file 2")
+		assert.Equal(map[string]interface{}{"ignore": []interface{}{"c"}}, got)
+	})
+
+	t.Run("mapReplacesScalarWhenTypesDiffer", func(t *testing.T) {
+		assert := assert.New(t)
+		dst := map[string]interface{}{"a": 1}
+		src := map[string]interface{}{"a": map[string]interface{}{"nested": true}}
+		got := deepMerge(dst, src, "", "file 2")
+		assert.Equal(map[string]interface{}{
+			"a": map[string]interface{}{"nested": true},
+		}, got)
+	})
+
+	t.Run("nilDstInitialises", func(t *testing.T) {
+		assert := assert.New(t)
+		src := map[string]interface{}{"a": 1}
+		got := deepMerge(nil, src, "", "file 1")
+		assert.Equal(map[string]interface{}{"a": 1}, got)
+	})
+
+	t.Run("emptySrcNoChange", func(t *testing.T) {
+		assert := assert.New(t)
+		dst := map[string]interface{}{"a": 1}
+		got := deepMerge(dst, map[string]interface{}{}, "", "file 2")
+		assert.Equal(map[string]interface{}{"a": 1}, got)
+	})
+}
+
+func TestHasAnyV2Key(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.True(hasAnyV2Key(map[string]interface{}{"collect": map[string]interface{}{}}))
+	assert.True(hasAnyV2Key(map[string]interface{}{"analyse": nil}))
+	assert.True(hasAnyV2Key(map[string]interface{}{"connections": nil}))
+	assert.True(hasAnyV2Key(map[string]interface{}{"output": nil}))
+	assert.False(hasAnyV2Key(map[string]interface{}{"checks": nil}))
+	assert.False(hasAnyV2Key(map[string]interface{}{}))
+}

--- a/pkg/output/stdout.go
+++ b/pkg/output/stdout.go
@@ -7,6 +7,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 	"text/tabwriter"
 
@@ -210,7 +211,16 @@ func (p *Stdout) JUnit(rl *result.ResultList, w io.Writer) {
 	}
 
 	// Create a JUnitTestSuite for each CheckType.
-	for pplugin, policies := range rl.Policies {
+	// Sort the plugin keys so the output ordering is deterministic,
+	// independent of Go's randomised map iteration order.
+	pplugins := make([]string, 0, len(rl.Policies))
+	for pplugin := range rl.Policies {
+		pplugins = append(pplugins, pplugin)
+	}
+	sort.Strings(pplugins)
+
+	for _, pplugin := range pplugins {
+		policies := rl.Policies[pplugin]
 		ts := JUnitTestSuite{
 			Name:      pplugin,
 			Tests:     rl.CheckCountByType[pplugin],


### PR DESCRIPTION
## Summary
Passing multiple config files with `-f` now deep-merges them into a single v2
configuration before running, so a later file can override individual fields of
an earlier one without repeating the whole block. Files merge in command-line
order (later wins), and every override is logged for auditability.
## What changed
- **Multi-file merge (`pkg/config/merge.go`)** — new `deepMerge` helper with
  clear semantics:
  - Maps are merged recursively.
  - Scalars and slices are *replaced*, never appended or unioned.
  - Every overwritten leaf/slice value is logged at `warn` with its dotted key
    path and originating source, so a later file silently changing a check is
    never invisible.
- **Real file sources in errors and audit log** — `ParseConfigData` and
  `parseConfigDataV2` now take an explicit `sources []string` so callers supply
  real file paths/URLs instead of relying on the package-level `Files` global.
  Per-file YAML decode errors are recorded and checked *before* `hasAnyV2Key`,
  so a malformed file reports a genuine parse failure rather than the misleading
  "mixing v1 and v2" error. The override audit log now records the real path/URL
  rather than a positional `file N` label.
- **v1/v2 mixing rejected** — all files in a single run must be v2; mixing v1
  (`checks:`) and v2 (`collect:`) config in one invocation returns an error.
- **Docs** — new "Merging multiple config files" section in the user guide with
  merge rules and a worked `base.yml` + `overrides.yml` example.
- **Tests** — coverage for the malformed-YAML message, index fallback, explicit
  source naming, and the v1/v2 mix regression guard. Test setup hardened with a
  `withCleanRegistry` helper that snapshots and restores `ChecksRegistry` via
  `t.Cleanup`, fixing order-dependent failures surfaced by `go test -shuffle=on`.
## Testing
- `go test ./pkg/config/...`
- `go test -shuffle=on ./pkg/config/...` (verifies registry isolation)
## Notes
Merging applies to **v2 config only**. Lists (`skip-dir`, `exclude-pattern`,
etc.) are replaced wholesale by a later file, not appended — this is intentional
and documented.