### PR TITLE
feat: add file:drift fact and drift analyser

### DIFF
--- a/docs/src/guide/gaps.md
+++ b/docs/src/guide/gaps.md
@@ -26,7 +26,7 @@ None of the statuses below mean "waiting for a one-to-one port". Almost every
 | 0.x check | Status | 1.x plugin chain |
 |---|---|---|
 | [`file`](../reference/checks/file.md) | Achievable now | `file:lookup` + `not:empty` — see `examples/files.yml` |
-| [`file:diff`](../reference/checks/file-diff.md) | Needs new capability | TBD |
+| [`file:diff`](../reference/checks/file-diff.md) | Achievable now | `file:read`/`http:fetch` + `file:drift` + `drift` — see `examples/file-drift.yml` |
 
 ### Recipe: file
 
@@ -45,6 +45,83 @@ analyse:
 ```
 
 Source: `examples/files.yml`
+
+### Recipe: file:diff
+
+0.x `file:diff` rendered a Jinja template with an operator-supplied vars map
+and diffed the result against an on-disk file. 1.x deliberately does **not**
+reproduce that: `file:drift` instead masks placeholder-shaped substrings
+(default `{{ VAR }}`) out of both sides before diffing, so the same config
+runs unmodified across every project provisioned from a template — no
+per-project vars map required. It also detects a placeholder that was never
+substituted, which rendering cannot.
+
+Template rendering was rejected in favour of drift matching for several
+reasons: a per-project vars map does not scale across many provisioned
+projects; `${{ VAR }}`-style placeholders collide with GitHub Actions'
+`${{ secrets.* }}` syntax when the template is a workflow file; rendering
+silently substitutes undefined variables rather than surfacing them;
+rendering cannot detect a placeholder that was never substituted, because
+there is nothing left to compare once it is rendered away; and a rendering
+engine (e.g. gonja) pulls in dozens of transitive dependencies where RE2
+(already in the standard library) needs none.
+
+```yaml
+collect:
+  template:
+    http:fetch:
+      url: https://raw.githubusercontent.com/client/project-template/main/.github/workflows/ci.yml
+
+  current:
+    file:read:
+      path: .github/workflows/ci.yml
+
+  ci-drift:
+    file:drift:
+      input: template
+      additional-inputs: [current]
+
+analyse:
+  ci-matches-template:
+    drift:
+      description: CI workflow has not drifted from the project template
+      input: ci-drift
+```
+
+`drift` breaches carry a full unified diff (3 lines of context) via
+`KeyValuesBreach` — legible in `pretty`, `json`, and `junit` output. The
+`table` renderer does not wrap multi-line breach values, so it is unsuitable
+for drift checks.
+
+**Caveat — placeholder matching is a wildcard, not a value check.** Each
+placeholder in a template line is matched against the current line with a
+non-greedy `(.*?)` capture, so `file:drift` confirms *something* occupies the
+placeholder's position, not that the surrounding line is otherwise identical
+in structure. In particular:
+
+- A placeholder capture can absorb adjacent genuine drift on the same line —
+  e.g. template `image: {{ IMG }}:v1` against current
+  `image: evil/malware:latest:v1` reports no drift, because the wildcard
+  swallows everything up to the literal `:v1` suffix. Keep placeholders on
+  their own line, or as the entire value, where the drift you care about
+  could plausibly appear.
+- The same placeholder name used twice on one line (e.g.
+  `a: {{ X }} b: {{ X }}`) is **not** checked for consistency between the two
+  captured values — RE2 has no backreferences, so `file:drift` cannot express
+  "these two captures must match". A current line of `a: one b: two` reports
+  no drift even though the two `X` values differ.
+- An empty substitution (the current file has nothing where the template has
+  `{{ VAR }}`) counts as substituted, not as drift. Only a placeholder that is
+  still **literally present** in the current file — the common
+  copy-paste-and-forgot-to-fill-in bug — is flagged as unsubstituted.
+
+None of these are considered blocking for the initial recipe: they are
+inherent to wildcard-based matching without a rendering/vars step, and are
+judged an acceptable trade-off against the config-per-project cost of true
+template rendering (see the rationale above). Prefer isolating a placeholder to its
+own line, or to the entirety of a value, where precision matters.
+
+Source: `examples/file-drift.yml`
 
 ## YAML / JSON checks
 
@@ -276,8 +353,8 @@ Source: `examples/docker.yml`
 
 | Status | Count |
 |---|---|
-| Achievable now | 14 |
+| Achievable now | 16 |
 | Achievable, undocumented | 0 |
-| Needs new capability | 4 |
+| Needs new capability | 2 |
 
 The plan for the remaining capabilities is on the [roadmap](roadmap.md) page.

--- a/examples/file-drift.yml
+++ b/examples/file-drift.yml
@@ -1,0 +1,85 @@
+# Detect drift between a project-template repository and a provisioned
+# project's current state, ignoring placeholders that are meant to vary per
+# project (e.g. {{ PROJECT_NAME }}).
+#
+# `file:drift` compares a template input against a single additional input
+# (the current file), masking placeholder-shaped substrings out of both sides
+# before diffing with a standard unified diff (3 lines of context). This is
+# deliberately not template rendering: it requires no per-project vars map,
+# so the same config runs unmodified across every project provisioned from
+# the template. See docs/plans/2026-07-24-needs-new-capability-plugins.md for
+# the full rationale (ADR: reject Jinja rendering for file-drift detection).
+#
+# In a real audit the template would usually be fetched from the template
+# repository with `http:fetch`:
+#
+#   collect:
+#     template:
+#       http:fetch:
+#         url: https://raw.githubusercontent.com/client/project-template/main/.github/workflows/ci.yml
+#     current:
+#       file:read:
+#         path: .github/workflows/ci.yml
+#
+# This example uses two committed fixtures instead of a live URL, so it runs
+# offline and deterministically in CI.
+#
+# `file:drift` emits an empty list when the current file matches the template
+# (modulo placeholders), or unified diff lines plus any
+# unsubstituted-placeholder notices when it does not - so it pairs naturally
+# with the `drift` analyser, which breaches whenever its input is non-empty.
+collect:
+  template:
+    file:read:
+      path: file-drift/template.yml
+
+  current-clean:
+    file:read:
+      path: file-drift/project-clean.yml
+
+  ci-drift-clean:
+    file:drift:
+      input: template
+      additional-inputs: [current-clean]
+
+  current-drifted:
+    file:read:
+      path: file-drift/project-drifted.yml
+
+  ci-drift-drifted:
+    file:drift:
+      input: template
+      additional-inputs: [current-drifted]
+
+  current-unsubstituted:
+    file:read:
+      path: file-drift/project-unsubstituted.yml
+
+  ci-drift-unsubstituted:
+    file:drift:
+      input: template
+      additional-inputs: [current-unsubstituted]
+
+analyse:
+  # Passes: the placeholder was substituted with a real value and every
+  # other line matches the template exactly.
+  ci-matches-template:
+    drift:
+      input: ci-drift-clean
+      description: "CI workflow has not drifted from the project template"
+
+  # Breaches: runs-on and node-version have genuinely drifted from the
+  # template. The {{ PROJECT_NAME }} line and the ${{ secrets.GITHUB_TOKEN }}
+  # GitHub Actions expression are both correctly excluded from the diff.
+  ci-drifted-from-template:
+    drift:
+      input: ci-drift-drifted
+      description: "CI workflow has not drifted from the project template"
+
+  # Breaches: the placeholder was never substituted - a common provisioning
+  # bug that a rendering-based approach cannot detect, since there would be
+  # nothing on the project side to compare the rendered value against.
+  ci-placeholder-unsubstituted:
+    drift:
+      input: ci-drift-unsubstituted
+      description: "CI workflow has not drifted from the project template"

--- a/examples/file-drift.yml
+++ b/examples/file-drift.yml
@@ -7,8 +7,8 @@
 # before diffing with a standard unified diff (3 lines of context). This is
 # deliberately not template rendering: it requires no per-project vars map,
 # so the same config runs unmodified across every project provisioned from
-# the template. See docs/plans/2026-07-24-needs-new-capability-plugins.md for
-# the full rationale (ADR: reject Jinja rendering for file-drift detection).
+# the template. See the "Recipe: file:diff" section of docs/src/guide/gaps.md
+# for the full rationale, including why template rendering was rejected.
 #
 # In a real audit the template would usually be fetched from the template
 # repository with `http:fetch`:

--- a/examples/testdata/file-drift/project-clean.yml
+++ b/examples/testdata/file-drift/project-clean.yml
@@ -1,0 +1,18 @@
+name: my-actual-project
+on:
+  push:
+    branches: [main]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm test
+      - name: notify
+        env:
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: curl -H "Authorization: Bearer $TOKEN" https://example.com

--- a/examples/testdata/file-drift/project-drifted.yml
+++ b/examples/testdata/file-drift/project-drifted.yml
@@ -1,0 +1,18 @@
+name: my-actual-project
+on:
+  push:
+    branches: [main]
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 16
+      - run: npm ci
+      - run: npm test
+      - name: notify
+        env:
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: curl -H "Authorization: Bearer $TOKEN" https://example.com

--- a/examples/testdata/file-drift/project-unsubstituted.yml
+++ b/examples/testdata/file-drift/project-unsubstituted.yml
@@ -1,0 +1,18 @@
+name: {{ PROJECT_NAME }}
+on:
+  push:
+    branches: [main]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm test
+      - name: notify
+        env:
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: curl -H "Authorization: Bearer $TOKEN" https://example.com

--- a/examples/testdata/file-drift/template.yml
+++ b/examples/testdata/file-drift/template.yml
@@ -1,0 +1,18 @@
+name: {{ PROJECT_NAME }}
+on:
+  push:
+    branches: [main]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm test
+      - name: notify
+        env:
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: curl -H "Authorization: Bearer $TOKEN" https://example.com

--- a/pkg/analyse/drift.go
+++ b/pkg/analyse/drift.go
@@ -1,0 +1,46 @@
+package analyse
+
+import (
+	"github.com/salsadigitalauorg/shipshape/pkg/breach"
+	"github.com/salsadigitalauorg/shipshape/pkg/data"
+	log "github.com/sirupsen/logrus"
+)
+
+// Drift is an analyser that breaches once per input, whenever its input
+// (typically file:drift) is non-empty. There is no toggle for the inverse
+// polarity: drift always means breach, so unlike allowed:list or
+// regex:match there is nothing to configure - the presence of any drift
+// content is itself the assertion failure.
+type Drift struct {
+	BaseAnalyser `yaml:",inline"`
+}
+
+//go:generate go run ../../cmd/gen.go analyse-plugin --plugin=Drift --package=analyse
+
+func init() {
+	Manager().RegisterFactory("drift", func(id string) Analyser { return NewDrift(id) })
+}
+
+func (p *Drift) GetName() string {
+	return "drift"
+}
+
+func (p *Drift) Analyse() {
+	log.WithField("input-format", p.input.GetFormat()).Debug("analysing")
+
+	switch p.input.GetFormat() {
+	case data.FormatListString:
+		inputData := data.AsListString(p.input.GetData())
+		if len(inputData) == 0 {
+			return
+		}
+		breach.EvaluateTemplate(p, &breach.KeyValuesBreach{
+			KeyLabel:   "file",
+			Key:        p.GetInputName(),
+			ValueLabel: "drift",
+			Values:     inputData,
+		}, p.Remediation)
+	default:
+		log.WithField("input-format", p.input.GetFormat()).Error("unsupported input format")
+	}
+}

--- a/pkg/analyse/drift_test.go
+++ b/pkg/analyse/drift_test.go
@@ -1,0 +1,132 @@
+package analyse_test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
+	. "github.com/salsadigitalauorg/shipshape/pkg/analyse"
+	"github.com/salsadigitalauorg/shipshape/pkg/breach"
+	"github.com/salsadigitalauorg/shipshape/pkg/data"
+	"github.com/salsadigitalauorg/shipshape/pkg/fact"
+	"github.com/salsadigitalauorg/shipshape/pkg/fact/testdata"
+)
+
+func TestDriftInit(t *testing.T) {
+	assert := assert.New(t)
+
+	plugin := Manager().GetFactories()["drift"]("testDrift")
+	assert.NotNil(plugin)
+	analyser, ok := plugin.(*Drift)
+	assert.True(ok)
+	assert.Equal("testDrift", analyser.Id)
+}
+
+func TestDriftPluginName(t *testing.T) {
+	instance := NewDrift("testDrift")
+	assert.Equal(t, "drift", instance.GetName())
+}
+
+func TestDriftAnalyse(t *testing.T) {
+	tt := []struct {
+		name             string
+		input            fact.Facter
+		inputName        string
+		expectedBreaches []breach.Breach
+	}{
+		{
+			name: "listStringNil",
+			input: testdata.New(
+				"testFacter",
+				data.FormatListString,
+				[]string(nil),
+			),
+			inputName:        "ci-drift",
+			expectedBreaches: []breach.Breach{},
+		},
+		{
+			name: "listStringEmpty",
+			input: testdata.New(
+				"testFacter",
+				data.FormatListString,
+				[]string{},
+			),
+			inputName:        "ci-drift",
+			expectedBreaches: []breach.Breach{},
+		},
+		{
+			name: "listStringNotEmpty",
+			input: testdata.New(
+				"testFacter",
+				data.FormatListString,
+				[]string{
+					"--- template\n",
+					"+++ current\n",
+					"@@ -1,1 +1,1 @@\n",
+					"-node-version: 20\n",
+					"+node-version: 16\n",
+				},
+			),
+			inputName: "ci-drift",
+			expectedBreaches: []breach.Breach{
+				&breach.KeyValuesBreach{
+					BreachType: "key-values",
+					CheckName:  "listStringNotEmpty",
+					KeyLabel:   "file",
+					Key:        "ci-drift",
+					ValueLabel: "drift",
+					Values: []string{
+						"--- template\n",
+						"+++ current\n",
+						"@@ -1,1 +1,1 @@\n",
+						"-node-version: 20\n",
+						"+node-version: 16\n",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		assert := assert.New(t)
+
+		currLogOut := logrus.StandardLogger().Out
+		defer logrus.SetOutput(currLogOut)
+		logrus.SetOutput(io.Discard)
+
+		t.Run(tc.name, func(t *testing.T) {
+			analyser := NewDrift(tc.name)
+			analyser.InputName = tc.inputName
+
+			tc.input.Collect()
+			analyser.SetInput(tc.input)
+			analyser.Analyse()
+
+			assert.Len(analyser.Result.Breaches, len(tc.expectedBreaches))
+			assert.ElementsMatch(tc.expectedBreaches, analyser.Result.Breaches)
+		})
+	}
+}
+
+// TestDriftAnalyseUnsupportedFormat ensures an unexpected input format does
+// not panic and produces no breach, matching the defensive pattern used by
+// other analysers (e.g. NotEmpty) for formats they cannot interpret.
+func TestDriftAnalyseUnsupportedFormat(t *testing.T) {
+	assert := assert.New(t)
+
+	currLogOut := logrus.StandardLogger().Out
+	defer logrus.SetOutput(currLogOut)
+	logrus.SetOutput(io.Discard)
+
+	analyser := NewDrift("testDrift")
+	input := testdata.New("testFacter", data.FormatString, "not-a-list")
+	input.Collect()
+	analyser.SetInput(input)
+
+	assert.NotPanics(func() {
+		analyser.Analyse()
+	})
+	assert.Empty(analyser.Result.Breaches)
+}

--- a/pkg/fact/file/drift.go
+++ b/pkg/fact/file/drift.go
@@ -1,0 +1,293 @@
+package file
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/pmezard/go-difflib/difflib"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/salsadigitalauorg/shipshape/pkg/data"
+	"github.com/salsadigitalauorg/shipshape/pkg/fact"
+	"github.com/salsadigitalauorg/shipshape/pkg/plugin"
+)
+
+var (
+	// ErrNoCurrentInput is returned when the plugin is configured without an
+	// additional input naming the current (provisioned) file to compare
+	// against the template.
+	ErrNoCurrentInput = errors.New(
+		"file:drift requires exactly one additional-inputs entry, naming the current file to compare against the template")
+	// ErrTooManyAdditionalInputs is returned when more than one
+	// additional-inputs entry is configured.
+	ErrTooManyAdditionalInputs = errors.New(
+		"file:drift accepts exactly one additional-inputs entry")
+	// ErrInvalidPlaceholderPattern is returned when placeholder-pattern does
+	// not compile as a regular expression.
+	ErrInvalidPlaceholderPattern = errors.New("file:drift placeholder-pattern is not a valid regular expression")
+
+	// defaultPlaceholderPattern matches Jinja/Mustache-style {{ VAR }}
+	// placeholders, tolerating surrounding whitespace.
+	defaultPlaceholderPattern = `{{\s*(\w+)\s*}}`
+)
+
+// Drift compares a template (its input) against the current state of a
+// provisioned file (its single additional input), treating
+// placeholder-shaped substrings (default `{{ VAR }}`) as wildcards rather
+// than as literal text to diff. This is the general-purpose alternative to
+// rendering the template with a vars map: it requires no per-project
+// configuration, because it never needs to know what a placeholder's actual
+// value should be - only that some value is present.
+//
+// Emits FormatListString: empty when the current file matches the template
+// (modulo placeholders), or containing unified diff lines (plus any
+// unsubstituted-placeholder notices) when it does not. Pairs naturally with
+// the `drift` analyser, which breaches whenever this list is non-empty.
+//
+// Caveats (documented in docs/src/guide/gaps.md - Recipe: file:diff):
+//   - Each placeholder is matched with a non-greedy (.*?) capture, so it can
+//     absorb adjacent genuine drift on the same line rather than surfacing it.
+//   - The same placeholder name repeated on one line is not checked for
+//     consistency between its captures - RE2 has no backreferences.
+//   - An empty substitution counts as substituted, not as drift; only a
+//     placeholder still literally present in the current file is flagged.
+type Drift struct {
+	fact.BaseFact `yaml:",inline"`
+
+	// Plugin fields.
+	PlaceholderPattern string `yaml:"placeholder-pattern"`
+
+	placeholderRegex *regexp.Regexp
+}
+
+func init() {
+	fact.Manager().RegisterFactory("file:drift", func(n string) fact.Facter {
+		return NewDrift(n)
+	})
+}
+
+func NewDrift(id string) *Drift {
+	return &Drift{
+		BaseFact: fact.BaseFact{
+			BasePlugin: plugin.BasePlugin{
+				Id: id,
+			},
+		},
+	}
+}
+
+func (p *Drift) GetName() string {
+	return "file:drift"
+}
+
+// SupportedInputFormats declares that file:drift requires a template input
+// of raw bytes or string (e.g. http:fetch or file:read).
+func (p *Drift) SupportedInputFormats() (plugin.SupportLevel, []data.DataFormat) {
+	return plugin.SupportRequired, []data.DataFormat{data.FormatRaw, data.FormatString}
+}
+
+func (p *Drift) Collect() {
+	contextLogger := log.WithFields(log.Fields{
+		"fact-plugin": p.GetName(),
+		"fact":        p.GetId(),
+	})
+
+	additionalInputs := p.GetAdditionalInputs()
+	if len(additionalInputs) == 0 {
+		p.AddErrors(ErrNoCurrentInput)
+		return
+	}
+	if len(additionalInputs) > 1 {
+		p.AddErrors(ErrTooManyAdditionalInputs)
+		return
+	}
+	currentInput := additionalInputs[0]
+
+	// SupportedInputFormats() only constrains the primary input; the
+	// additional (current-file) input is read directly via
+	// stringifyFactData, which silently returns "" for any format it
+	// doesn't recognise. Without this check, pointing additional-inputs at
+	// e.g. a file:lookup (map-bytes) or json:key (list-string) output
+	// produces an empty "current" side and a false-positive breach
+	// claiming the entire template was deleted, rather than a config
+	// error - the worst failure mode for an audit tool.
+	switch currentInput.GetFormat() {
+	case data.FormatRaw, data.FormatString:
+	default:
+		contextLogger.WithField("format", currentInput.GetFormat()).
+			Error("unsupported additional input format")
+		p.AddErrors(&plugin.ErrSupportNone{
+			Plugin:        p.GetName(),
+			SupportType:   "additionalInputFormat",
+			SupportPlugin: string(currentInput.GetFormat())})
+		return
+	}
+
+	pattern := p.PlaceholderPattern
+	if pattern == "" {
+		pattern = defaultPlaceholderPattern
+	}
+	placeholderRegex, err := regexp.Compile(pattern)
+	if err != nil {
+		contextLogger.WithError(err).Error("invalid placeholder pattern")
+		p.AddErrors(ErrInvalidPlaceholderPattern)
+		return
+	}
+	p.placeholderRegex = placeholderRegex
+
+	templateContent := stringifyFactData(p.GetInput().GetData())
+	currentContent := stringifyFactData(currentInput.GetData())
+
+	drift := p.diff(templateContent, currentContent)
+
+	p.Format = data.FormatListString
+	p.SetData(drift)
+}
+
+// stringifyFactData accepts either raw bytes or string fact data, since
+// file:drift's input may come from file:read (raw) or http:fetch (raw).
+func stringifyFactData(d interface{}) string {
+	switch v := d.(type) {
+	case []byte:
+		return string(v)
+	case string:
+		return v
+	default:
+		return ""
+	}
+}
+
+// diff masks placeholder-shaped substrings out of both the template and the
+// current file before diffing, so legitimate per-project variation never
+// appears as drift. A project-side placeholder that was never substituted is
+// flagged as its own entry, since forward-rendering approaches cannot detect
+// this common provisioning bug.
+func (p *Drift) diff(templateContent, currentContent string) []string {
+	templateLines := difflib.SplitLines(templateContent)
+	currentLines := difflib.SplitLines(currentContent)
+
+	maskedTemplate := make([]string, len(templateLines))
+	maskedCurrent := make([]string, len(currentLines))
+
+	matcher := difflib.NewMatcher(templateLines, currentLines)
+	var unsubstituted []string
+
+	for _, op := range matcher.GetOpCodes() {
+		switch op.Tag {
+		case 'e':
+			for k := 0; k < op.I2-op.I1; k++ {
+				tLine := templateLines[op.I1+k]
+				maskedTemplate[op.I1+k] = tLine
+				maskedCurrent[op.J1+k] = tLine
+				// An equal line containing a placeholder means the current
+				// file still literally contains the placeholder text - it
+				// was never substituted. Rendering-based approaches cannot
+				// detect this, because there is nothing on the current side
+				// to compare against once the placeholder is rendered away.
+				for _, ph := range p.placeholderRegex.FindAllString(tLine, -1) {
+					unsubstituted = append(unsubstituted, fmt.Sprintf(
+						"line %d: placeholder %q was left unsubstituted", op.J1+k+1, ph))
+				}
+			}
+		case 'r':
+			n := op.I2 - op.I1
+			if n == op.J2-op.J1 {
+				for k := 0; k < n; k++ {
+					tLine := templateLines[op.I1+k]
+					cLine := currentLines[op.J1+k]
+					masked, values, matched := maskLine(p.placeholderRegex, tLine, cLine)
+					maskedTemplate[op.I1+k] = tLine
+					if matched {
+						maskedCurrent[op.J1+k] = masked
+						for _, v := range values {
+							if p.placeholderRegex.MatchString(v) {
+								unsubstituted = append(unsubstituted, fmt.Sprintf(
+									"line %d: placeholder %q was left unsubstituted", op.J1+k+1, v))
+							}
+						}
+					} else {
+						maskedCurrent[op.J1+k] = cLine
+					}
+				}
+			} else {
+				for k := 0; k < n; k++ {
+					maskedTemplate[op.I1+k] = templateLines[op.I1+k]
+				}
+				for k := 0; k < op.J2-op.J1; k++ {
+					maskedCurrent[op.J1+k] = currentLines[op.J1+k]
+				}
+			}
+		case 'd':
+			for k := 0; k < op.I2-op.I1; k++ {
+				maskedTemplate[op.I1+k] = templateLines[op.I1+k]
+			}
+		case 'i':
+			for k := 0; k < op.J2-op.J1; k++ {
+				maskedCurrent[op.J1+k] = currentLines[op.J1+k]
+			}
+		}
+	}
+
+	unifiedDiff := difflib.UnifiedDiff{
+		A:        maskedTemplate,
+		B:        maskedCurrent,
+		FromFile: "template",
+		ToFile:   "current",
+		Context:  3,
+	}
+	diffStr, _ := difflib.GetUnifiedDiffString(unifiedDiff)
+
+	var result []string
+	if diffStr != "" {
+		// SplitLines preserves each line's trailing "\n", which is what
+		// UnifiedDiff needs as input elsewhere - but here each entry becomes
+		// its own list item, and the "drift" analyser's breach joins items
+		// with its own separator, so a retained "\n" would double up into a
+		// blank line between every entry. SplitLines also always appends an
+		// artificial trailing "\n"-only entry when the input ends in a
+		// newline (its convention for reconstructing multi-line text), which
+		// becomes an empty string once trimmed - drop it rather than emit a
+		// dangling bullet in rendered breach output.
+		for _, line := range difflib.SplitLines(diffStr) {
+			trimmed := strings.TrimSuffix(line, "\n")
+			if trimmed != "" {
+				result = append(result, trimmed)
+			}
+		}
+	}
+	result = append(result, unsubstituted...)
+	return result
+}
+
+// maskLine attempts to match currentLine against templateLine, treating each
+// placeholder in templateLine as a wildcard capture. On a successful match,
+// it returns templateLine (so the diff sees no change on this line) and the
+// captured values (so callers can detect unsubstituted placeholders).
+func maskLine(placeholderRegex *regexp.Regexp, templateLine, currentLine string) (masked string, values []string, matched bool) {
+	locs := placeholderRegex.FindAllStringIndex(templateLine, -1)
+	if len(locs) == 0 {
+		return templateLine, nil, templateLine == currentLine
+	}
+
+	linePattern := "^"
+	lastEnd := 0
+	for _, loc := range locs {
+		linePattern += regexp.QuoteMeta(templateLine[lastEnd:loc[0]])
+		linePattern += "(.*?)"
+		lastEnd = loc[1]
+	}
+	linePattern += regexp.QuoteMeta(templateLine[lastEnd:]) + "$"
+
+	lineRegex, err := regexp.Compile(linePattern)
+	if err != nil {
+		return templateLine, nil, false
+	}
+
+	m := lineRegex.FindStringSubmatch(currentLine)
+	if m == nil {
+		return templateLine, nil, false
+	}
+	return templateLine, m[1:], true
+}

--- a/pkg/fact/file/drift_test.go
+++ b/pkg/fact/file/drift_test.go
@@ -1,0 +1,347 @@
+package file_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/salsadigitalauorg/shipshape/pkg/data"
+	"github.com/salsadigitalauorg/shipshape/pkg/fact"
+	. "github.com/salsadigitalauorg/shipshape/pkg/fact/file"
+	"github.com/salsadigitalauorg/shipshape/pkg/fact/testdata"
+	"github.com/salsadigitalauorg/shipshape/pkg/internal"
+	"github.com/salsadigitalauorg/shipshape/pkg/plugin"
+)
+
+func TestDriftInit(t *testing.T) {
+	assert := assert.New(t)
+
+	factPlugin := fact.Manager().GetFactories()["file:drift"]("testDrift")
+	assert.NotNil(factPlugin)
+	driftFacter, ok := factPlugin.(*Drift)
+	assert.True(ok)
+	assert.Equal("testDrift", driftFacter.GetId())
+}
+
+func TestDriftPluginName(t *testing.T) {
+	assert.Equal(t, "file:drift", NewDrift("testDrift").GetName())
+}
+
+func TestDriftSupportedInputFormats(t *testing.T) {
+	d := NewDrift("testDrift")
+	supportLevel, inputFormats := d.SupportedInputFormats()
+	assert.Equal(t, plugin.SupportRequired, supportLevel)
+	assert.ElementsMatch(t, []data.DataFormat{
+		data.FormatRaw,
+		data.FormatString,
+	}, inputFormats)
+}
+
+func TestDriftCollect(t *testing.T) {
+	tests := []internal.FactCollectTest{
+		{
+			Name:               "noInput",
+			Facter:             NewDrift("drift"),
+			ExpectedInputError: &plugin.ErrSupportRequired{SupportType: "input"},
+		},
+		{
+			Name: "noAdditionalInputs",
+			FactFn: func() fact.Facter {
+				f := NewDrift("drift")
+				f.SetInputName("test-input")
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatRaw, Data: []byte("runs-on: ubuntu-latest\n"),
+			},
+			ExpectedErrors: []error{ErrNoCurrentInput},
+		},
+		{
+			Name: "identicalNoPlaceholders",
+			FactFn: func() fact.Facter {
+				f := NewDrift("drift")
+				f.SetInputName("test-input")
+				f.AdditionalInputNames = []string{"current"}
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatRaw,
+				Data:       []byte("runs-on: ubuntu-latest\nsteps:\n  - run: build\n"),
+			},
+			TestAdditionalInputs: map[string]internal.FactInputTest{
+				"current": {
+					DataFormat: data.FormatRaw,
+					Data:       []byte("runs-on: ubuntu-latest\nsteps:\n  - run: build\n"),
+				},
+			},
+			ExpectedFormat: data.FormatListString,
+			ExpectedData:   []string{},
+		},
+		{
+			Name: "placeholderSubstitutedNoDrift",
+			FactFn: func() fact.Facter {
+				f := NewDrift("drift")
+				f.SetInputName("test-input")
+				f.AdditionalInputNames = []string{"current"}
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatRaw,
+				Data:       []byte("name: {{ PROJECT_NAME }}\nruns-on: ubuntu-latest\n"),
+			},
+			TestAdditionalInputs: map[string]internal.FactInputTest{
+				"current": {
+					DataFormat: data.FormatRaw,
+					Data:       []byte("name: my-actual-project\nruns-on: ubuntu-latest\n"),
+				},
+			},
+			ExpectedFormat: data.FormatListString,
+			ExpectedData:   []string{},
+		},
+		{
+			Name: "githubActionsExpressionNotTreatedAsDrift",
+			FactFn: func() fact.Facter {
+				f := NewDrift("drift")
+				f.SetInputName("test-input")
+				f.AdditionalInputNames = []string{"current"}
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatRaw,
+				Data:       []byte("token: ${{ secrets.GITHUB_TOKEN }}\n"),
+			},
+			TestAdditionalInputs: map[string]internal.FactInputTest{
+				"current": {
+					DataFormat: data.FormatRaw,
+					Data:       []byte("token: ${{ secrets.GITHUB_TOKEN }}\n"),
+				},
+			},
+			ExpectedFormat: data.FormatListString,
+			ExpectedData:   []string{},
+		},
+		{
+			Name: "genuineDriftProducesDiff",
+			FactFn: func() fact.Facter {
+				f := NewDrift("drift")
+				f.SetInputName("test-input")
+				f.AdditionalInputNames = []string{"current"}
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatRaw,
+				Data:       []byte("name: {{ PROJECT_NAME }}\nruns-on: ubuntu-latest\n"),
+			},
+			TestAdditionalInputs: map[string]internal.FactInputTest{
+				"current": {
+					DataFormat: data.FormatRaw,
+					Data:       []byte("name: my-actual-project\nruns-on: ubuntu-20.04\n"),
+				},
+			},
+			ExpectedFormat: data.FormatListString,
+			// Non-empty; exact diff content is asserted in a dedicated test
+			// below since ElementsMatch on diff lines is order-sensitive.
+		},
+		{
+			Name: "unsubstitutedPlaceholderFlagged",
+			FactFn: func() fact.Facter {
+				f := NewDrift("drift")
+				f.SetInputName("test-input")
+				f.AdditionalInputNames = []string{"current"}
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatRaw,
+				Data:       []byte("name: {{ PROJECT_NAME }}\n"),
+			},
+			TestAdditionalInputs: map[string]internal.FactInputTest{
+				"current": {
+					DataFormat: data.FormatRaw,
+					Data:       []byte("name: {{ PROJECT_NAME }}\n"),
+				},
+			},
+			ExpectedFormat: data.FormatListString,
+			// Non-empty; asserted in a dedicated test below.
+		},
+		{
+			Name: "invalidPlaceholderPattern",
+			FactFn: func() fact.Facter {
+				f := NewDrift("drift")
+				f.SetInputName("test-input")
+				f.AdditionalInputNames = []string{"current"}
+				f.PlaceholderPattern = "(unclosed"
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatRaw, Data: []byte("name: x\n"),
+			},
+			TestAdditionalInputs: map[string]internal.FactInputTest{
+				"current": {DataFormat: data.FormatRaw, Data: []byte("name: x\n")},
+			},
+			ExpectedErrors: []error{ErrInvalidPlaceholderPattern},
+		},
+		{
+			// Regression test: an additional input in a format file:drift
+			// cannot read (e.g. map-bytes from file:lookup, or list-string
+			// from json:key) must error, not silently stringify to "" and
+			// produce a false-positive breach claiming the entire template
+			// was deleted.
+			Name: "unsupportedAdditionalInputFormatMapBytes",
+			FactFn: func() fact.Facter {
+				f := NewDrift("drift")
+				f.SetInputName("test-input")
+				f.AdditionalInputNames = []string{"current"}
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatRaw,
+				Data:       []byte("name: {{ P }}\nkeep: 1\n"),
+			},
+			TestAdditionalInputs: map[string]internal.FactInputTest{
+				"current": {
+					DataFormat: data.FormatMapBytes,
+					Data:       map[string][]byte{"a": []byte("x")},
+				},
+			},
+			ExpectedErrors: []error{&plugin.ErrSupportNone{
+				Plugin:        "file:drift",
+				SupportType:   "additionalInputFormat",
+				SupportPlugin: string(data.FormatMapBytes),
+			}},
+		},
+		{
+			Name: "unsupportedAdditionalInputFormatListString",
+			FactFn: func() fact.Facter {
+				f := NewDrift("drift")
+				f.SetInputName("test-input")
+				f.AdditionalInputNames = []string{"current"}
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatRaw,
+				Data:       []byte("name: {{ P }}\nkeep: 1\n"),
+			},
+			TestAdditionalInputs: map[string]internal.FactInputTest{
+				"current": {
+					DataFormat: data.FormatListString,
+					Data:       []string{"x"},
+				},
+			},
+			ExpectedErrors: []error{&plugin.ErrSupportNone{
+				Plugin:        "file:drift",
+				SupportType:   "additionalInputFormat",
+				SupportPlugin: string(data.FormatListString),
+			}},
+		},
+		{
+			Name: "customPlaceholderPattern",
+			FactFn: func() fact.Facter {
+				f := NewDrift("drift")
+				f.SetInputName("test-input")
+				f.AdditionalInputNames = []string{"current"}
+				f.PlaceholderPattern = `__(\w+)__`
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatRaw,
+				Data:       []byte("name: __PROJECT_NAME__\n"),
+			},
+			TestAdditionalInputs: map[string]internal.FactInputTest{
+				"current": {
+					DataFormat: data.FormatRaw,
+					Data:       []byte("name: my-actual-project\n"),
+				},
+			},
+			ExpectedFormat: data.FormatListString,
+			ExpectedData:   []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			internal.TestFactCollect(t, tt)
+		})
+	}
+}
+
+// TestDriftGenuineDriftContainsBothChangedLines exercises the exact diff
+// content produced by a real Collect() run (rather than the harness's
+// ElementsMatch-based ExpectedData, which is order-sensitive and awkward for
+// diff text), confirming the unchanged placeholder line is masked out of the
+// diff and only the genuinely-drifted line appears.
+func TestDriftGenuineDriftContainsBothChangedLines(t *testing.T) {
+	fact.Manager().ResetPlugins()
+	defer fact.Manager().ResetPlugins()
+
+	tmpl, _ := fact.Manager().GetPlugin("testdata:testfacter", "tmpl")
+	tmplP := tmpl.(*testdata.TestFacter)
+	tmplP.TestInputDataFormat = data.FormatRaw
+	tmplP.TestInputData = []byte("name: {{ PROJECT_NAME }}\nruns-on: ubuntu-latest\n")
+	tmplP.Collect()
+
+	current, _ := fact.Manager().GetPlugin("testdata:testfacter", "current")
+	currentP := current.(*testdata.TestFacter)
+	currentP.TestInputDataFormat = data.FormatRaw
+	currentP.TestInputData = []byte("name: my-actual-project\nruns-on: ubuntu-20.04\n")
+	currentP.Collect()
+
+	d := NewDrift("drift")
+	d.SetInputName("tmpl")
+	d.SetInput(tmplP)
+	d.AdditionalInputNames = []string{"current"}
+	errs := fact.LoadAdditionalInputs(d)
+	assert.Empty(t, errs)
+
+	d.Collect()
+	assert.Empty(t, d.GetErrors())
+
+	lines := data.AsListString(d.GetData())
+	joined := ""
+	var changedLines []string
+	for _, l := range lines {
+		joined += l
+		if strings.HasPrefix(l, "+") || strings.HasPrefix(l, "-") {
+			changedLines = append(changedLines, l)
+		}
+	}
+	changedJoined := strings.Join(changedLines, "")
+	assert.NotContains(t, changedJoined, "my-actual-project",
+		"placeholder-masked line must appear only as unchanged diff context, not as a +/- change")
+	assert.Contains(t, joined, "ubuntu-latest")
+	assert.Contains(t, joined, "ubuntu-20.04")
+}
+
+func TestDriftUnsubstitutedPlaceholderMessage(t *testing.T) {
+	fact.Manager().ResetPlugins()
+	defer fact.Manager().ResetPlugins()
+
+	tmpl, _ := fact.Manager().GetPlugin("testdata:testfacter", "tmpl")
+	tmplP := tmpl.(*testdata.TestFacter)
+	tmplP.TestInputDataFormat = data.FormatRaw
+	tmplP.TestInputData = []byte("name: {{ PROJECT_NAME }}\n")
+	tmplP.Collect()
+
+	current, _ := fact.Manager().GetPlugin("testdata:testfacter", "current")
+	currentP := current.(*testdata.TestFacter)
+	currentP.TestInputDataFormat = data.FormatRaw
+	currentP.TestInputData = []byte("name: {{ PROJECT_NAME }}\n")
+	currentP.Collect()
+
+	d := NewDrift("drift")
+	d.SetInputName("tmpl")
+	d.SetInput(tmplP)
+	d.AdditionalInputNames = []string{"current"}
+	errs := fact.LoadAdditionalInputs(d)
+	assert.Empty(t, errs)
+
+	d.Collect()
+	assert.Empty(t, d.GetErrors())
+
+	found := false
+	for _, l := range data.AsListString(d.GetData()) {
+		if l == `line 1: placeholder "{{ PROJECT_NAME }}" was left unsubstituted` {
+			found = true
+		}
+	}
+	assert.True(t, found, "expected an unsubstituted-placeholder notice, got %v", data.AsListString(d.GetData()))
+}

--- a/tests/e2e/examples_test.go
+++ b/tests/e2e/examples_test.go
@@ -120,6 +120,23 @@ func selfContainedCases() []selfContainedCase {
 				{name: "tracking-code-check", status: "Fail", checkType: "equals", breachCount: 1},
 			},
 		},
+		{
+			name:         "file-drift",
+			file:         "file-drift.yml",
+			wantChecks:   3,
+			wantBreaches: 2,
+			wantSeverity: map[string]int{"normal": 2},
+			// wantPolicies is intentionally omitted: all three checks share
+			// the drift plugin, and the policy IDs within a plugin are
+			// collected via Go map iteration (see shipshape.go), so their
+			// order is non-deterministic. checkResults asserts each check by
+			// name, which is order-independent.
+			checkResults: []wantResult{
+				{name: "ci-matches-template", status: "Pass", checkType: "drift"},
+				{name: "ci-drifted-from-template", status: "Fail", checkType: "drift", breachCount: 1},
+				{name: "ci-placeholder-unsubstituted", status: "Fail", checkType: "drift", breachCount: 1},
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
## What this does

Closes the `file:diff` gap in the 0.x → 1.x recipe catalogue, in three commits.

**`feat: add file:drift fact and drift analyser`**
`file:drift` compares a template against the current state of a provisioned
file, masking placeholder-shaped substrings (default `{{ VAR }}`) as wildcards
rather than rendering them, so the same config runs unmodified across every
project without a per-project vars map. It also detects placeholders that were
never substituted. The `drift` analyser breaches whenever the fact's diff
output is non-empty.

**`test(e2e): add file-drift example and e2e case`**
A self-contained example (`http:fetch`/`file:read` + `file:drift` + `drift`)
with fixtures covering three cases: a clean match, drifted content, and an
unsubstituted placeholder. Uses committed fixtures rather than a live URL so
it runs offline and deterministically in CI.

**`docs(gaps): move file:diff to Achievable now`**
Documents the recipe, the rationale for masking placeholders instead of
rendering templates, and the wildcard-matching caveats.

## Why not template rendering

0.x `file:diff` rendered a Jinja template against an operator-supplied vars
map. That was deliberately not reproduced:

- a per-project vars map does not scale across many provisioned projects;
- `${{ VAR }}`-style placeholders collide with GitHub Actions'
  `${{ secrets.* }}` syntax when the template is a workflow file;
- rendering silently substitutes undefined variables instead of surfacing them;
- rendering cannot detect a placeholder that was never substituted — there is
  nothing left to compare once it is rendered away;
- a rendering engine (e.g. gonja) pulls in dozens of transitive dependencies,
  where RE2 (already in the standard library) needs none.

## Known limitations

Placeholder matching is a wildcard, not a value check — a capture can absorb
adjacent drift on the same line, repeated placeholders aren't checked for
consistency (RE2 has no backreferences), and an empty substitution counts as
substituted. These are inherent to wildcard matching without a vars step and
are documented with mitigations in `gaps.md`.

## Test plan

- `pkg/fact/file/drift_test.go`, `pkg/analyse/drift_test.go` — unit coverage
- `tests/e2e/examples_test.go` — `file-drift` case: 3 checks, 2 expected breaches
- Verified locally (`go generate && go vet && go test -race`, plus the e2e
  suite), since `pull_request` triggers are scoped to `branches: [1.x]` and
  this PR gets no CI until it is retargeted.