### PR TITLE
fix(utils): bound outbound URL fetches and check HTTP status

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -15,6 +15,7 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/go-version"
 	log "github.com/sirupsen/logrus"
@@ -282,17 +283,43 @@ func StringIsUrl(s string) bool {
 	return err == nil && u.Scheme != "" && u.Host != ""
 }
 
+// fetchTimeout bounds the total time (connection, redirects and body read)
+// spent fetching a remote URL, so a slow or unresponsive host cannot hang a
+// run indefinitely. Go's http.Client already caps redirects at 10 by
+// default when CheckRedirect is unset.
+const fetchTimeout = 30 * time.Second
+
+// maxFetchResponseSize bounds the number of bytes read from a remote
+// response body, so an unexpectedly large or malicious response cannot
+// exhaust memory. ISM-1288: outbound content must be bounded and validated.
+const maxFetchResponseSize = 10 * 1024 * 1024 // 10 MiB
+
+var fetchClient = &http.Client{Timeout: fetchTimeout}
+
 // FetchContentFromUrl fetches the content from a url and returns its bytes.
+// The request is bounded by fetchTimeout and the response body is capped at
+// maxFetchResponseSize; a response exceeding the cap returns an error rather
+// than being silently truncated.
 func FetchContentFromUrl(u string) ([]byte, error) {
-	rsp, err := http.Get(u)
+	rsp, err := fetchClient.Get(u)
 	if err != nil {
 		return []byte(nil), err
 	}
 
 	defer rsp.Body.Close()
+	if rsp.StatusCode < 200 || rsp.StatusCode >= 300 {
+		return []byte(nil), fmt.Errorf(
+			"fetching %s returned HTTP %d", u, rsp.StatusCode)
+	}
+
+	limited := io.LimitReader(rsp.Body, maxFetchResponseSize+1)
 	buf := new(bytes.Buffer)
-	if _, err := buf.ReadFrom(rsp.Body); err != nil {
+	if _, err := buf.ReadFrom(limited); err != nil {
 		return []byte(nil), err
+	}
+	if buf.Len() > maxFetchResponseSize {
+		return []byte(nil), fmt.Errorf(
+			"response from %s exceeds maximum allowed size of %d bytes", u, maxFetchResponseSize)
 	}
 	return buf.Bytes(), nil
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -477,6 +477,37 @@ func TestFetchContentFromUrl(t *testing.T) {
 	}
 }
 
+// TestFetchContentFromUrlSizeCap ensures a response larger than the maximum
+// allowed size is rejected with an error rather than silently truncated,
+// bounding memory use for outbound fetches of operator-controlled URLs.
+func TestFetchContentFromUrlSizeCap(t *testing.T) {
+	const overCap = 10*1024*1024 + 1
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(make([]byte, overCap))
+	}))
+	defer svr.Close()
+
+	c, err := FetchContentFromUrl(svr.URL + "/big.yml")
+	assert.Error(t, err)
+	assert.Nil(t, c)
+	assert.Contains(t, err.Error(), "exceeds maximum allowed size")
+}
+
+// TestFetchContentFromUrlWithinCap ensures a response right at the boundary
+// of the size cap is still accepted, guarding against an off-by-one in the
+// limit check.
+func TestFetchContentFromUrlWithinCap(t *testing.T) {
+	const atCap = 10 * 1024 * 1024
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(make([]byte, atCap))
+	}))
+	defer svr.Close()
+
+	c, err := FetchContentFromUrl(svr.URL + "/exact.yml")
+	assert.NoError(t, err)
+	assert.Len(t, c, atCap)
+}
+
 func TestIsDirectory(t *testing.T) {
 	if a, e := IsDirectory("testdata"); e != nil || !a {
 		t.Errorf("expected directory 'testdata' to exist")


### PR DESCRIPTION
FetchContentFromUrl had no request timeout, no cap on response size, and did not check the HTTP status code, so a slow, oversized, or error response (e.g. 404) was treated as valid content.