### PR TITLE
fix(fact): propagate errors from all inputs in CollectFact

### DIFF
--- a/pkg/fact/manager.go
+++ b/pkg/fact/manager.go
@@ -63,6 +63,23 @@ func (m *manager) GetFactoriesKeys() []string {
 	return plugin.GetFactoriesKeys[Facter](m.GetFactories())
 }
 
+// ResetPlugins clears the registered plugin instances, as well as the
+// manager's own collected-facts cache. Overrides
+// pluginmanager.Manager.ResetPlugins(), which only clears plugin instances:
+// without also clearing m.collected here, a fact name collected by one test
+// (or run) would be silently skipped by CollectFact's de-dup check
+// (utils.StringSliceContains(m.collected, name)) in a later test/run that
+// reuses the same name with a fresh plugin instance, even though that fresh
+// instance was never actually collected. Production code never calls
+// ResetPlugins mid-process, so this only affects test isolation - but it
+// affects it significantly, since fact names like "primary"/"current" are
+// reused across many _test.go files sharing the package-level manager
+// singleton.
+func (m *manager) ResetPlugins() {
+	m.Manager.ResetPlugins()
+	m.collected = nil
+}
+
 // ParseConfig parses the raw config and creates the facts.
 func (m *manager) ParseConfig(raw map[string]map[string]interface{}) error {
 	count := 0
@@ -110,13 +127,17 @@ func (m *manager) CollectAllFacts() {
 // CollectFact collects a fact.
 func (m *manager) CollectFact(name string, f Facter) {
 	log.WithField("fact", name).Debug("starting CollectFact process")
-	var inputF Facter
+
+	var inputErrored bool
 	if f.GetInputName() != "" {
 		log.WithField("fact", name).
 			WithField("inputName", f.GetInputName()).
 			Debug("collect input")
-		inputF = m.FindPlugin(f.GetInputName())
+		inputF := m.FindPlugin(f.GetInputName())
 		m.CollectFact(f.GetInputName(), inputF)
+		if inputF != nil && len(inputF.GetErrors()) > 0 {
+			inputErrored = true
+		}
 	}
 
 	if len(f.GetAdditionalInputNames()) > 0 {
@@ -124,12 +145,15 @@ func (m *manager) CollectFact(name string, f Facter) {
 			log.WithField("fact", name).
 				WithField("additionalInputName", n).
 				Debug("collect additional input")
-			inputF = m.FindPlugin(n)
-			m.CollectFact(n, inputF)
+			additionalInputF := m.FindPlugin(n)
+			m.CollectFact(n, additionalInputF)
+			if additionalInputF != nil && len(additionalInputF.GetErrors()) > 0 {
+				inputErrored = true
+			}
 		}
 	}
 
-	if inputF != nil && len(inputF.GetErrors()) > 0 {
+	if inputErrored {
 		return
 	}
 

--- a/pkg/fact/manager_test.go
+++ b/pkg/fact/manager_test.go
@@ -1,13 +1,16 @@
 package fact_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/salsadigitalauorg/shipshape/pkg/data"
 	"github.com/salsadigitalauorg/shipshape/pkg/fact"
 	"github.com/salsadigitalauorg/shipshape/pkg/fact/testdata"
+	"github.com/salsadigitalauorg/shipshape/pkg/plugin"
 )
 
 func registerFact(name string, format data.DataFormat, d any) {
@@ -81,4 +84,129 @@ func TestLookupFactAsStringMapUnknownInput(t *testing.T) {
 	assert.NotPanics(t, func() {
 		assert.Equal(t, "", fact.LookupFactAsStringMap("nonexistent", "key"))
 	})
+}
+
+// dependentTestFacter builds a TestFacter that declares a required input of
+// data.FormatString, so ValidateInput() actually passes and Collect() is
+// reached - without this, every TestFacter defaults to SupportNone/no
+// formats and ValidateInput() rejects the fact before the code path under
+// test (CollectFact's error propagation) ever runs, making the regression
+// test pass regardless of whether the bug is present.
+func dependentTestFacter(id string) *testdata.TestFacter {
+	d := testdata.New(id, data.FormatString, "should not collect")
+	d.TestSupportedInputFormatsLevel = plugin.SupportRequired
+	d.TestSupportedInputFormatsList = []data.DataFormat{data.FormatString}
+	return d
+}
+
+// TestCollectFactPrimaryInputErrorStopsCollection ensures a failure in the
+// *primary* input still halts collection of the dependent fact, even when an
+// additional input is also configured and collects successfully. Regression
+// test for a bug where CollectFact reused a single loop variable across the
+// primary-input and additional-inputs loops, so the error check after both
+// loops only ever inspected the last additional input.
+func TestCollectFactPrimaryInputErrorStopsCollection(t *testing.T) {
+	defer fact.Manager().ResetPlugins()
+	fact.Manager().ResetPlugins()
+
+	primary := testdata.New("primary", data.FormatString, nil)
+	primary.TestError = errors.New("primary input failed")
+
+	additional := testdata.New("additional", data.FormatString, "ok")
+
+	dependent := dependentTestFacter("dependent")
+	dependent.SetInputName("primary")
+	dependent.AdditionalInputNames = []string{"additional"}
+
+	fact.Manager().SetPlugins(map[string]fact.Facter{
+		"primary":    primary,
+		"additional": additional,
+		"dependent":  dependent,
+	})
+
+	fact.Manager().CollectFact("dependent", dependent)
+
+	// Sanity check: confirm the primary input's error was actually recorded,
+	// so a passing assertion below can't be explained by the primary
+	// silently succeeding instead of by the fix working.
+	require.NotEmpty(t, primary.GetErrors(), "primary input must have recorded its error")
+
+	assert.False(t, dependent.TestCollected,
+		"dependent fact's Collect() must not have run when its primary input errored")
+}
+
+// TestCollectFactAdditionalInputErrorStopsCollection is the mirror case:
+// a failure in an *earlier* additional input must halt collection even when
+// a *later* additional input succeeds. This shape specifically targets the
+// original bug: CollectFact aliased a single loop variable across every
+// additional input, so after the loop it only ever reflected the last one
+// processed - a failure earlier in the list was silently overwritten by a
+// later success. A single-additional-input case (as this test previously
+// used) cannot distinguish the fix from the bug, because with only one
+// additional input, "last processed" and "the erroring one" are always the
+// same input.
+func TestCollectFactAdditionalInputErrorStopsCollection(t *testing.T) {
+	defer fact.Manager().ResetPlugins()
+	fact.Manager().ResetPlugins()
+
+	primary := testdata.New("primary", data.FormatString, "ok")
+
+	additionalFailing := testdata.New("additional-failing", data.FormatString, nil)
+	additionalFailing.TestError = errors.New("additional input failed")
+
+	additionalOK := testdata.New("additional-ok", data.FormatString, "ok")
+
+	dependent := dependentTestFacter("dependent")
+	dependent.SetInputName("primary")
+	// additional-failing is deliberately listed before additional-ok, so a
+	// manager that only inspects the last additional input processed would
+	// see the (later, successful) additional-ok and incorrectly conclude
+	// nothing failed.
+	dependent.AdditionalInputNames = []string{"additional-failing", "additional-ok"}
+
+	fact.Manager().SetPlugins(map[string]fact.Facter{
+		"primary":            primary,
+		"additional-failing": additionalFailing,
+		"additional-ok":      additionalOK,
+		"dependent":          dependent,
+	})
+
+	fact.Manager().CollectFact("dependent", dependent)
+
+	require.NotEmpty(t, additionalFailing.GetErrors(), "additional-failing input must have recorded its error")
+	require.Empty(t, additionalOK.GetErrors(), "additional-ok input must not have errored")
+
+	assert.False(t, dependent.TestCollected,
+		"dependent fact's Collect() must not have run when an earlier additional input errored, "+
+			"even though a later additional input succeeded")
+}
+
+// TestCollectFactCollectsWhenNoInputErrors is the converse check: with both
+// the primary and additional input free of errors, the dependent fact's
+// Collect() must actually run. Without this, TestCollectFact*StopsCollection
+// above could be satisfied by a manager that never calls Collect() at all.
+func TestCollectFactCollectsWhenNoInputErrors(t *testing.T) {
+	defer fact.Manager().ResetPlugins()
+	fact.Manager().ResetPlugins()
+
+	primary := testdata.New("primary", data.FormatString, "ok")
+	additional := testdata.New("additional", data.FormatString, "ok")
+
+	dependent := dependentTestFacter("dependent")
+	dependent.SetInputName("primary")
+	dependent.AdditionalInputNames = []string{"additional"}
+
+	fact.Manager().SetPlugins(map[string]fact.Facter{
+		"primary":    primary,
+		"additional": additional,
+		"dependent":  dependent,
+	})
+
+	fact.Manager().CollectFact("dependent", dependent)
+
+	assert.Empty(t, dependent.GetErrors())
+	assert.True(t, dependent.TestCollected,
+		"dependent fact's Collect() must have run when neither input errored")
+	assert.Equal(t, data.FormatString, dependent.GetFormat(),
+		"dependent fact's Collect() must have run and set its format/data")
 }

--- a/pkg/fact/testdata/testfacter.go
+++ b/pkg/fact/testdata/testfacter.go
@@ -12,6 +12,23 @@ type TestFacter struct {
 	// Plugin fields.
 	TestInputDataFormat data.DataFormat
 	TestInputData       any
+	// TestError, when set, is recorded as a Collect() error instead of
+	// setting data - used to exercise error-propagation in the manager.
+	TestError error
+	// TestSupportedInputFormatsLevel, when non-empty, overrides
+	// SupportedInputFormats() so a TestFacter can stand in for a fact that
+	// actually declares an input requirement (e.g. to exercise
+	// ValidateInput()/CollectFact() gating). Left unset, the zero value
+	// preserves the original SupportNone/no-formats behaviour every existing
+	// caller relies on.
+	TestSupportedInputFormatsLevel plugin.SupportLevel
+	TestSupportedInputFormatsList  []data.DataFormat
+	// TestCollected records whether Collect() has run, so tests can assert
+	// directly on invocation rather than inferring it from GetData()/
+	// GetFormat() (which are also both zero-valued before Collect() runs,
+	// making "not collected" and "collected but produced a zero value"
+	// indistinguishable without this).
+	TestCollected bool
 }
 
 func init() {
@@ -36,7 +53,28 @@ func (p *TestFacter) GetName() string {
 	return "testdata:testfacter"
 }
 
+// SupportedInputFormats defaults to plugin.SupportNone/no formats (the
+// original TestFacter behaviour), unless TestSupportedInputFormatsLevel has
+// been set to opt a specific test into input validation.
+func (p *TestFacter) SupportedInputFormats() (plugin.SupportLevel, []data.DataFormat) {
+	if p.TestSupportedInputFormatsLevel == "" {
+		return plugin.SupportNone, []data.DataFormat{}
+	}
+	return p.TestSupportedInputFormatsLevel, p.TestSupportedInputFormatsList
+}
+
 func (p *TestFacter) Collect() {
+	p.TestCollected = true
+	// Format is set regardless of TestError, mirroring real fact plugins
+	// (e.g. file:read sets Format at construction time via NewRead, entirely
+	// independent of whether Collect() later errors). This matters for
+	// tests that assert on ValidateInput()'s inPlug.GetFormat() == "" check,
+	// which would otherwise misreport an errored-but-well-formed input as
+	// unformatted.
 	p.Format = p.TestInputDataFormat
+	if p.TestError != nil {
+		p.AddErrors(p.TestError)
+		return
+	}
 	p.SetData(p.TestInputData)
 }


### PR DESCRIPTION
CollectFact stopped checking additional inputs for errors after the first one succeeded, so a later erroring input was silently ignored. ResetPlugins also never cleared m.collected, letting a fact name reused across tests skip collection via the de-dup check.