### PR TITLE
feat(fact): add json:key JSONPath fact plugin

### DIFF
--- a/docs/src/guide/gaps.md
+++ b/docs/src/guide/gaps.md
@@ -51,7 +51,7 @@ Source: `examples/files.yml`
 | 0.x check | Status | 1.x plugin chain |
 |---|---|---|
 | [`yaml`](../reference/checks/yaml.md) | Achievable now | `file:read` + `yaml:key` + `equals` / `allowed:list` — see `examples/drupal-config.yml` |
-| [`json`](../reference/checks/json.md) | Needs new capability | Needs a `json:key` fact plugin (analogous to `yaml:key`) — [on the roadmap](roadmap.md) |
+| [`json`](../reference/checks/json.md) | Achievable now | `file:read` + `json:key` + `equals` / `allowed:list` — see `examples/json-lookup.yml` |
 
 ### Recipe: yaml
 
@@ -78,6 +78,48 @@ analyse:
 ```
 
 Source: `examples/drupal-config.yml`
+
+### Recipe: json
+
+`json:key` is the JSON counterpart to `yaml:key`. It reads raw JSON (typically
+from a `file:read`) and evaluates an [RFC 9535](https://www.rfc-editor.org/rfc/rfc9535.html)
+JSONPath expression against it — e.g. `$.name`, `$.items[0]`, the wildcard
+`$.scripts.*`, or a filter such as `$.deps[?@.name=='x'].version`.
+
+The emitted format follows the shape of the match, mirroring `yaml:key`: a
+single scalar emits a string, multiple values emit a list, and objects emit a
+map. An expression that matches nothing emits nil rather than erroring, so
+`not-empty` can act on the absence of a value.
+
+Note that `json:key` implements RFC 9535, whereas `yaml:key` uses an older
+pre-RFC dialect. The practical difference is filter syntax: `json:key` accepts
+both `[?@.x=='y']` (the RFC form) and `[?(@.x=='y')]`, and supports the RFC
+functions `length()`, `count()`, `match()` and `search()`; `yaml:key` accepts
+only the parenthesised form and none of the functions.
+
+```yaml
+collect:
+  pkg-file:
+    file:read:
+      path: package.json
+
+  script-commands:
+    json:key:
+      input: pkg-file
+      expression: "$.scripts.*"
+
+analyse:
+  approved-script-tooling:
+    allowed:list:
+      description: A script uses an unapproved build tool
+      input: script-commands
+      allowed:
+        - eslint .
+        - vite build
+        - vitest run
+```
+
+Source: `examples/json-lookup.yml`
 
 ## Drupal checks
 

--- a/examples/json-lookup.yml
+++ b/examples/json-lookup.yml
@@ -1,0 +1,63 @@
+# Read values out of a JSON file using RFC 9535 JSONPath expressions.
+#
+# `json:key` reads raw JSON (e.g. from a `file:read`) and evaluates an
+# RFC 9535 JSONPath expression against it, emitting the matched values for
+# downstream analysers. This is the JSON counterpart to `yaml:key`, using the
+# more expressive JSONPath query language rather than the dotted-path lookup.
+#
+# The emitted format follows the shape of the match: a single scalar emits a
+# string, multiple values emit a list, and objects emit a map.
+#
+# A sample package.json is bundled at examples/testdata/package.json, e.g.:
+#   cd examples/testdata && shipshape run . -f ../json-lookup.yml
+collect:
+  pkg-file:
+    file:read:
+      path: package.json
+
+  # The package name scalar, e.g. "example-app".
+  pkg-name:
+    json:key:
+      input: pkg-file
+      expression: "$.name"
+
+  # The command run by each declared npm script, e.g. ["eslint .", "vite build"].
+  script-commands:
+    json:key:
+      input: pkg-file
+      expression: "$.scripts.*"
+
+  # RFC 9535 filters and functions are supported. Here `search()` selects only
+  # the dependencies pinned with a caret range, which allow silent minor
+  # upgrades at install time.
+  caret-ranged-deps:
+    json:key:
+      input: pkg-file
+      expression: "$.dependencies[?search(@,'\\\\^')]"
+
+analyse:
+  # The package name must match the approved application name. A single scalar
+  # match emits a string, so the scalar analysers apply here rather than
+  # `allowed:list`. `not:equals` breaches when the value differs.
+  approved-app-name:
+    not:equals:
+      description: package.json name is not the approved application
+      input: pkg-name
+      value: example-app
+
+  # Every script must invoke an approved build tool; anything else is flagged.
+  approved-script-tooling:
+    allowed:list:
+      description: A script uses an unapproved build tool
+      input: script-commands
+      allowed:
+        - eslint .
+        - vite build
+        - vitest run
+
+  # Runtime dependencies must be pinned exactly, so a caret range is a breach.
+  # A filter that matches multiple values emits a list.
+  pinned-dependencies:
+    not:empty:
+      description: A runtime dependency uses a caret version range
+      input: caret-ranged-deps

--- a/examples/testdata/package.json
+++ b/examples/testdata/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "example-app",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "vite build",
+    "test": "vitest run",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.34.0
 	github.com/testcontainers/testcontainers-go/modules/mysql v0.34.0
+	github.com/theory/jsonpath v0.12.0
 	github.com/vmware-labs/yaml-jsonpath v0.3.2
 	golang.org/x/oauth2 v0.31.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -260,6 +260,8 @@ github.com/testcontainers/testcontainers-go v0.34.0 h1:5fbgF0vIN5u+nD3IWabQwRybu
 github.com/testcontainers/testcontainers-go v0.34.0/go.mod h1:6P/kMkQe8yqPHfPWNulFGdFHTD8HB2vLq/231xY2iPQ=
 github.com/testcontainers/testcontainers-go/modules/mysql v0.34.0 h1:Tqz17mGXjPORHFS/oBUGdeJyIsZXLsVVHRhaBqhewGI=
 github.com/testcontainers/testcontainers-go/modules/mysql v0.34.0/go.mod h1:hDpm3DLfjo7rd6232wWflEBDGr6Ow9ys43mJTiJwWx8=
+github.com/theory/jsonpath v0.12.0 h1:NQeuE0ohHHhss0DoxU9Xu2IpTTrlx9x4mv4F3pcmDME=
+github.com/theory/jsonpath v0.12.0/go.mod h1:vl8nfJyq9MKMbcAiKv+7N9W3jDCH8qPr0mZoZj8wRk8=
 github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU=
 github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=

--- a/pkg/fact/json/determinism_test.go
+++ b/pkg/fact/json/determinism_test.go
@@ -1,0 +1,123 @@
+package json
+
+import (
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/salsadigitalauorg/shipshape/pkg/data"
+)
+
+// TestObjectWildcardDeterminism asserts that matching the members of an
+// (unordered) JSON object yields a stable order across repeated evaluations.
+// Go randomises map iteration, so this fails without the normalised-path sort
+// in query().
+func TestObjectWildcardDeterminism(t *testing.T) {
+	assert := assert.New(t)
+
+	src := []byte(`{"scripts":{"lint":"eslint .","build":"vite build",` +
+		`"test":"vitest run","fmt":"prettier -w .","e2e":"playwright test"}}`)
+
+	var first []string
+	for i := 0; i < 25; i++ {
+		p := New("json-values")
+		p.Expression = "$.scripts.*"
+		assert.NoError(p.ValidateExpression())
+
+		format, values, err := p.query(src)
+		assert.NoError(err)
+		assert.Equal(data.FormatListString, format)
+
+		got, ok := values.([]string)
+		assert.True(ok)
+
+		if first == nil {
+			first = got
+			continue
+		}
+		assert.Equal(first, got, "object wildcard order changed between runs")
+	}
+
+	// Sorted by normalised path, i.e. by member name: build, e2e, fmt, lint, test.
+	assert.Equal([]string{
+		"vite build", "playwright test", "prettier -w .", "eslint .", "vitest run",
+	}, first)
+}
+
+// TestArrayOrderPreserved asserts document order is retained for array matches,
+// which a blanket sort of the values would break.
+func TestArrayOrderPreserved(t *testing.T) {
+	assert := assert.New(t)
+
+	p := New("json-values")
+	p.Expression = "$.items[*]"
+	assert.NoError(p.ValidateExpression())
+
+	format, values, err := p.query([]byte(`{"items":["c","a","b","10","2"]}`))
+	assert.NoError(err)
+	assert.Equal(data.FormatListString, format)
+	assert.Equal([]string{"c", "a", "b", "10", "2"}, values)
+}
+
+// TestMultiFileMixedShapesDeterminism is a regression test for a bug where
+// combining multiple files' JSONPath matches into one map-shaped fact depended
+// on Go's randomised map iteration order: whichever file was visited first
+// fixed the result's format, and every file that did not share that shape was
+// silently dropped from the output. Against two files whose matches have
+// different shapes (one object, one scalar), this asserts every run over many
+// iterations produces the same format and retains both files' data.
+func TestMultiFileMixedShapesDeterminism(t *testing.T) {
+	assert := assert.New(t)
+
+	inputData := map[string][]byte{
+		"x.json": []byte(`{"a":{"k":"v"}}`),
+		"y.json": []byte(`{"a":"scalarValue"}`),
+	}
+	logger := log.WithField("test", "TestMultiFileMixedShapesDeterminism")
+
+	for i := 0; i < 100; i++ {
+		p := New("json-values")
+		p.Expression = "$.a"
+		assert.NoError(p.ValidateExpression())
+
+		format, values, err := p.queryMap(logger, inputData)
+		assert.NoError(err)
+		assert.Equal(data.FormatMapListString, format,
+			"run %d: format changed between runs", i)
+
+		got, ok := values.(map[string][]string)
+		assert.True(ok, "run %d: unexpected value type %T", i, values)
+		assert.Len(got, 2, "run %d: a file's match was dropped", i)
+		assert.Equal([]string{"k=v"}, got["x.json"], "run %d", i)
+		assert.Equal([]string{"scalarValue"}, got["y.json"], "run %d", i)
+	}
+}
+
+// TestMultiFileUniformShapeDeterminism covers the common case - every file's
+// match shares the same shape - across many runs, since map iteration order
+// could in principle affect which file's error surfaces first even when the
+// combined format itself is stable.
+func TestMultiFileUniformShapeDeterminism(t *testing.T) {
+	assert := assert.New(t)
+
+	inputData := map[string][]byte{
+		"a.json": []byte(`{"name":"alpha"}`),
+		"b.json": []byte(`{"name":"beta"}`),
+		"c.json": []byte(`{"name":"gamma"}`),
+	}
+	logger := log.WithField("test", "TestMultiFileUniformShapeDeterminism")
+
+	want := map[string]string{"a.json": "alpha", "b.json": "beta", "c.json": "gamma"}
+
+	for i := 0; i < 100; i++ {
+		p := New("json-values")
+		p.Expression = "$.name"
+		assert.NoError(p.ValidateExpression())
+
+		format, values, err := p.queryMap(logger, inputData)
+		assert.NoError(err)
+		assert.Equal(data.FormatMapString, format, "run %d", i)
+		assert.Equal(want, values, "run %d", i)
+	}
+}

--- a/pkg/fact/json/key.go
+++ b/pkg/fact/json/key.go
@@ -1,0 +1,486 @@
+package json
+
+import (
+	stdjson "encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/theory/jsonpath"
+
+	"github.com/salsadigitalauorg/shipshape/pkg/data"
+	"github.com/salsadigitalauorg/shipshape/pkg/fact"
+	"github.com/salsadigitalauorg/shipshape/pkg/plugin"
+)
+
+var (
+	// ErrNoExpression is returned when the plugin is configured without a
+	// JSONPath expression.
+	ErrNoExpression = errors.New("json:key requires an 'expression'")
+	// ErrInvalidExpression is returned when the expression is not a valid
+	// RFC 9535 JSONPath query.
+	ErrInvalidExpression = errors.New("invalid JSONPath expression")
+	// ErrInvalidJSON is returned when the input cannot be decoded as JSON.
+	ErrInvalidJSON = errors.New("invalid JSON input")
+)
+
+// Key evaluates an RFC 9535 JSONPath expression against JSON input and emits
+// the matched values. It is the JSON counterpart to yaml:key, using the
+// JSONPath query language (e.g. "$.a.b[0]", "$.items.*",
+// "$.deps[?@.name=='x'].version") rather than a dotted-path lookup.
+//
+// The emitted data format is derived from the shape of the match, mirroring
+// yaml:key: a single scalar emits FormatString, multiple scalars emit
+// FormatListString, objects emit FormatMapString or FormatListMapString, and
+// no match at all emits FormatNil.
+type Key struct {
+	fact.BaseFact `yaml:",inline"`
+
+	// Expression is the RFC 9535 JSONPath expression to evaluate against the
+	// input.
+	Expression string `yaml:"expression"`
+
+	// path holds the expression parsed once and cached, so that a multi-file
+	// input does not re-parse it per document.
+	path *jsonpath.Path
+}
+
+//go:generate go run ../../../cmd/gen.go fact-plugin --package=json
+
+func init() {
+	fact.Manager().RegisterFactory("json:key", func(n string) fact.Facter {
+		return New(n)
+	})
+}
+
+func New(id string) *Key {
+	return &Key{
+		BaseFact: fact.BaseFact{
+			BasePlugin: plugin.BasePlugin{
+				Id: id,
+			},
+		},
+	}
+}
+
+func (p *Key) GetName() string {
+	return "json:key"
+}
+
+// SupportedInputFormats declares that json:key requires an input and reads
+// either raw JSON bytes (file:read) or a map of JSON bytes keyed by filename
+// (file:lookup).
+func (p *Key) SupportedInputFormats() (plugin.SupportLevel, []data.DataFormat) {
+	return plugin.SupportRequired, []data.DataFormat{
+		data.FormatRaw,
+		data.FormatMapBytes,
+	}
+}
+
+// ValidateExpression parses the configured JSONPath expression, returning an
+// error if it is missing or malformed. It is safe to call more than once.
+//
+// Parse is used rather than MustParse so that a malformed user-supplied
+// expression surfaces as an error instead of a panic.
+func (p *Key) ValidateExpression() error {
+	if p.Expression == "" {
+		return ErrNoExpression
+	}
+
+	if p.path != nil {
+		return nil
+	}
+
+	parsed, err := jsonpath.Parse(p.Expression)
+	if err != nil {
+		return fmt.Errorf("%w %q: %s", ErrInvalidExpression, p.Expression, err)
+	}
+
+	p.path = parsed
+	return nil
+}
+
+func (p *Key) Collect() {
+	contextLogger := log.WithFields(log.Fields{
+		"fact-plugin": p.GetName(),
+		"fact":        p.GetId(),
+	})
+
+	if err := p.ValidateExpression(); err != nil {
+		contextLogger.WithError(err).Error("invalid jsonpath expression")
+		p.AddErrors(sentinel(err))
+		return
+	}
+
+	contextLogger.WithFields(log.Fields{
+		"input":        p.GetInputName(),
+		"input-plugin": p.GetInput().GetName(),
+		"input-format": p.GetInput().GetFormat(),
+		"expression":   p.Expression,
+	}).Debug("collecting data")
+
+	switch p.GetInput().GetFormat() {
+	case data.FormatRaw:
+		inputData := data.AsBytes(p.GetInput().GetData())
+		if inputData == nil {
+			return
+		}
+
+		format, values, err := p.query(inputData)
+		if err != nil {
+			contextLogger.WithError(err).Error("error evaluating jsonpath")
+			p.AddErrors(sentinel(err))
+			return
+		}
+
+		p.Format = format
+		p.SetData(values)
+
+	case data.FormatMapBytes:
+		inputData := data.AsMapBytes(p.GetInput().GetData())
+		if inputData == nil {
+			return
+		}
+
+		format, values, err := p.queryMap(contextLogger, inputData)
+		if err != nil {
+			p.AddErrors(sentinel(err))
+			return
+		}
+
+		p.Format = format
+		if format != data.FormatNil {
+			p.SetData(values)
+		}
+
+	default:
+		contextLogger.WithField("format", p.GetInput().GetFormat()).
+			Error("unsupported input format")
+		p.AddErrors(fmt.Errorf("unsupported input format %s", p.GetInput().GetFormat()))
+	}
+}
+
+// sentinel maps a detailed internal error back to a stable, comparable
+// sentinel so downstream reporting is deterministic. Errors that do not match a
+// known sentinel are returned unchanged.
+func sentinel(err error) error {
+	for _, s := range []error{ErrNoExpression, ErrInvalidExpression, ErrInvalidJSON} {
+		if errors.Is(err, s) {
+			return s
+		}
+	}
+	return err
+}
+
+// query decodes JSON bytes, evaluates the JSONPath expression, and derives both
+// the data format and the value from the shape of the match.
+func (p *Key) query(src []byte) (data.DataFormat, interface{}, error) {
+	var doc interface{}
+	if err := stdjson.Unmarshal(src, &doc); err != nil {
+		return data.FormatNil, nil, fmt.Errorf("%w: %s", ErrInvalidJSON, err)
+	}
+
+	// SelectLocated is used rather than Select so that results carry their
+	// normalised path (e.g. "$['scripts']['lint']"), which Sort orders
+	// deterministically. This keeps output stable for expressions that match an
+	// unordered JSON object's members via a wildcard, while preserving document
+	// order for array matches.
+	nodes := p.path.SelectLocated(doc)
+	nodes.Sort()
+
+	matches := make([]interface{}, 0, len(nodes))
+	for n := range nodes.All() {
+		matches = append(matches, n.Node)
+	}
+
+	format, value := shapeToData(matches)
+	return format, value, nil
+}
+
+// fileMatch is a single file's query result, kept alongside its format so that
+// queryMap can decide, once every file has been evaluated, whether all files
+// share a common shape or need to be promoted to a uniform one.
+type fileMatch struct {
+	format data.DataFormat
+	value  interface{}
+}
+
+// queryMap evaluates the expression against every file in a FormatMapBytes
+// input and combines the results into a single map-shaped value.
+//
+// Files are visited in sorted name order and every file's format is recorded
+// before any data is combined, so the result does not depend on Go's
+// randomised map iteration order: the same input always produces the same
+// format and the same data. If every file's match has the same shape, that
+// shape is preserved (e.g. a map of strings); if shapes differ across files,
+// every value is rendered to a string (or list of strings) so that no file's
+// finding is silently dropped.
+func (p *Key) queryMap(contextLogger *log.Entry, inputData map[string][]byte) (data.DataFormat, interface{}, error) {
+	names := make([]string, 0, len(inputData))
+	for name := range inputData {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	matches := map[string]fileMatch{}
+	order := make([]string, 0, len(names))
+	commonFormat := data.DataFormat("")
+	mixed := false
+
+	for _, name := range names {
+		format, values, err := p.query(inputData[name])
+		if err != nil {
+			contextLogger.WithError(err).WithField("file", name).
+				Error("error evaluating jsonpath")
+			return data.FormatNil, nil, err
+		}
+
+		// Skip files where the expression matched nothing, so that a single
+		// unmatched file does not affect the shape of the combined result.
+		if format == data.FormatNil {
+			continue
+		}
+
+		matches[name] = fileMatch{format: format, value: values}
+		order = append(order, name)
+
+		switch {
+		case commonFormat == "":
+			commonFormat = format
+		case commonFormat != format:
+			mixed = true
+		}
+	}
+
+	if len(order) == 0 {
+		return data.FormatNil, nil, nil
+	}
+
+	if mixed {
+		contextLogger.WithField("files", order).
+			Debug("files matched with differing shapes; rendering every file as a list of strings")
+		result := make(map[string][]string, len(order))
+		for _, name := range order {
+			result[name] = toStringList(matches[name].value)
+		}
+		return data.FormatMapListString, result, nil
+	}
+
+	mapFormat := mapValueFormat(commonFormat)
+	return mapFormat, buildMapData(mapFormat, order, matches), nil
+}
+
+// buildMapData assembles the final map-shaped value once every file is known
+// to share the same underlying format. mapFormat is the promoted map format
+// (see mapValueFormat); the type assertions below are safe because every
+// value in matches was produced by the same commonFormat branch of
+// shapeToData.
+func buildMapData(mapFormat data.DataFormat, order []string, matches map[string]fileMatch) interface{} {
+	switch mapFormat {
+	case data.FormatMapString:
+		result := make(map[string]string, len(order))
+		for _, name := range order {
+			result[name] = matches[name].value.(string)
+		}
+		return result
+
+	case data.FormatMapNestedString:
+		result := make(map[string]map[string]string, len(order))
+		for _, name := range order {
+			result[name] = matches[name].value.(map[string]string)
+		}
+		return result
+
+	default: // FormatMapListString, promoted from ListString, ListMapString or MapNestedString.
+		result := make(map[string][]string, len(order))
+		for _, name := range order {
+			result[name] = toStringList(matches[name].value)
+		}
+		return result
+	}
+}
+
+// toStringList renders any of the shapes shapeToData can produce as a list of
+// strings, so that a file's result can always be represented even when its
+// siblings matched a different shape.
+func toStringList(v interface{}) []string {
+	switch t := v.(type) {
+	case string:
+		return []string{t}
+	case []string:
+		return t
+	case map[string]string:
+		return []string{mapToSortedString(t)}
+	case []map[string]string:
+		out := make([]string, 0, len(t))
+		for _, m := range t {
+			out = append(out, mapToSortedString(m))
+		}
+		return out
+	case map[string]map[string]string:
+		keys := make([]string, 0, len(t))
+		for k := range t {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+
+		out := make([]string, 0, len(keys))
+		for _, k := range keys {
+			out = append(out, fmt.Sprintf("%s: %s", k, mapToSortedString(t[k])))
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+// shapeToData derives the data format and value from the matched nodes,
+// mirroring the format selection that yaml:key applies to YAML node kinds.
+//
+// No match is reported as FormatNil rather than an error, so that analysers
+// such as not-empty can act on the absence of a value.
+func shapeToData(matches []interface{}) (data.DataFormat, interface{}) {
+	if len(matches) == 0 {
+		return data.FormatNil, nil
+	}
+
+	if len(matches) == 1 {
+		switch v := matches[0].(type) {
+		case map[string]interface{}:
+			if nested, ok := objectOfObjects(v); ok {
+				return data.FormatMapNestedString, nested
+			}
+			return data.FormatMapString, objectToMapString(v)
+		case []interface{}:
+			// A matched array is emitted as its members, preserving order.
+			return listToData(v)
+		default:
+			return data.FormatString, scalarToString(v)
+		}
+	}
+
+	return listToData(matches)
+}
+
+// listToData renders a list of matches as either a list of strings or, when
+// every member is a flat object, a list of maps.
+func listToData(matches []interface{}) (data.DataFormat, interface{}) {
+	if len(matches) == 0 {
+		return data.FormatNil, nil
+	}
+
+	allObjects := true
+	for _, m := range matches {
+		if _, ok := m.(map[string]interface{}); !ok {
+			allObjects = false
+			break
+		}
+	}
+
+	if allObjects {
+		result := make([]map[string]string, 0, len(matches))
+		for _, m := range matches {
+			result = append(result, objectToMapString(m.(map[string]interface{})))
+		}
+		return data.FormatListMapString, result
+	}
+
+	result := make([]string, 0, len(matches))
+	for _, m := range matches {
+		result = append(result, scalarToString(m))
+	}
+	return data.FormatListString, result
+}
+
+// objectOfObjects reports whether every value of an object is itself a flat
+// object, and if so returns the nested map representation.
+func objectOfObjects(obj map[string]interface{}) (map[string]map[string]string, bool) {
+	if len(obj) == 0 {
+		return nil, false
+	}
+
+	result := map[string]map[string]string{}
+	for k, v := range obj {
+		inner, ok := v.(map[string]interface{})
+		if !ok {
+			return nil, false
+		}
+		result[k] = objectToMapString(inner)
+	}
+	return result, true
+}
+
+// objectToMapString renders a JSON object's values as strings.
+func objectToMapString(obj map[string]interface{}) map[string]string {
+	result := map[string]string{}
+	for k, v := range obj {
+		result[k] = scalarToString(v)
+	}
+	return result
+}
+
+// mapValueFormat promotes the format of a per-file value to the format of the
+// map that holds it, matching the promotion yaml:key applies across files.
+func mapValueFormat(format data.DataFormat) data.DataFormat {
+	switch format {
+	case data.FormatString:
+		return data.FormatMapString
+	case data.FormatListString:
+		return data.FormatMapListString
+	case data.FormatMapString:
+		return data.FormatMapNestedString
+	default:
+		// List-of-map and nested-map results have no map-of-map equivalent in
+		// the data package, so fall back to a map of lists of strings.
+		return data.FormatMapListString
+	}
+}
+
+// mapToSortedString renders a map as a deterministic "k=v k2=v2" string, used
+// when a map-shaped result has to be flattened into a list. Values are joined
+// with strings.Join rather than a slice-typed fmt.Sprintf, which would leak Go's
+// "[k=v k2=v2]" bracket syntax into the rendered string.
+func mapToSortedString(m map[string]string) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	pairs := make([]string, 0, len(keys))
+	for _, k := range keys {
+		pairs = append(pairs, fmt.Sprintf("%s=%s", k, m[k]))
+	}
+	return strings.Join(pairs, " ")
+}
+
+// scalarToString renders a JSON scalar as a string. Numbers decoded by
+// encoding/json are float64; render integral values without a trailing ".0".
+//
+// A non-scalar value (object or array) reaching this function means a scalar
+// was expected but the document held a nested structure instead - e.g. a
+// flat-object assumption (objectToMapString) meeting a value that is itself
+// an object or array. Rendering it with fmt's default verb would leak Go's
+// internal syntax (and the nested structure's contents, which may include
+// sensitive values) into breach output, so - mirroring yaml:key, which reads
+// a YAML scalar node's Value and gets "" for non-scalar nodes - an empty
+// string is returned instead.
+func scalarToString(v interface{}) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	case float64:
+		if t == float64(int64(t)) {
+			return fmt.Sprintf("%d", int64(t))
+		}
+		return fmt.Sprintf("%g", t)
+	case bool:
+		return fmt.Sprintf("%t", t)
+	case nil:
+		return ""
+	default:
+		return ""
+	}
+}

--- a/pkg/fact/json/key_test.go
+++ b/pkg/fact/json/key_test.go
@@ -1,0 +1,540 @@
+package json_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/salsadigitalauorg/shipshape/pkg/data"
+	"github.com/salsadigitalauorg/shipshape/pkg/fact"
+	. "github.com/salsadigitalauorg/shipshape/pkg/fact/json"
+	"github.com/salsadigitalauorg/shipshape/pkg/internal"
+	"github.com/salsadigitalauorg/shipshape/pkg/plugin"
+)
+
+func TestKeyInit(t *testing.T) {
+	assert := assert.New(t)
+
+	factPlugin := fact.Manager().GetFactories()["json:key"]("testKeyJson")
+	assert.NotNil(factPlugin)
+	keyFacter, ok := factPlugin.(*Key)
+	assert.True(ok)
+	assert.Equal("testKeyJson", keyFacter.GetId())
+}
+
+func TestKeyPluginName(t *testing.T) {
+	key := New("testKeyJson")
+	assert.Equal(t, "json:key", key.GetName())
+}
+
+func TestKeySupportedInputFormats(t *testing.T) {
+	key := New("testKeyJson")
+	supportLevel, inputFormats := key.SupportedInputFormats()
+	assert.Equal(t, plugin.SupportRequired, supportLevel)
+	assert.ElementsMatch(t, []data.DataFormat{
+		data.FormatRaw,
+		data.FormatMapBytes,
+	}, inputFormats)
+}
+
+func TestKeyCollect(t *testing.T) {
+	tests := []internal.FactCollectTest{
+		{
+			Name:               "noInput",
+			Facter:             New("json-values"),
+			ExpectedInputError: &plugin.ErrSupportRequired{SupportType: "input"},
+		},
+		{
+			Name: "noExpression",
+			FactFn: func() fact.Facter {
+				f := New("json-values")
+				f.SetInputName("test-input")
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatRaw, Data: []byte(`{"foo":"bar"}`)},
+			ExpectedErrors: []error{errors.New("json:key requires an 'expression'")},
+		},
+
+		// Raw data format (data.FormatRaw) cases.
+		{
+			Name: "inputFormat/Raw/scalarString",
+			FactFn: func() fact.Facter {
+				f := New("json-values")
+				f.SetInputName("test-input")
+				f.Expression = "$.foo"
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatRaw, Data: []byte(`{"foo":"bar"}`)},
+			ExpectedFormat: data.FormatString,
+			ExpectedData:   "bar",
+		},
+		{
+			Name: "inputFormat/Raw/scalarNumber",
+			FactFn: func() fact.Facter {
+				f := New("json-values")
+				f.SetInputName("test-input")
+				f.Expression = "$.count"
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatRaw, Data: []byte(`{"count":42}`)},
+			ExpectedFormat: data.FormatString,
+			ExpectedData:   "42",
+		},
+		{
+			Name: "inputFormat/Raw/scalarBool",
+			FactFn: func() fact.Facter {
+				f := New("json-values")
+				f.SetInputName("test-input")
+				f.Expression = "$.private"
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatRaw, Data: []byte(`{"private":true}`)},
+			ExpectedFormat: data.FormatString,
+			ExpectedData:   "true",
+		},
+		{
+			Name: "inputFormat/Raw/arrayIndex",
+			FactFn: func() fact.Facter {
+				f := New("json-values")
+				f.SetInputName("test-input")
+				f.Expression = "$.items[0]"
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatRaw, Data: []byte(`{"items":["a","b","c"]}`)},
+			ExpectedFormat: data.FormatString,
+			ExpectedData:   "a",
+		},
+		{
+			Name: "inputFormat/Raw/wildcardValues",
+			FactFn: func() fact.Facter {
+				f := New("json-values")
+				f.SetInputName("test-input")
+				f.Expression = "$.scripts.*"
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatRaw,
+				Data:       []byte(`{"scripts":{"build":"vite build","test":"vitest run"}}`)},
+			ExpectedFormat: data.FormatListString,
+			ExpectedData:   []string{"vite build", "vitest run"},
+		},
+		{
+			Name: "inputFormat/Raw/invalidJSON",
+			FactFn: func() fact.Facter {
+				f := New("json-values")
+				f.SetInputName("test-input")
+				f.Expression = "$.foo"
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatRaw, Data: []byte(`{not json`)},
+			ExpectedErrors: []error{errors.New("invalid JSON input")},
+		},
+
+		// Map of Raw data (data.FormatMapBytes) format cases.
+		{
+			Name: "inputFormat/MapBytes/scalar",
+			FactFn: func() fact.Facter {
+				f := New("json-values")
+				f.SetInputName("test-input")
+				f.Expression = "$.foo"
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatMapBytes,
+				Data:       map[string][]byte{"file1": []byte(`{"foo":"bar"}`)},
+			},
+			ExpectedFormat: data.FormatMapString,
+			ExpectedData:   map[string]string{"file1": "bar"},
+		},
+		{
+			Name: "inputFormat/MapBytes/list",
+			FactFn: func() fact.Facter {
+				f := New("json-values")
+				f.SetInputName("test-input")
+				f.Expression = "$.items[*]"
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatMapBytes,
+				Data: map[string][]byte{
+					"file1": []byte(`{"items":["c","a"]}`)},
+			},
+			ExpectedFormat: data.FormatMapListString,
+			ExpectedData:   map[string][]string{"file1": {"c", "a"}},
+		},
+
+		// Multi-file cases where every file's match shares the same shape: the
+		// map format is promoted from that shared shape, and no file's result
+		// depends on which order the files happen to be visited in.
+		{
+			Name: "inputFormat/MapBytes/multiFile/uniformScalar",
+			FactFn: func() fact.Facter {
+				f := New("json-values")
+				f.SetInputName("test-input")
+				f.Expression = "$.name"
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatMapBytes,
+				Data: map[string][]byte{
+					"a.json": []byte(`{"name":"alpha"}`),
+					"b.json": []byte(`{"name":"beta"}`),
+					"c.json": []byte(`{"name":"gamma"}`),
+				},
+			},
+			ExpectedFormat: data.FormatMapString,
+			ExpectedData: map[string]string{
+				"a.json": "alpha", "b.json": "beta", "c.json": "gamma"},
+		},
+		{
+			Name: "inputFormat/MapBytes/multiFile/uniformObject",
+			FactFn: func() fact.Facter {
+				f := New("json-values")
+				f.SetInputName("test-input")
+				f.Expression = "$.a"
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatMapBytes,
+				Data: map[string][]byte{
+					"x.json": []byte(`{"a":{"k":"v"}}`),
+					"y.json": []byte(`{"a":{"k2":"v2"}}`),
+				},
+			},
+			ExpectedFormat: data.FormatMapNestedString,
+			ExpectedData: map[string]map[string]string{
+				"x.json": {"k": "v"}, "y.json": {"k2": "v2"}},
+		},
+
+		// Multi-file case where files match with DIFFERING shapes (one scalar,
+		// one object). This is a regression test for a bug where the combined
+		// map format was decided by whichever file Go's randomised map
+		// iteration visited first, silently discarding every file that did not
+		// match that shape - so the same input could produce 1 or 2 result
+		// entries depending on run. Every file's finding must always be
+		// present, and the format must be the same on every run.
+		{
+			Name: "inputFormat/MapBytes/multiFile/mixedShapesNoDataLoss",
+			FactFn: func() fact.Facter {
+				f := New("json-values")
+				f.SetInputName("test-input")
+				f.Expression = "$.a"
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatMapBytes,
+				Data: map[string][]byte{
+					"x.json": []byte(`{"a":{"k":"v"}}`),
+					"y.json": []byte(`{"a":"scalarValue"}`),
+				},
+			},
+			ExpectedFormat: data.FormatMapListString,
+			ExpectedData: map[string][]string{
+				"x.json": {"k=v"}, "y.json": {"scalarValue"}},
+		},
+
+		// A file where the expression matches nothing must not affect the
+		// shape of the files that do match.
+		{
+			Name: "inputFormat/MapBytes/multiFile/oneFileNoMatch",
+			FactFn: func() fact.Facter {
+				f := New("json-values")
+				f.SetInputName("test-input")
+				f.Expression = "$.name"
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatMapBytes,
+				Data: map[string][]byte{
+					"a.json":       []byte(`{"name":"alpha"}`),
+					"noMatch.json": []byte(`{"other":"value"}`),
+				},
+			},
+			ExpectedFormat: data.FormatMapString,
+			ExpectedData:   map[string]string{"a.json": "alpha"},
+		},
+
+		// If every file's expression matches nothing, the fact resolves to nil
+		// rather than an empty map.
+		{
+			Name: "inputFormat/MapBytes/multiFile/allFilesNoMatch",
+			FactFn: func() fact.Facter {
+				f := New("json-values")
+				f.SetInputName("test-input")
+				f.Expression = "$.missing"
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatMapBytes,
+				Data: map[string][]byte{
+					"a.json": []byte(`{"name":"alpha"}`),
+					"b.json": []byte(`{"name":"beta"}`),
+				},
+			},
+			ExpectedFormat: data.FormatNil,
+		},
+
+		// Malformed expressions. With fail-early false (the default) the error
+		// is recorded rather than aborting the run.
+		{
+			Name: "invalidExpression",
+			FactFn: func() fact.Facter {
+				f := New("json-values")
+				f.SetInputName("test-input")
+				f.Expression = "$.items[?(("
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatRaw, Data: []byte(`{"items":["a"]}`)},
+			ExpectedErrors: []error{errors.New("invalid JSONPath expression")},
+		},
+
+		// No match emits FormatNil rather than an error, so that analysers such
+		// as not-empty can act on the absence of a value.
+		{
+			Name: "inputFormat/Raw/noMatch",
+			FactFn: func() fact.Facter {
+				f := New("json-values")
+				f.SetInputName("test-input")
+				f.Expression = "$.missing"
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatRaw, Data: []byte(`{"foo":"bar"}`)},
+			ExpectedFormat: data.FormatNil,
+		},
+
+		// Array order must be preserved, not sorted.
+		{
+			Name: "inputFormat/Raw/arrayOrderPreserved",
+			FactFn: func() fact.Facter {
+				f := New("json-values")
+				f.SetInputName("test-input")
+				f.Expression = "$.items[*]"
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatRaw, Data: []byte(`{"items":["c","a","b"]}`)},
+			ExpectedFormat: data.FormatListString,
+			ExpectedData:   []string{"c", "a", "b"},
+		},
+		{
+			Name: "inputFormat/Raw/matchedArrayOrderPreserved",
+			FactFn: func() fact.Facter {
+				f := New("json-values")
+				f.SetInputName("test-input")
+				f.Expression = "$.items"
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatRaw, Data: []byte(`{"items":["c","a","b"]}`)},
+			ExpectedFormat: data.FormatListString,
+			ExpectedData:   []string{"c", "a", "b"},
+		},
+
+		// Object and nested-object shapes, mirroring yaml:key's formats.
+		{
+			Name: "inputFormat/Raw/object",
+			FactFn: func() fact.Facter {
+				f := New("json-values")
+				f.SetInputName("test-input")
+				f.Expression = "$.scripts"
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatRaw,
+				Data:       []byte(`{"scripts":{"build":"vite build","test":"vitest run"}}`)},
+			ExpectedFormat: data.FormatMapString,
+			ExpectedData: map[string]string{
+				"build": "vite build", "test": "vitest run"},
+		},
+		{
+			Name: "inputFormat/Raw/objectOfObjects",
+			FactFn: func() fact.Facter {
+				f := New("json-values")
+				f.SetInputName("test-input")
+				f.Expression = "$.envs"
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatRaw,
+				Data:       []byte(`{"envs":{"dev":{"url":"d.example"},"prod":{"url":"p.example"}}}`)},
+			ExpectedFormat: data.FormatMapNestedString,
+			ExpectedData: map[string]map[string]string{
+				"dev":  {"url": "d.example"},
+				"prod": {"url": "p.example"},
+			},
+		},
+
+		// A flat object containing a value that is itself an object (deeper
+		// than objectOfObjects can represent as FormatMapNestedString) or an
+		// array must not render Go's internal syntax (e.g. "map[k:v]", "[1 2]")
+		// into the emitted value - doing so could leak nested sensitive values
+		// (such as a credential) verbatim into breach output. This mirrors
+		// yaml:key, which reads a YAML scalar node's Value and gets "" for a
+		// non-scalar node.
+		{
+			Name: "inputFormat/Raw/objectWithNonFlatValueNoGoSyntaxLeak",
+			FactFn: func() fact.Facter {
+				f := New("json-values")
+				f.SetInputName("test-input")
+				f.Expression = "$.config"
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatRaw,
+				Data: []byte(`{"config":` +
+					`{"db":{"host":"localhost","password":"s3cr3t"},"name":"app"}}`)},
+			ExpectedFormat: data.FormatMapString,
+			ExpectedData: map[string]string{
+				"db": "", "name": "app"},
+		},
+		{
+			Name: "inputFormat/Raw/objectWithArrayValueNoGoSyntaxLeak",
+			FactFn: func() fact.Facter {
+				f := New("json-values")
+				f.SetInputName("test-input")
+				f.Expression = "$.a"
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatRaw,
+				Data:       []byte(`{"a":{"k":[1,2],"n":"v"}}`)},
+			ExpectedFormat: data.FormatMapString,
+			ExpectedData:   map[string]string{"k": "", "n": "v"},
+		},
+		{
+			Name: "inputFormat/Raw/listOfObjects",
+			FactFn: func() fact.Facter {
+				f := New("json-values")
+				f.SetInputName("test-input")
+				f.Expression = "$.deps[*]"
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatRaw,
+				Data:       []byte(`{"deps":[{"n":"x","v":"1.0"},{"n":"y","v":"2.0"}]}`)},
+			ExpectedFormat: data.FormatListMapString,
+			ExpectedData: []map[string]string{
+				{"n": "x", "v": "1.0"},
+				{"n": "y", "v": "2.0"},
+			},
+		},
+
+		// RFC 9535 syntax that the previous (pre-RFC) library rejected.
+		{
+			Name: "rfc9535/filterWithoutParens",
+			FactFn: func() fact.Facter {
+				f := New("json-values")
+				f.SetInputName("test-input")
+				f.Expression = "$.deps[?@.n=='x'].v"
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatRaw,
+				Data:       []byte(`{"deps":[{"n":"x","v":"1.0"},{"n":"y","v":"2.0"}]}`)},
+			ExpectedFormat: data.FormatString,
+			ExpectedData:   "1.0",
+		},
+		{
+			Name: "rfc9535/filterWithWhitespace",
+			FactFn: func() fact.Facter {
+				f := New("json-values")
+				f.SetInputName("test-input")
+				f.Expression = "$.deps[?@.n == 'y'].v"
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatRaw,
+				Data:       []byte(`{"deps":[{"n":"x","v":"1.0"},{"n":"y","v":"2.0"}]}`)},
+			ExpectedFormat: data.FormatString,
+			ExpectedData:   "2.0",
+		},
+		{
+			Name: "rfc9535/matchFunction",
+			FactFn: func() fact.Facter {
+				f := New("json-values")
+				f.SetInputName("test-input")
+				f.Expression = "$.scripts[?match(@,'vite.*')]"
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatRaw,
+				Data:       []byte(`{"scripts":{"build":"vite build","lint":"eslint ."}}`)},
+			ExpectedFormat: data.FormatString,
+			ExpectedData:   "vite build",
+		},
+		{
+			Name: "rfc9535/searchFunction",
+			FactFn: func() fact.Facter {
+				f := New("json-values")
+				f.SetInputName("test-input")
+				f.Expression = "$.scripts[?search(@,'eslint')]"
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatRaw,
+				Data:       []byte(`{"scripts":{"build":"vite build","lint":"eslint ."}}`)},
+			ExpectedFormat: data.FormatString,
+			ExpectedData:   "eslint .",
+		},
+		{
+			Name: "rfc9535/union",
+			FactFn: func() fact.Facter {
+				f := New("json-values")
+				f.SetInputName("test-input")
+				f.Expression = "$.items[0,2]"
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatRaw, Data: []byte(`{"items":["a","b","c"]}`)},
+			ExpectedFormat: data.FormatListString,
+			ExpectedData:   []string{"a", "c"},
+		},
+		{
+			Name: "rfc9535/descendant",
+			FactFn: func() fact.Facter {
+				f := New("json-values")
+				f.SetInputName("test-input")
+				f.Expression = "$..n"
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatRaw,
+				Data:       []byte(`{"deps":[{"n":"x"},{"n":"y"}]}`)},
+			ExpectedFormat: data.FormatListString,
+			ExpectedData:   []string{"x", "y"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			internal.TestFactCollect(t, tt)
+		})
+	}
+}
+
+// TestKeyValidateExpression covers expression parsing in isolation, including
+// the malformed case that must return an error rather than panic.
+func TestKeyValidateExpression(t *testing.T) {
+	assert := assert.New(t)
+
+	k := New("json-values")
+	assert.ErrorIs(k.ValidateExpression(), ErrNoExpression)
+
+	k.Expression = "$.items[?(("
+	assert.ErrorIs(k.ValidateExpression(), ErrInvalidExpression)
+
+	k = New("json-values")
+	k.Expression = "$.deps[?@.n=='x'].v"
+	assert.NoError(k.ValidateExpression())
+	// Repeated calls reuse the already-parsed path.
+	assert.NoError(k.ValidateExpression())
+}

--- a/tests/e2e/examples_test.go
+++ b/tests/e2e/examples_test.go
@@ -70,6 +70,25 @@ func selfContainedCases() []selfContainedCase {
 			},
 		},
 		{
+			name:         "json-lookup",
+			file:         "json-lookup.yml",
+			wantChecks:   3,
+			wantBreaches: 2,
+			// wantPolicies is intentionally omitted: the policy IDs within a
+			// plugin are collected via Go map iteration (see shipshape.go), so
+			// their order is non-deterministic. checkResults asserts each check
+			// by name, which is order-independent.
+			//
+			// pinned-dependencies breaches twice: the RFC 9535 filter
+			// `$.dependencies[?search(@,'\^')]` matches both caret-ranged
+			// runtime dependencies in testdata/package.json.
+			checkResults: []wantResult{
+				{name: "approved-app-name", status: "Pass", checkType: "not:equals"},
+				{name: "approved-script-tooling", status: "Pass", checkType: "allowed:list"},
+				{name: "pinned-dependencies", status: "Fail", checkType: "not:empty", breachCount: 2},
+			},
+		},
+		{
 			name:         "drupal-config",
 			file:         "drupal-config.yml",
 			wantChecks:   3,


### PR DESCRIPTION
Closes the JSON gap in the 0.x→1.x recipe catalogue. json:key reads raw
JSON (via file:read) or a map of JSON bytes (via file:lookup) and
evaluates an RFC 9535 JSONPath expression against it for downstream
analysers.

- pkg/fact/json/key.go: new fact registered as json:key; handles
  FormatRaw and FormatMapBytes input; stable sentinel errors
  (ErrNoExpression, ErrInvalidExpression, ErrInvalidJSON)
- pkg/fact/json/key.go: //go:generate directive so the package is
  included in registry_gen.go — without it json:key is unresolvable at
  runtime despite being wired into the plugin manager
- Emitted format follows the shape of the match, mirroring yaml:key:
  scalar / list / map / nested-map / nil. Scalar analysers (equals,
  not:equals) therefore work on single-value matches rather than every
  result being forced through allowed:list. A no-match emits nil rather
  than erroring, so not-empty can act on the absence of a value.
- Multi-file (file:lookup) matches are combined via queryMap(), which
  visits files in sorted order and records every file's shape before
  deciding the combined format, so the result does not depend on Go's
  randomised map iteration order.
- Non-scalar values render as "" rather than falling through to fmt's
  %v verb, which would leak Go's internal syntax — and potentially
  nested secrets — into breach output. Matches yaml:key's handling of
  non-scalar YAML nodes.
- pkg/fact/json/key_test.go: unit tests covering scalars, numbers,
  bools, array index, wildcard, invalid JSON, missing expression, no
  input, object and nested-object shapes, non-scalar redaction, and
  multi-file map-bytes cases including mixed shapes and partial
  no-match; plus RFC 9535 syntax cases (bare and parenthesised
  filters, match(), search(), unions, descendants)
- pkg/fact/json/determinism_test.go: repeated-run loops asserting
  stable output for multi-file combination and object wildcards, and
  that array order is preserved
- examples/json-lookup.yml + examples/testdata/package.json: self-
  contained example demonstrating the intended UX
- tests/e2e/examples_test.go: selfContainedCase for json-lookup
- docs/src/guide/gaps.md: move JSON row to Achievable now, add recipe,
  and note the RFC 9535 vs pre-RFC filter-syntax difference against
  yaml:key
- go.mod/go.sum: add github.com/theory/jsonpath v0.12.0 (RFC 9535,
  actively maintained) — one new runtime module, zero new transitives