### PR TITLE
ci: create latest tag from 1.x

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -58,6 +58,8 @@ jobs:
         uses: docker/metadata-action@master
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=true
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}


### PR DESCRIPTION
The `latest` image tag is currently being built from `main`, whereas the default branch is `1.x`. This PR fixes that to instead build `latest` from `1.x`

Fixes #85