### PR TITLE
feat: close the sca:application_type recipe gap with file:fingerprint and detected

### DIFF
--- a/docs/src/.vuepress/config.js
+++ b/docs/src/.vuepress/config.js
@@ -93,6 +93,7 @@ module.exports = {
                 ['/reference/collect/database-search', 'database:search'],
                 ['/reference/collect/docker-command', 'docker:command'],
                 ['/reference/collect/docker-images', 'docker:images'],
+                ['/reference/collect/file-fingerprint', 'file:fingerprint'],
                 ['/reference/collect/file-lookup', 'file:lookup'],
                 ['/reference/collect/file-read', 'file:read'],
                 ['/reference/collect/file-read-multiple', 'file:read:multiple'],

--- a/docs/src/guide/gaps.md
+++ b/docs/src/guide/gaps.md
@@ -288,7 +288,7 @@ of the other Drush-based checks — the shape stays the same.
 | 0.x check | Status | 1.x plugin chain |
 |---|---|---|
 | [`phpstan`](../reference/checks/phpstan.md) | Achievable now | `static-analysis` + `static-analysis:breaches` — see `examples/phpstan.yml` |
-| [`sca:application_type`](../reference/checks/sca-application-type.md) | Needs new capability | TBD |
+| [`sca:application_type`](../reference/checks/sca-application-type.md) | Achievable now | `file:fingerprint` + `detected` — see `examples/app-type.yml` |
 
 ### Recipe: phpstan
 
@@ -309,6 +309,120 @@ analyse:
 ```
 
 Source: `examples/phpstan.yml`
+
+### Recipe: sca:application_type
+
+0.x `sca:application_type` scored each disallowed framework with a weighted
+likelihood — markers (content matches in entrypoint files), dirs (directory
+presence), and dependencies (manifest lookup) each added to a running total,
+which breached once it exceeded a threshold. `file:fingerprint` reproduces
+this weighted model rather than simple presence matching (`detect` implies
+boolean presence; `fingerprint` conveys accumulated weighted evidence), and
+`detected` breaches once per label present in its map-shaped input.
+
+No framework knowledge is baked into the binary: every signature (which
+markers/dirs/dependencies identify which label) is entirely operator config
+under `frameworks`. The binary only supplies the generic matching mechanism.
+
+```yaml
+collect:
+  app-type:
+    file:fingerprint:
+      path: .
+      threshold: 20
+      entrypoints: ["index.php"]
+      weights: {markers: 5, dirs: 5, dependencies: 10}
+      manifest: composer.json
+      dependency-paths:            # optional override; sensible defaults ship
+        - "$.require"
+        - "$['require-dev']"
+      frameworks:
+        drupal:
+          markers: ["use Drupal\\Core\\DrupalKernel;"]
+          dirs: [web, docroot]
+          dependencies: [drupal/core-recommended]
+        wordpress:
+          markers: [" * @package WordPress"]
+          dirs: [wp-content]
+
+analyse:
+  no-disallowed-frameworks:
+    detected:
+      description: Disallowed application framework detected
+      input: app-type
+      severity: high
+```
+
+Source: `examples/app-type.yml`
+
+**Caveat — markers/dirs accumulate per match, dependencies does not.** A
+framework with 2 markers each found in 2 entrypoint files scores
+`weights.markers * 2 * 2`, not a flat `weights.markers` — and a framework
+with the same directory name matched twice (or two configured dir names both
+present) scores `weights.dirs` twice. This reproduces 0.x's
+`sca:application_type` accumulation model exactly
+(`pkg/checks/sca/apptypecheck.go`), so a ported 0.x config scores
+identically. Dependencies is the one signal that does **not** accumulate:
+however many configured dependency names match, or however many
+`dependency-paths` expressions surface them, a framework's dependencies
+signal contributes `weights.dependencies` at most once — mirroring 0.x's
+single bool-driven award for that signal. Do not assume all three signals
+behave the same way when tuning weights and thresholds.
+
+**Caveat — threshold is a "strictly greater than" boundary, and 0 cannot mean
+"any single match".** A label is only emitted when its accumulated score is
+strictly greater than `threshold`; a score equal to `threshold` does not
+breach. Because YAML unmarshals an absent field to Go's zero value,
+`threshold: 0` and simply omitting `threshold` are indistinguishable from "use
+the default (30)". An operator who genuinely wants "any single match
+breaches" cannot express `threshold: 0` and must configure a negative
+threshold (e.g. `-1`) instead. This is inherited from 0.x, which has the
+identical limitation, and is kept unchanged for compatibility with ported 0.x
+threshold values.
+
+**Composing a shared signature library.** Because `frameworks` is plain
+operator config, a signature library (a YAML file defining `frameworks` for
+common PHP/Node frameworks) can be maintained centrally and composed with a
+project-local config via repeated `-f` flags, which support URLs:
+
+```sh
+shipshape run . \
+  -f https://raw.githubusercontent.com/your-org/shipshape-signatures/main/frameworks.yml \
+  -f ./my-audit.yml
+```
+
+v2 config deep-merges every `-f` file in order
+(`pkg/config/config.go`, `pkg/config/merge.go`). **Caveat: `deepMerge`
+replaces slices and scalars, it does not union or append them.** If both the
+shared library and the local override define `frameworks.drupal.dirs`, the
+local file's list *replaces* the library's list entirely — a local override
+adding one directory to an otherwise-good signature must repeat every
+existing entry, not just the new one. Every override is logged at `Warn`
+with the dotted key path, so a later file silently changing a signature is
+never invisible — but it is easy to author an override that unintentionally
+drops entries from a signature the author only meant to extend. Only maps
+merge recursively; everything else (scalars and slices) is a full
+replacement.
+
+**Scope boundary — this recipe answers "is a disallowed framework present?",
+not "is this the expected app type?".** `file:fingerprint` emits a map of
+label to score for every framework whose score clears the threshold; it does
+not emit a fixed list of allowed/expected labels to compare against, so it
+cannot directly express "this project must be exactly a Drupal site and
+nothing else". Composing the output with `allowed:list` does not work
+either: `allowed:list` on a `FormatMapString` input compares the map's
+*values* (the scores) against an allow-list, not its keys (the labels) — the
+comparison you would actually want. Expected-app-type checking would need a
+`labels-only` toggle (emitting the label set rather than label→score) that
+`file:fingerprint` does not currently offer. Until then, use this recipe only
+for "flag disallowed frameworks", not "assert the one expected framework".
+
+**Sovereignty note.** `file:fingerprint` itself performs local filesystem I/O
+only — no network calls. The `-f <url>` signature-library composition
+pattern above is outbound network I/O at config-load time, not inside the
+fact plugin. For AU-sovereign deployments, host shared signature libraries
+in-region (`ap-southeast-2` or `ap-southeast-4`) rather than pulling them from
+an offshore URL.
 
 ## Infrastructure checks
 

--- a/docs/src/reference/collect/file-fingerprint.md
+++ b/docs/src/reference/collect/file-fingerprint.md
@@ -1,0 +1,1 @@
+# file:fingerprint

--- a/examples/app-type.yml
+++ b/examples/app-type.yml
@@ -1,0 +1,113 @@
+# Detect disallowed application frameworks using weighted evidence rather
+# than simple presence checks.
+#
+# `file:fingerprint` scores each configured framework signature against a
+# codebase: markers (exact-line matches in entrypoint files, e.g. index.php),
+# dirs (directory names present anywhere under the scanned path), and
+# dependencies (package names present in a manifest such as composer.json).
+# Each signal contributes its configured weight per match - so two markers
+# found in two entrypoints score 2x2x weights.markers, not a flat weight -
+# reproducing the accumulation model of the 0.x sca:application_type check
+# it replaces. The one exception is dependencies: a matched dependency scores
+# once only, no matter how many configured names match, mirroring 0.x's
+# single bool-driven award for that signal.
+#
+# A framework is only emitted (as label -> accumulated score) when its score
+# is strictly greater than `threshold`. Sub-threshold scores are not emitted
+# at all, not even as a low value - so a codebase that merely shares one
+# incidental signal with a framework (e.g. a "public" directory, common to
+# several PHP frameworks) does not falsely trigger a breach. This example's
+# threshold (15) is chosen so that a single coincidental dirs-only match
+# (weight 5) never breaches on its own, but a real framework match
+# (markers + dirs + dependencies, typically 20) does.
+#
+# No framework knowledge is baked into the binary - the `frameworks` map
+# below is entirely operator-supplied config. A signature library like this
+# can be shared across projects and composed with local overrides via
+# multiple `-f` flags (deep-merged - see docs/src/guide/gaps.md for the
+# override-replaces-not-appends caveat on repeated list keys).
+#
+# `detected` breaches once per label present in a map-shaped input (any
+# entry is itself the assertion failure), pairing naturally with
+# `file:fingerprint`'s "is a disallowed framework present?" output.
+collect:
+  drupal-project:
+    file:fingerprint:
+      path: app-type/drupal
+      threshold: 15
+      entrypoints: ["index.php"]
+      frameworks: &x-frameworks
+        drupal:
+          markers: ["use Drupal\\Core\\DrupalKernel;"]
+          dirs: [web, docroot]
+          dependencies: [drupal/core-recommended]
+        wordpress:
+          markers: [" * @package WordPress"]
+          dirs: [wp-content]
+        symfony:
+          markers: ["  return new Kernel($context['APP_ENV'], (bool) $context['APP_DEBUG']);"]
+          dirs: [bin, config, public]
+          dependencies: [symfony/runtime, symfony/symfony, symfony/framework]
+        laravel:
+          markers: ["use Illuminate\\Contracts\\Http\\Kernel;"]
+          dirs: [config, public]
+          dependencies: [laravel/framework, laravel/tinker]
+
+  wordpress-project:
+    file:fingerprint:
+      path: app-type/wordpress
+      threshold: 15
+      entrypoints: ["index.php"]
+      frameworks: *x-frameworks
+
+  symfony-project:
+    file:fingerprint:
+      path: app-type/symfony
+      threshold: 15
+      entrypoints: ["index.php"]
+      frameworks: *x-frameworks
+
+  laravel-project:
+    file:fingerprint:
+      path: app-type/laravel
+      threshold: 15
+      entrypoints: ["index.php"]
+      frameworks: *x-frameworks
+
+analyse:
+  # Breaches: the drupal fixture scores markers + dirs + dependencies
+  # (5+5+10=20), well over the threshold.
+  drupal-project-frameworks:
+    detected:
+      description: Disallowed application framework detected
+      input: drupal-project
+      severity: high
+
+  # Passes: the wordpress fixture only matches its own marker line
+  # (score 5). No dirs or dependencies signal fires for any configured
+  # framework, so 5 never exceeds the threshold of 15 - this is the case
+  # that proves threshold filtering, not just label choice.
+  wordpress-project-frameworks:
+    detected:
+      description: Disallowed application framework detected
+      input: wordpress-project
+      severity: high
+
+  # Breaches: the symfony fixture scores markers + dirs + dependencies
+  # (5+5+10=20). The laravel signature's "public" dir also incidentally
+  # matches here (score 5), but 5 stays under threshold and is correctly
+  # not emitted.
+  symfony-project-frameworks:
+    detected:
+      description: Disallowed application framework detected
+      input: symfony-project
+      severity: high
+
+  # Breaches: the laravel fixture scores markers + dirs + dependencies
+  # (5+5+10=20). The symfony signature's "public" dir also incidentally
+  # matches here (score 5) but stays under threshold.
+  laravel-project-frameworks:
+    detected:
+      description: Disallowed application framework detected
+      input: laravel-project
+      severity: high

--- a/examples/testdata/app-type/drupal/composer.json
+++ b/examples/testdata/app-type/drupal/composer.json
@@ -1,0 +1,95 @@
+{
+  "name": "drupal/recommended-project",
+  "description": "Project template for Drupal projects with a relocated document root",
+  "type": "project",
+  "license": "GPL-2.0-or-later",
+  "homepage": "https://www.drupal.org/project/drupal",
+  "support": {
+    "docs": "https://www.drupal.org/docs/user_guide/en/index.html",
+    "chat": "https://www.drupal.org/node/314178"
+  },
+  "repositories": [
+    {
+      "type": "composer",
+      "url": "https://packages.drupal.org/8"
+    }
+  ],
+  "require": {
+    "composer/installers": "^2.0",
+    "drupal/core-composer-scaffold": "^10.0",
+    "drupal/core-project-message": "^10.0",
+    "drupal/core-recommended": "^10.0"
+  },
+  "conflict": {
+    "drupal/drupal": "*"
+  },
+  "minimum-stability": "stable",
+  "prefer-stable": true,
+  "config": {
+    "allow-plugins": {
+      "composer/installers": true,
+      "drupal/core-composer-scaffold": true,
+      "drupal/core-project-message": true,
+      "phpstan/extension-installer": true,
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    },
+    "sort-packages": true
+  },
+  "extra": {
+    "drupal-scaffold": {
+      "locations": {
+        "web-root": "web/"
+      }
+    },
+    "installer-paths": {
+      "web/core": [
+        "type:drupal-core"
+      ],
+      "web/libraries/{$name}": [
+        "type:drupal-library"
+      ],
+      "web/modules/contrib/{$name}": [
+        "type:drupal-module"
+      ],
+      "web/profiles/contrib/{$name}": [
+        "type:drupal-profile"
+      ],
+      "web/themes/contrib/{$name}": [
+        "type:drupal-theme"
+      ],
+      "drush/Commands/contrib/{$name}": [
+        "type:drupal-drush"
+      ],
+      "web/modules/custom/{$name}": [
+        "type:drupal-custom-module"
+      ],
+      "web/profiles/custom/{$name}": [
+        "type:drupal-custom-profile"
+      ],
+      "web/themes/custom/{$name}": [
+        "type:drupal-custom-theme"
+      ]
+    },
+    "drupal-core-project-message": {
+      "include-keys": [
+        "homepage",
+        "support"
+      ],
+      "post-create-project-cmd-message": [
+        "<bg=blue;fg=white>                                                         </>",
+        "<bg=blue;fg=white>  Congratulations, you’ve installed the Drupal codebase  </>",
+        "<bg=blue;fg=white>  from the drupal/recommended-project template!          </>",
+        "<bg=blue;fg=white>                                                         </>",
+        "",
+        "<bg=yellow;fg=black>Next steps</>:",
+        "  * Install the site: https://www.drupal.org/docs/installing-drupal",
+        "  * Read the user guide: https://www.drupal.org/docs/user_guide/en/index.html",
+        "  * Get support: https://www.drupal.org/support",
+        "  * Get involved with the Drupal community:",
+        "      https://www.drupal.org/getting-involved",
+        "  * Remove the plugin that prints this message:",
+        "      composer remove drupal/core-project-message"
+      ]
+    }
+  }
+}

--- a/examples/testdata/app-type/drupal/web/index.php
+++ b/examples/testdata/app-type/drupal/web/index.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @file
+ * The PHP page that serves all page requests on a Drupal installation.
+ *
+ * All Drupal code is released under the GNU General Public License.
+ * See COPYRIGHT.txt and LICENSE.txt files in the "core" directory.
+ */
+
+use Drupal\Core\DrupalKernel;
+use Symfony\Component\HttpFoundation\Request;
+
+$autoloader = require_once 'autoload.php';
+
+$kernel = new DrupalKernel('prod', $autoloader);
+
+$request = Request::createFromGlobals();
+$response = $kernel->handle($request);
+$response->send();
+
+$kernel->terminate($request, $response);

--- a/examples/testdata/app-type/laravel/composer.json
+++ b/examples/testdata/app-type/laravel/composer.json
@@ -1,0 +1,68 @@
+{
+  "name": "laravel/laravel",
+  "type": "project",
+  "description": "The Laravel Framework.",
+  "keywords": [
+    "framework",
+    "laravel"
+  ],
+  "license": "MIT",
+  "require": {
+    "php": "^8.0.2",
+    "guzzlehttp/guzzle": "^7.2",
+    "laravel/framework": "^9.19",
+    "laravel/sanctum": "^3.0",
+    "laravel/tinker": "^2.7"
+  },
+  "require-dev": {
+    "fakerphp/faker": "^1.9.1",
+    "laravel/pint": "^1.0",
+    "laravel/sail": "^1.0.1",
+    "mockery/mockery": "^1.4.4",
+    "nunomaduro/collision": "^6.1",
+    "phpunit/phpunit": "^9.5.10",
+    "spatie/laravel-ignition": "^1.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "App\\": "app/",
+      "Database\\Factories\\": "database/factories/",
+      "Database\\Seeders\\": "database/seeders/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Tests\\": "tests/"
+    }
+  },
+  "scripts": {
+    "post-autoload-dump": [
+      "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
+      "@php artisan package:discover --ansi"
+    ],
+    "post-update-cmd": [
+      "@php artisan vendor:publish --tag=laravel-assets --ansi --force"
+    ],
+    "post-root-package-install": [
+      "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""
+    ],
+    "post-create-project-cmd": [
+      "@php artisan key:generate --ansi"
+    ]
+  },
+  "extra": {
+    "laravel": {
+      "dont-discover": []
+    }
+  },
+  "config": {
+    "optimize-autoloader": true,
+    "preferred-install": "dist",
+    "sort-packages": true,
+    "allow-plugins": {
+      "pestphp/pest-plugin": true
+    }
+  },
+  "minimum-stability": "dev",
+  "prefer-stable": true
+}

--- a/examples/testdata/app-type/laravel/public/index.php
+++ b/examples/testdata/app-type/laravel/public/index.php
@@ -1,0 +1,55 @@
+<?php
+
+use Illuminate\Contracts\Http\Kernel;
+use Illuminate\Http\Request;
+
+define('LARAVEL_START', microtime(true));
+
+/*
+|--------------------------------------------------------------------------
+| Check If The Application Is Under Maintenance
+|--------------------------------------------------------------------------
+|
+| If the application is in maintenance / demo mode via the "down" command
+| we will load this file so that any pre-rendered content can be shown
+| instead of starting the framework, which could cause an exception.
+|
+*/
+
+if (file_exists($maintenance = __DIR__ . '/../storage/framework/maintenance.php')) {
+  require $maintenance;
+}
+
+/*
+|--------------------------------------------------------------------------
+| Register The Auto Loader
+|--------------------------------------------------------------------------
+|
+| Composer provides a convenient, automatically generated class loader for
+| this application. We just need to utilize it! We'll simply require it
+| into the script here so we don't need to manually load our classes.
+|
+*/
+
+require __DIR__ . '/../vendor/autoload.php';
+
+/*
+|--------------------------------------------------------------------------
+| Run The Application
+|--------------------------------------------------------------------------
+|
+| Once we have the application, we can handle the incoming request using
+| the application's HTTP kernel. Then, we will send the response back
+| to this client's browser, allowing them to enjoy our application.
+|
+*/
+
+$app = require_once __DIR__ . '/../bootstrap/app.php';
+
+$kernel = $app->make(Kernel::class);
+
+$response = $kernel->handle(
+  $request = Request::capture()
+)->send();
+
+$kernel->terminate($request, $response);

--- a/examples/testdata/app-type/symfony/composer.json
+++ b/examples/testdata/app-type/symfony/composer.json
@@ -1,0 +1,65 @@
+{
+  "type": "project",
+  "license": "proprietary",
+  "minimum-stability": "dev",
+  "prefer-stable": true,
+  "require": {
+    "php": ">=8.1",
+    "ext-ctype": "*",
+    "ext-iconv": "*",
+    "symfony/console": "6.2.*",
+    "symfony/dotenv": "6.2.*",
+    "symfony/flex": "^2",
+    "symfony/framework-bundle": "6.2.*",
+    "symfony/runtime": "6.2.*",
+    "symfony/yaml": "6.2.*"
+  },
+  "require-dev": {},
+  "config": {
+    "allow-plugins": {
+      "symfony/flex": true,
+      "symfony/runtime": true
+    },
+    "sort-packages": true
+  },
+  "autoload": {
+    "psr-4": {
+      "App\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "App\\Tests\\": "tests/"
+    }
+  },
+  "replace": {
+    "symfony/polyfill-ctype": "*",
+    "symfony/polyfill-iconv": "*",
+    "symfony/polyfill-php72": "*",
+    "symfony/polyfill-php73": "*",
+    "symfony/polyfill-php74": "*",
+    "symfony/polyfill-php80": "*",
+    "symfony/polyfill-php81": "*"
+  },
+  "scripts": {
+    "auto-scripts": {
+      "cache:clear": "symfony-cmd",
+      "assets:install %PUBLIC_DIR%": "symfony-cmd"
+    },
+    "post-install-cmd": [
+      "@auto-scripts"
+    ],
+    "post-update-cmd": [
+      "@auto-scripts"
+    ]
+  },
+  "conflict": {
+    "symfony/symfony": "*"
+  },
+  "extra": {
+    "symfony": {
+      "allow-contrib": false,
+      "require": "6.2.*"
+    }
+  }
+}

--- a/examples/testdata/app-type/symfony/public/index.php
+++ b/examples/testdata/app-type/symfony/public/index.php
@@ -1,0 +1,9 @@
+<?php
+
+use App\Kernel;
+
+require_once dirname(__DIR__) . '/vendor/autoload_runtime.php';
+
+return function (array $context) {
+  return new Kernel($context['APP_ENV'], (bool) $context['APP_DEBUG']);
+};

--- a/examples/testdata/app-type/wordpress/composer.json
+++ b/examples/testdata/app-type/wordpress/composer.json
@@ -1,0 +1,6 @@
+{
+    "_comment": "Minimal manifest required because the shared frameworks signature (examples/app-type.yml) configures a 'dependencies' list for drupal/symfony/laravel; file:fingerprint requires the manifest to exist whenever any configured framework uses that signal, even one that never matches this fixture.",
+    "require": {
+        "php": "^8.1"
+    }
+}

--- a/examples/testdata/app-type/wordpress/index.php
+++ b/examples/testdata/app-type/wordpress/index.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Front to the WordPress application. This file doesn't do anything, but loads
+ * wp-blog-header.php which does and tells WordPress to load the theme.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Tells WordPress to load the WordPress theme and output it.
+ *
+ * @var bool
+ */
+define('WP_USE_THEMES', true);
+
+/** Loads the WordPress Environment and Template */
+require __DIR__ . '/wp-blog-header.php';

--- a/pkg/analyse/detected.go
+++ b/pkg/analyse/detected.go
@@ -1,0 +1,63 @@
+package analyse
+
+import (
+	"sort"
+
+	"github.com/salsadigitalauorg/shipshape/pkg/breach"
+	"github.com/salsadigitalauorg/shipshape/pkg/data"
+	log "github.com/sirupsen/logrus"
+)
+
+// Detected is an analyser that breaches once per entry in a map-shaped
+// input (typically file:fingerprint), whenever that entry is present.
+// Like Drift, there is no toggle for the inverse polarity: any entry in
+// the map is itself the assertion failure, so there is nothing to
+// configure beyond input/description/severity.
+//
+// Map keys are sorted before breaches are emitted, because Go's map
+// iteration order is randomised and this analyser is typically used with
+// multi-label input (e.g. several detected frameworks) - without
+// sorting, breach order (and therefore e2e assertions on it) would be
+// non-deterministic.
+type Detected struct {
+	BaseAnalyser `yaml:",inline"`
+}
+
+//go:generate go run ../../cmd/gen.go analyse-plugin --plugin=Detected --package=analyse
+
+func init() {
+	Manager().RegisterFactory("detected", func(id string) Analyser { return NewDetected(id) })
+}
+
+func (p *Detected) GetName() string {
+	return "detected"
+}
+
+func (p *Detected) Analyse() {
+	log.WithField("input-format", p.input.GetFormat()).Debug("analysing")
+
+	switch p.input.GetFormat() {
+	case data.FormatMapString:
+		inputData := data.AsMapString(p.input.GetData())
+		if len(inputData) == 0 {
+			return
+		}
+
+		keys := make([]string, 0, len(inputData))
+		for k := range inputData {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+
+		for _, k := range keys {
+			breach.EvaluateTemplate(p, &breach.KeyValueBreach{
+				KeyLabel:   "framework",
+				Key:        k,
+				ValueLabel: "likelihood",
+				Value:      inputData[k],
+			}, p.Remediation)
+		}
+	default:
+		log.WithField("input-format", p.input.GetFormat()).Error("unsupported input format")
+	}
+}

--- a/pkg/analyse/detected_test.go
+++ b/pkg/analyse/detected_test.go
@@ -1,0 +1,207 @@
+package analyse_test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
+	. "github.com/salsadigitalauorg/shipshape/pkg/analyse"
+	"github.com/salsadigitalauorg/shipshape/pkg/breach"
+	"github.com/salsadigitalauorg/shipshape/pkg/data"
+	"github.com/salsadigitalauorg/shipshape/pkg/fact"
+	"github.com/salsadigitalauorg/shipshape/pkg/fact/testdata"
+)
+
+func TestDetectedInit(t *testing.T) {
+	assert := assert.New(t)
+
+	plugin := Manager().GetFactories()["detected"]("testDetected")
+	assert.NotNil(plugin)
+	analyser, ok := plugin.(*Detected)
+	assert.True(ok)
+	assert.Equal("testDetected", analyser.Id)
+}
+
+func TestDetectedPluginName(t *testing.T) {
+	instance := NewDetected("testDetected")
+	assert.Equal(t, "detected", instance.GetName())
+}
+
+func TestDetectedAnalyse(t *testing.T) {
+	tt := []struct {
+		name             string
+		input            fact.Facter
+		inputName        string
+		expectedBreaches []breach.Breach
+	}{
+		{
+			name: "mapStringNil",
+			input: testdata.New(
+				"testFacter",
+				data.FormatMapString,
+				map[string]string(nil),
+			),
+			inputName:        "app-type",
+			expectedBreaches: []breach.Breach{},
+		},
+		{
+			name: "mapStringEmpty",
+			input: testdata.New(
+				"testFacter",
+				data.FormatMapString,
+				map[string]string{},
+			),
+			inputName:        "app-type",
+			expectedBreaches: []breach.Breach{},
+		},
+		{
+			name: "mapStringSingle",
+			input: testdata.New(
+				"testFacter",
+				data.FormatMapString,
+				map[string]string{
+					"drupal": "15",
+				},
+			),
+			inputName: "app-type",
+			expectedBreaches: []breach.Breach{
+				&breach.KeyValueBreach{
+					BreachType: "key-value",
+					CheckName:  "mapStringSingle",
+					KeyLabel:   "framework",
+					Key:        "drupal",
+					ValueLabel: "likelihood",
+					Value:      "15",
+				},
+			},
+		},
+		{
+			name: "mapStringMultiple",
+			input: testdata.New(
+				"testFacter",
+				data.FormatMapString,
+				map[string]string{
+					"wordpress": "25",
+					"drupal":    "15",
+					"laravel":   "30",
+				},
+			),
+			inputName: "app-type",
+			expectedBreaches: []breach.Breach{
+				&breach.KeyValueBreach{
+					BreachType: "key-value",
+					CheckName:  "mapStringMultiple",
+					KeyLabel:   "framework",
+					Key:        "drupal",
+					ValueLabel: "likelihood",
+					Value:      "15",
+				},
+				&breach.KeyValueBreach{
+					BreachType: "key-value",
+					CheckName:  "mapStringMultiple",
+					KeyLabel:   "framework",
+					Key:        "laravel",
+					ValueLabel: "likelihood",
+					Value:      "30",
+				},
+				&breach.KeyValueBreach{
+					BreachType: "key-value",
+					CheckName:  "mapStringMultiple",
+					KeyLabel:   "framework",
+					Key:        "wordpress",
+					ValueLabel: "likelihood",
+					Value:      "25",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		assert := assert.New(t)
+
+		currLogOut := logrus.StandardLogger().Out
+		defer logrus.SetOutput(currLogOut)
+		logrus.SetOutput(io.Discard)
+
+		t.Run(tc.name, func(t *testing.T) {
+			analyser := NewDetected(tc.name)
+			analyser.InputName = tc.inputName
+
+			tc.input.Collect()
+			analyser.SetInput(tc.input)
+			analyser.Analyse()
+
+			assert.Len(analyser.Result.Breaches, len(tc.expectedBreaches))
+			assert.ElementsMatch(tc.expectedBreaches, analyser.Result.Breaches)
+		})
+	}
+}
+
+// TestDetectedAnalyseBreachOrderDeterministic asserts that breach order is
+// stable across repeated runs against the same multi-entry map input, since
+// Go randomises map iteration and Detected must sort keys before emitting
+// breaches to keep e2e assertions on breach order reliable.
+func TestDetectedAnalyseBreachOrderDeterministic(t *testing.T) {
+	assert := assert.New(t)
+
+	currLogOut := logrus.StandardLogger().Out
+	defer logrus.SetOutput(currLogOut)
+	logrus.SetOutput(io.Discard)
+
+	inputData := map[string]string{
+		"wordpress": "25",
+		"drupal":    "15",
+		"laravel":   "30",
+		"symfony":   "20",
+	}
+
+	var firstOrder []string
+	for i := 0; i < 25; i++ {
+		input := testdata.New("testFacter", data.FormatMapString, inputData)
+		input.Collect()
+
+		analyser := NewDetected("testDetected")
+		analyser.InputName = "app-type"
+		analyser.SetInput(input)
+		analyser.Analyse()
+
+		order := make([]string, 0, len(analyser.Result.Breaches))
+		for _, b := range analyser.Result.Breaches {
+			kv, ok := b.(*breach.KeyValueBreach)
+			assert.True(ok)
+			order = append(order, kv.Key)
+		}
+
+		if firstOrder == nil {
+			firstOrder = order
+			continue
+		}
+		assert.Equal(firstOrder, order, "breach order changed between runs")
+	}
+
+	assert.Equal([]string{"drupal", "laravel", "symfony", "wordpress"}, firstOrder)
+}
+
+// TestDetectedAnalyseUnsupportedFormat ensures an unexpected input format
+// does not panic and produces no breach, matching the defensive pattern
+// used by other analysers (e.g. Drift, NotEmpty) for formats they cannot
+// interpret.
+func TestDetectedAnalyseUnsupportedFormat(t *testing.T) {
+	assert := assert.New(t)
+
+	currLogOut := logrus.StandardLogger().Out
+	defer logrus.SetOutput(currLogOut)
+	logrus.SetOutput(io.Discard)
+
+	analyser := NewDetected("testDetected")
+	input := testdata.New("testFacter", data.FormatString, "not-a-map")
+	input.Collect()
+	analyser.SetInput(input)
+
+	assert.NotPanics(func() {
+		analyser.Analyse()
+	})
+	assert.Empty(analyser.Result.Breaches)
+}

--- a/pkg/fact/file/fingerprint.go
+++ b/pkg/fact/file/fingerprint.go
@@ -1,0 +1,281 @@
+package file
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/salsadigitalauorg/shipshape/pkg/config"
+	"github.com/salsadigitalauorg/shipshape/pkg/data"
+	"github.com/salsadigitalauorg/shipshape/pkg/fact"
+	"github.com/salsadigitalauorg/shipshape/pkg/plugin"
+	"github.com/salsadigitalauorg/shipshape/pkg/utils"
+)
+
+var (
+	// ErrNoFrameworks is returned when the plugin is configured without any
+	// 'frameworks' signatures to score against.
+	ErrNoFrameworks = errors.New(
+		"file:fingerprint requires at least one entry under 'frameworks'")
+	// ErrNoPath is returned when the plugin is configured without a 'path'
+	// to scan.
+	ErrNoPath = errors.New("file:fingerprint requires a 'path'")
+)
+
+// FingerprintWeights configures the score contribution of each signal
+// type. Markers and Dirs default to 5, matching 0.x's
+// sca:application_type (pkg/checks/sca/apptypecheck.go), which added +5
+// per marker match and +5 per matching directory. The dependencies signal
+// (weight, default 10) is added in a later slice.
+type FingerprintWeights struct {
+	Markers int `yaml:"markers"`
+	Dirs    int `yaml:"dirs"`
+}
+
+// FrameworkSignature is the operator-supplied evidence associated with a
+// single label. No framework knowledge is baked into the binary - every
+// signature (which markers/dirs identify which label) is entirely
+// operator config; the binary only supplies the generic matching
+// mechanism.
+type FrameworkSignature struct {
+	// Markers are exact-line strings searched for within each discovered
+	// entrypoint file. A marker scores once per (marker, entrypoint file)
+	// pair in which it is found, so N markers found across M entrypoint
+	// files score weights.markers * N * M - this deliberately reproduces
+	// 0.x's per-match accumulation (apptypecheck.go:79-96) rather than
+	// capping at one match per marker, so a ported 0.x config scores
+	// identically.
+	Markers []string `yaml:"markers"`
+
+	// Dirs are directory names searched for anywhere in the tree under
+	// Path. Each matching directory occurrence scores independently (so a
+	// framework with both "web" and "docroot" present, or the same name
+	// nested twice, scores twice), again reproducing 0.x's per-match
+	// accumulation.
+	Dirs []string `yaml:"dirs"`
+}
+
+// Fingerprint scores each configured framework signature against the
+// filesystem under Path and emits the labels whose accumulated score
+// exceeds Threshold. It reproduces the weighted-likelihood model of 0.x's
+// sca:application_type check (pkg/checks/sca/apptypecheck.go) rather than
+// simple presence matching, so ported 0.x configs (markers/dirs/weights/
+// threshold) score identically.
+//
+// Emits FormatMapString: label -> accumulated score (as a string),
+// containing only labels whose score is strictly greater than Threshold.
+// Sub-threshold scores are never included in the output - not even as a
+// zero or low value - they are logged at debug level only. This is a
+// deliberate difference from a raw "all scores" dump: the fact answers
+// "is a disallowed framework present?", pairing naturally with the
+// detected analyser (any output is a breach), not "what is this app's
+// type?", which would need every label's score to compare against an
+// expected one.
+//
+// Threshold default note: 0.x's check code defaults Threshold to 30
+// (apptypecheck.go:65-67) but its own reference doc claims 1
+// (docs/src/reference/checks/sca-application-type.md:16). This fact
+// follows the code (30), which is what 0.x actually executes; the doc
+// value was never true at runtime.
+//
+// Threshold/weights zero-value caveat: because YAML unmarshals an absent
+// field to Go's zero value, Threshold: 0 and an unset Weights field are
+// indistinguishable from "use the default". An operator who genuinely
+// wants "any single match breaches" cannot express Threshold: 0 - they
+// must use a threshold of -1 or lower. This is inherited from 0.x, which
+// has the identical limitation, and is not fixed here for config
+// compatibility with ported 0.x definitions.
+//
+// Entrypoint matching note: entrypoint files are matched by exact
+// basename against Entrypoints, not by 0.x's substring Glob helper
+// (utils.Glob does strings.Contains(name, match)), which would also
+// match e.g. "myindex.phpx" against "index.php". This is a deliberate
+// divergence from 0.x: exact-basename matching is what an operator
+// writing `entrypoints: [index.php]` expects, and the substring form
+// would inflate marker scores via unintended file matches. A config
+// relying on 0.x's looser matching must list the extra basenames
+// explicitly.
+//
+// Data handling note: breach/fact output never includes the matched
+// marker text or file path, only the label and its score, so a
+// carelessly-written marker cannot echo file content (potentially
+// containing secrets) into an audit report.
+type Fingerprint struct {
+	fact.BaseFact `yaml:",inline"`
+
+	// Plugin fields.
+	Path        string                        `yaml:"path"`
+	Threshold   int                           `yaml:"threshold"`
+	Entrypoints []string                      `yaml:"entrypoints"`
+	Weights     FingerprintWeights            `yaml:"weights"`
+	Frameworks  map[string]FrameworkSignature `yaml:"frameworks"`
+}
+
+func init() {
+	fact.Manager().RegisterFactory("file:fingerprint", func(n string) fact.Facter {
+		return NewFingerprint(n)
+	})
+}
+
+func NewFingerprint(id string) *Fingerprint {
+	return &Fingerprint{
+		BaseFact: fact.BaseFact{
+			BasePlugin: plugin.BasePlugin{
+				Id: id,
+			},
+		},
+	}
+}
+
+func (p *Fingerprint) GetName() string {
+	return "file:fingerprint"
+}
+
+func (p *Fingerprint) Collect() {
+	contextLogger := log.WithFields(log.Fields{
+		"fact-plugin": p.GetName(),
+		"fact":        p.GetId(),
+	})
+
+	if len(p.Frameworks) == 0 {
+		contextLogger.Error("no frameworks configured")
+		p.AddErrors(ErrNoFrameworks)
+		return
+	}
+
+	if p.Path == "" {
+		contextLogger.Error("no path configured")
+		p.AddErrors(ErrNoPath)
+		return
+	}
+
+	threshold := p.Threshold
+	if threshold == 0 {
+		threshold = 30
+	}
+
+	weights := p.Weights
+	if weights.Markers == 0 {
+		weights.Markers = 5
+	}
+	if weights.Dirs == 0 {
+		weights.Dirs = 5
+	}
+
+	entrypoints := p.Entrypoints
+	if len(entrypoints) == 0 {
+		entrypoints = []string{"index.php"}
+	}
+
+	fullPath := filepath.Join(config.ProjectDir, p.Path)
+
+	contextLogger.WithFields(log.Fields{
+		"project-dir": config.ProjectDir,
+		"path":        p.Path,
+		"threshold":   threshold,
+		"weights":     weights,
+	}).Debug("fingerprinting codebase")
+
+	var entrypointFiles []string
+	var dirNames []string
+
+	// filepath.WalkDir does not follow symbolic links, so a symlink under
+	// Path cannot be used to walk outside it.
+	err := filepath.WalkDir(fullPath, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			dirNames = append(dirNames, d.Name())
+			return nil
+		}
+		if utils.StringSliceContains(entrypoints, d.Name()) {
+			entrypointFiles = append(entrypointFiles, path)
+		}
+		return nil
+	})
+	if err != nil {
+		contextLogger.WithError(err).Error("error walking path")
+		p.AddErrors(err)
+		return
+	}
+
+	// Read each entrypoint once up front rather than re-opening it per
+	// (marker, framework) pair. This keeps I/O proportional to the number
+	// of entrypoints instead of entrypoints x markers x frameworks, and -
+	// more importantly - means an unreadable entrypoint is reported once,
+	// as a single collection error, rather than once per marker.
+	//
+	// An unreadable entrypoint is a hard error, not a skipped file: any
+	// marker it might have matched is now invisible, so continuing would
+	// under-score the framework and report a framework that is present as
+	// absent. Silently under-reporting is the worst failure mode for an
+	// audit tool, so this aborts the run (fact errors are fatal in
+	// pkg/shipshape/shipshape.go) exactly as an unreadable Path does.
+	entrypointLines := make(map[string][]string, len(entrypointFiles))
+	for _, ep := range entrypointFiles {
+		content, err := os.ReadFile(ep)
+		if err != nil {
+			contextLogger.WithError(err).WithField("entrypoint", ep).
+				Error("error reading entrypoint")
+			p.AddErrors(err)
+			return
+		}
+		// Markers are matched against whole lines. Trailing carriage
+		// returns are trimmed so a marker matches identically whether the
+		// file uses LF or CRLF line endings - bufio.Scanner (used by the
+		// 0.x utils.FileContains this replaces) strips them, and a config
+		// should not silently stop matching because a file was committed
+		// with Windows line endings.
+		lines := strings.Split(string(content), "\n")
+		for i, line := range lines {
+			lines[i] = strings.TrimSuffix(line, "\r")
+		}
+		entrypointLines[ep] = lines
+	}
+
+	frameworkNames := make([]string, 0, len(p.Frameworks))
+	for name := range p.Frameworks {
+		frameworkNames = append(frameworkNames, name)
+	}
+	sort.Strings(frameworkNames)
+
+	result := map[string]string{}
+	for _, name := range frameworkNames {
+		sig := p.Frameworks[name]
+		score := 0
+
+		for _, marker := range sig.Markers {
+			for _, ep := range entrypointFiles {
+				if utils.StringSliceContains(entrypointLines[ep], marker) {
+					score += weights.Markers
+				}
+			}
+		}
+
+		for _, dirName := range dirNames {
+			if utils.StringSliceContains(sig.Dirs, dirName) {
+				score += weights.Dirs
+			}
+		}
+
+		contextLogger.WithFields(log.Fields{
+			"framework": name,
+			"score":     score,
+			"threshold": threshold,
+		}).Debug("computed fingerprint score")
+
+		if score > threshold {
+			result[name] = strconv.Itoa(score)
+		}
+	}
+
+	p.Format = data.FormatMapString
+	p.SetData(result)
+}

--- a/pkg/fact/file/fingerprint.go
+++ b/pkg/fact/file/fingerprint.go
@@ -1,7 +1,9 @@
 package file
 
 import (
+	stdjson "encoding/json"
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -10,6 +12,7 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/theory/jsonpath"
 
 	"github.com/salsadigitalauorg/shipshape/pkg/config"
 	"github.com/salsadigitalauorg/shipshape/pkg/data"
@@ -26,16 +29,54 @@ var (
 	// ErrNoPath is returned when the plugin is configured without a 'path'
 	// to scan.
 	ErrNoPath = errors.New("file:fingerprint requires a 'path'")
+	// ErrManifestNotFound is returned when at least one configured
+	// framework signature uses 'dependencies' but the configured (or
+	// default) manifest file does not exist under Path. A missing
+	// manifest is reported explicitly rather than silently scoring the
+	// dependencies signal as zero, so an operator who expects
+	// composer.json to be present (e.g. it was misconfigured, or Path is
+	// wrong) is told why the framework was not detected instead of
+	// getting a quiet under-score.
+	ErrManifestNotFound = errors.New("file:fingerprint manifest not found")
+	// ErrManifestUnreadable is returned when the manifest exists but
+	// cannot be read (e.g. permissions). Unlike a missing manifest, this
+	// is treated as a hard collection error: the file is present and
+	// expected to be readable, so silently skipping it risks
+	// under-scoring a framework that is actually present.
+	ErrManifestUnreadable = errors.New("file:fingerprint manifest unreadable")
+	// ErrManifestInvalidJSON is returned when the manifest exists and is
+	// readable but cannot be parsed as JSON.
+	ErrManifestInvalidJSON = errors.New("file:fingerprint manifest is not valid JSON")
+	// ErrInvalidDependencyPath is returned when a configured
+	// 'dependency-paths' entry is not a valid RFC 9535 JSONPath
+	// expression. jsonpath.Parse is used rather than MustParse so a
+	// malformed operator-supplied expression surfaces as a clear error
+	// instead of a panic.
+	ErrInvalidDependencyPath = errors.New("file:fingerprint invalid dependency-paths expression")
 )
+
+// defaultDependencyPaths cover composer's require/require-dev (fixing a
+// 0.x gap: utils.HasComposerDependency only ever read 'require') and
+// package.json's dependencies/devDependencies, so a single default
+// configuration works across the PHP and Node ecosystems without
+// operator-supplied 'dependency-paths'.
+var defaultDependencyPaths = []string{
+	"$.require",
+	"$['require-dev']",
+	"$.dependencies",
+	"$.devDependencies",
+}
 
 // FingerprintWeights configures the score contribution of each signal
 // type. Markers and Dirs default to 5, matching 0.x's
 // sca:application_type (pkg/checks/sca/apptypecheck.go), which added +5
-// per marker match and +5 per matching directory. The dependencies signal
-// (weight, default 10) is added in a later slice.
+// per marker match and +5 per matching directory. Dependencies defaults
+// to 10, matching 0.x's single +10 award for a matched dependency
+// (apptypecheck.go:98-102).
 type FingerprintWeights struct {
-	Markers int `yaml:"markers"`
-	Dirs    int `yaml:"dirs"`
+	Markers      int `yaml:"markers"`
+	Dirs         int `yaml:"dirs"`
+	Dependencies int `yaml:"dependencies"`
 }
 
 // FrameworkSignature is the operator-supplied evidence associated with a
@@ -59,6 +100,16 @@ type FrameworkSignature struct {
 	// nested twice, scores twice), again reproducing 0.x's per-match
 	// accumulation.
 	Dirs []string `yaml:"dirs"`
+
+	// Dependencies are manifest package names (e.g.
+	// "drupal/core-recommended") searched for among the values matched by
+	// Fingerprint.DependencyPaths in the manifest. Unlike Markers and
+	// Dirs, a matched dependency scores once only, no matter how many
+	// configured dependency names match or how many dependency-paths
+	// expressions surface them - this reproduces 0.x's single bool-driven
+	// +10 award (apptypecheck.go:98-102), the one signal that does not
+	// accumulate per-hit.
+	Dependencies []string `yaml:"dependencies"`
 }
 
 // Fingerprint scores each configured framework signature against the
@@ -105,7 +156,17 @@ type FrameworkSignature struct {
 // Data handling note: breach/fact output never includes the matched
 // marker text or file path, only the label and its score, so a
 // carelessly-written marker cannot echo file content (potentially
-// containing secrets) into an audit report.
+// containing secrets) into an audit report. The same applies to the
+// dependencies signal: only the label and score are emitted, never the
+// matched manifest key or version string.
+//
+// Dependency-paths safety note: DependencyPaths expressions are parsed
+// with jsonpath.Parse (never MustParse), so a malformed operator-supplied
+// expression is a collection error, not a panic. RFC 9535 JSONPath has
+// no unbounded-recursion construct comparable to e.g. a regex catastrophic
+// backtracking - evaluation cost is bounded by the size of the parsed
+// manifest document, which this fact already reads fully into memory once
+// per Collect call.
 type Fingerprint struct {
 	fact.BaseFact `yaml:",inline"`
 
@@ -115,6 +176,27 @@ type Fingerprint struct {
 	Entrypoints []string                      `yaml:"entrypoints"`
 	Weights     FingerprintWeights            `yaml:"weights"`
 	Frameworks  map[string]FrameworkSignature `yaml:"frameworks"`
+
+	// Manifest is the filename (relative to Path) read for the
+	// dependencies signal. Defaults to "composer.json". Only a single
+	// manifest file is supported per fact instance; a project needing
+	// both composer.json and package.json signatures configures two
+	// file:fingerprint facts.
+	Manifest string `yaml:"manifest"`
+
+	// DependencyPaths are RFC 9535 JSONPath expressions evaluated against
+	// the parsed Manifest; every object matched is treated as a map of
+	// dependency name to version constraint, and its keys are the
+	// candidate dependency names checked against each framework's
+	// Dependencies. Defaults to defaultDependencyPaths, covering
+	// composer's require/require-dev and package.json's
+	// dependencies/devDependencies.
+	DependencyPaths []string `yaml:"dependency-paths"`
+
+	// dependencyPaths holds DependencyPaths (or the defaults) parsed once
+	// and cached, so a multi-framework Collect does not re-parse the same
+	// expressions per framework.
+	dependencyPaths []*jsonpath.Path
 }
 
 func init() {
@@ -167,6 +249,9 @@ func (p *Fingerprint) Collect() {
 	if weights.Dirs == 0 {
 		weights.Dirs = 5
 	}
+	if weights.Dependencies == 0 {
+		weights.Dependencies = 10
+	}
 
 	entrypoints := p.Entrypoints
 	if len(entrypoints) == 0 {
@@ -181,6 +266,35 @@ func (p *Fingerprint) Collect() {
 		"threshold":   threshold,
 		"weights":     weights,
 	}).Debug("fingerprinting codebase")
+
+	// The dependencies signal (manifest read + jsonpath evaluation) is
+	// only attempted when at least one configured framework actually
+	// uses it - a config that never sets 'dependencies' should not fail
+	// just because Path happens not to contain a composer.json.
+	needsDependencies := false
+	for _, sig := range p.Frameworks {
+		if len(sig.Dependencies) > 0 {
+			needsDependencies = true
+			break
+		}
+	}
+
+	var dependencyNames map[string]struct{}
+	if needsDependencies {
+		if err := p.validateDependencyPaths(); err != nil {
+			contextLogger.WithError(err).Error("invalid dependency-paths expression")
+			p.AddErrors(sentinelError(err))
+			return
+		}
+
+		names, err := p.readManifestDependencyNames(fullPath)
+		if err != nil {
+			contextLogger.WithError(err).Error("error reading manifest for dependencies signal")
+			p.AddErrors(sentinelError(err))
+			return
+		}
+		dependencyNames = names
+	}
 
 	var entrypointFiles []string
 	var dirNames []string
@@ -265,6 +379,18 @@ func (p *Fingerprint) Collect() {
 			}
 		}
 
+		// Dependencies score once only, no matter how many configured
+		// names match or how many dependency-paths expressions surface
+		// them - reproducing 0.x's single bool-driven award
+		// (apptypecheck.go:98-102), the one signal that does not
+		// accumulate per-hit.
+		for _, dep := range sig.Dependencies {
+			if _, ok := dependencyNames[dep]; ok {
+				score += weights.Dependencies
+				break
+			}
+		}
+
 		contextLogger.WithFields(log.Fields{
 			"framework": name,
 			"score":     score,
@@ -278,4 +404,104 @@ func (p *Fingerprint) Collect() {
 
 	p.Format = data.FormatMapString
 	p.SetData(result)
+}
+
+// validateDependencyPaths parses DependencyPaths (or
+// defaultDependencyPaths, if unset) into p.dependencyPaths, returning an
+// error wrapping ErrInvalidDependencyPath if any expression is not a
+// valid RFC 9535 JSONPath query. jsonpath.Parse is used rather than
+// MustParse so a malformed operator-supplied expression surfaces as a
+// clear error instead of a panic. Safe to call more than once: parsing is
+// skipped once p.dependencyPaths is populated.
+func (p *Fingerprint) validateDependencyPaths() error {
+	if p.dependencyPaths != nil {
+		return nil
+	}
+
+	exprs := p.DependencyPaths
+	if len(exprs) == 0 {
+		exprs = defaultDependencyPaths
+	}
+
+	parsed := make([]*jsonpath.Path, 0, len(exprs))
+	for _, expr := range exprs {
+		path, err := jsonpath.Parse(expr)
+		if err != nil {
+			return fmt.Errorf("%w %q: %s", ErrInvalidDependencyPath, expr, err)
+		}
+		parsed = append(parsed, path)
+	}
+
+	p.dependencyPaths = parsed
+	return nil
+}
+
+// readManifestDependencyNames reads the configured (or default) Manifest
+// file under fullPath, evaluates every p.dependencyPaths expression
+// against it, and returns the union of keys from every matched object -
+// the set of candidate dependency names checked against each framework's
+// Dependencies.
+//
+// A missing manifest, an unreadable manifest, and a manifest that is not
+// valid JSON each return a distinct sentinel error (ErrManifestNotFound,
+// ErrManifestUnreadable, ErrManifestInvalidJSON respectively) rather than
+// a panic or a silent zero score.
+func (p *Fingerprint) readManifestDependencyNames(fullPath string) (map[string]struct{}, error) {
+	manifestName := p.Manifest
+	if manifestName == "" {
+		manifestName = "composer.json"
+	}
+
+	manifestPath := filepath.Join(fullPath, manifestName)
+
+	if _, err := os.Stat(manifestPath); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, fmt.Errorf("%w: %s", ErrManifestNotFound, manifestPath)
+		}
+		return nil, fmt.Errorf("%w: %s", ErrManifestUnreadable, err)
+	}
+
+	content, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %s", ErrManifestUnreadable, err)
+	}
+
+	var doc any
+	if err := stdjson.Unmarshal(content, &doc); err != nil {
+		return nil, fmt.Errorf("%w: %s", ErrManifestInvalidJSON, err)
+	}
+
+	names := map[string]struct{}{}
+	for _, path := range p.dependencyPaths {
+		nodes := path.Select(doc)
+		for node := range nodes.All() {
+			obj, ok := node.(map[string]any)
+			if !ok {
+				continue
+			}
+			for name := range obj {
+				names[name] = struct{}{}
+			}
+		}
+	}
+
+	return names, nil
+}
+
+// sentinelError maps a detailed internal error back to a stable,
+// comparable sentinel so downstream reporting is deterministic. Errors
+// that do not match a known sentinel are returned unchanged. Mirrors
+// json/key.go's sentinel helper.
+func sentinelError(err error) error {
+	for _, s := range []error{
+		ErrManifestNotFound,
+		ErrManifestUnreadable,
+		ErrManifestInvalidJSON,
+		ErrInvalidDependencyPath,
+	} {
+		if errors.Is(err, s) {
+			return s
+		}
+	}
+	return err
 }

--- a/pkg/fact/file/fingerprint_test.go
+++ b/pkg/fact/file/fingerprint_test.go
@@ -242,6 +242,189 @@ func TestFileFingerprintCollect(t *testing.T) {
 			},
 			ExpectedErrors: []error{},
 		},
+		{
+			Name: "testDependenciesOnlyRequire",
+			FactFn: func() fact.Facter {
+				f := NewFingerprint("testDependenciesOnlyRequire")
+				f.Path = "testdata/fingerprint/dependencies-only"
+				f.Threshold = 1
+				f.Frameworks = map[string]FrameworkSignature{
+					"drupal": {
+						Dependencies: []string{"drupal/core-recommended"},
+					},
+				}
+				return f
+			},
+			ExpectedFormat: data.FormatMapString,
+			ExpectedData: map[string]string{
+				"drupal": "10",
+			},
+			ExpectedErrors: []error{},
+		},
+		{
+			Name: "testDependenciesRequireDevFixesZeroXGap",
+			FactFn: func() fact.Facter {
+				f := NewFingerprint("testDependenciesRequireDevFixesZeroXGap")
+				f.Path = "testdata/fingerprint/dependencies-require-dev-only"
+				f.Threshold = 1
+				f.Frameworks = map[string]FrameworkSignature{
+					"drupal": {
+						Dependencies: []string{"drupal/core-dev"},
+					},
+				}
+				return f
+			},
+			ExpectedFormat: data.FormatMapString,
+			ExpectedData: map[string]string{
+				"drupal": "10",
+			},
+			ExpectedErrors: []error{},
+		},
+		{
+			Name: "testDependencyMatchDoesNotAccumulatePerHit",
+			FactFn: func() fact.Facter {
+				f := NewFingerprint("testDependencyMatchDoesNotAccumulatePerHit")
+				f.Path = "testdata/fingerprint/dependencies-only"
+				f.Threshold = 1
+				f.Frameworks = map[string]FrameworkSignature{
+					"drupal": {
+						// Both configured dependency names match (php and
+						// drupal/core-recommended are both present in the
+						// fixture's require block), but the score must
+						// still be a single weights.dependencies award,
+						// not two.
+						Dependencies: []string{"php", "drupal/core-recommended"},
+					},
+				}
+				return f
+			},
+			ExpectedFormat: data.FormatMapString,
+			ExpectedData: map[string]string{
+				"drupal": "10",
+			},
+			ExpectedErrors: []error{},
+		},
+		{
+			Name: "testAllThreeSignalsCombined",
+			FactFn: func() fact.Facter {
+				f := NewFingerprint("testAllThreeSignalsCombined")
+				f.Path = "testdata/fingerprint/all-signals"
+				f.Threshold = 1
+				f.Entrypoints = []string{"index.php"}
+				f.Frameworks = map[string]FrameworkSignature{
+					"drupal": {
+						Markers:      []string{"use Drupal\\Core\\DrupalKernel;"},
+						Dirs:         []string{"web", "docroot"},
+						Dependencies: []string{"drupal/core-recommended"},
+					},
+				}
+				return f
+			},
+			ExpectedFormat: data.FormatMapString,
+			ExpectedData: map[string]string{
+				// markers: 1*1*5 = 5; dirs: 1*5 = 5; dependencies: 10;
+				// total 20.
+				"drupal": "20",
+			},
+			ExpectedErrors: []error{},
+		},
+		{
+			Name: "testMissingManifestIsCollectionError",
+			FactFn: func() fact.Facter {
+				f := NewFingerprint("testMissingManifestIsCollectionError")
+				f.Path = "testdata/fingerprint/markers-only"
+				f.Threshold = 1
+				f.Frameworks = map[string]FrameworkSignature{
+					"drupal": {
+						Dependencies: []string{"drupal/core-recommended"},
+					},
+				}
+				return f
+			},
+			ExpectedFormat: "",
+			ExpectedErrors: []error{ErrManifestNotFound},
+		},
+		{
+			Name: "testMalformedManifestIsCollectionError",
+			FactFn: func() fact.Facter {
+				f := NewFingerprint("testMalformedManifestIsCollectionError")
+				f.Path = "testdata/fingerprint/malformed-manifest"
+				f.Threshold = 1
+				f.Frameworks = map[string]FrameworkSignature{
+					"drupal": {
+						Dependencies: []string{"drupal/core-recommended"},
+					},
+				}
+				return f
+			},
+			ExpectedFormat: "",
+			ExpectedErrors: []error{ErrManifestInvalidJSON},
+		},
+		{
+			Name: "testInvalidDependencyPathExpression",
+			FactFn: func() fact.Facter {
+				f := NewFingerprint("testInvalidDependencyPathExpression")
+				f.Path = "testdata/fingerprint/dependencies-only"
+				f.Threshold = 1
+				f.DependencyPaths = []string{"$.require[?(("}
+				f.Frameworks = map[string]FrameworkSignature{
+					"drupal": {
+						Dependencies: []string{"drupal/core-recommended"},
+					},
+				}
+				return f
+			},
+			ExpectedFormat: "",
+			ExpectedErrors: []error{ErrInvalidDependencyPath},
+		},
+		{
+			Name: "testCustomManifestAndDependencyPathsForPackageJson",
+			FactFn: func() fact.Facter {
+				f := NewFingerprint("testCustomManifestAndDependencyPathsForPackageJson")
+				f.Path = "testdata/fingerprint/package-json-deps"
+				f.Threshold = 1
+				f.Manifest = "package.json"
+				f.DependencyPaths = []string{"$.dependencies", "$.devDependencies"}
+				f.Frameworks = map[string]FrameworkSignature{
+					"react-app": {
+						Dependencies: []string{"react"},
+					},
+					"jest-tested": {
+						Dependencies: []string{"jest"},
+					},
+				}
+				return f
+			},
+			ExpectedFormat: data.FormatMapString,
+			ExpectedData: map[string]string{
+				"react-app":   "10",
+				"jest-tested": "10",
+			},
+			ExpectedErrors: []error{},
+		},
+		{
+			Name: "testDependenciesSkippedWhenNoFrameworkUsesThem",
+			FactFn: func() fact.Facter {
+				// No composer.json under this path - if the dependencies
+				// signal were unconditionally evaluated, this would fail
+				// with ErrManifestNotFound even though no framework
+				// configures 'dependencies'.
+				f := NewFingerprint("testDependenciesSkippedWhenNoFrameworkUsesThem")
+				f.Path = "testdata/fingerprint/markers-only"
+				f.Threshold = 1
+				f.Frameworks = map[string]FrameworkSignature{
+					"drupal": {
+						Markers: []string{"use Drupal\\Core\\DrupalKernel;"},
+					},
+				}
+				return f
+			},
+			ExpectedFormat: data.FormatMapString,
+			ExpectedData: map[string]string{
+				"drupal": "5",
+			},
+			ExpectedErrors: []error{},
+		},
 	}
 
 	config.ProjectDir = ""
@@ -389,4 +572,51 @@ func TestFileFingerprintMarkerMatchingIgnoresCarriageReturns(t *testing.T) {
 			assert.Equal(map[string]string{"drupal": "5"}, f.GetData())
 		})
 	}
+}
+
+// TestFileFingerprintUnreadableManifest asserts that a manifest which
+// exists but cannot be read is reported as ErrManifestUnreadable, not
+// silently scored as zero and not conflated with ErrManifestNotFound -
+// the file is present and expected to be readable, so this is a hard
+// collection error distinct from "no manifest configured for this
+// ecosystem".
+//
+// The fixture is created at runtime with mode 0000 rather than committed,
+// since a permission-stripped file in testdata would not survive checkout
+// reliably.
+func TestFileFingerprintUnreadableManifest(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: mode 0000 is still readable, cannot test unreadable file")
+	}
+
+	assert := assert.New(t)
+
+	dir := t.TempDir()
+	manifest := filepath.Join(dir, "composer.json")
+	if err := os.WriteFile(manifest, []byte(`{"require":{"drupal/core-recommended":"^10"}}`), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	if err := os.Chmod(manifest, 0o000); err != nil {
+		t.Fatalf("chmod fixture: %v", err)
+	}
+	t.Cleanup(func() {
+		// Restore permissions so t.TempDir cleanup can remove the file.
+		_ = os.Chmod(manifest, 0o644)
+	})
+
+	config.ProjectDir = ""
+
+	f := NewFingerprint("testUnreadableManifest")
+	f.Path = dir
+	f.Threshold = 1
+	f.Frameworks = map[string]FrameworkSignature{
+		"drupal": {Dependencies: []string{"drupal/core-recommended"}},
+	}
+
+	f.Collect()
+
+	if assert.NotEmpty(f.GetErrors(), "unreadable manifest must raise a collection error") {
+		assert.ErrorIs(f.GetErrors()[0], ErrManifestUnreadable)
+	}
+	assert.Empty(f.GetData(), "no data should be emitted when collection fails")
 }

--- a/pkg/fact/file/fingerprint_test.go
+++ b/pkg/fact/file/fingerprint_test.go
@@ -1,0 +1,392 @@
+package file_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/salsadigitalauorg/shipshape/pkg/config"
+	"github.com/salsadigitalauorg/shipshape/pkg/data"
+	"github.com/salsadigitalauorg/shipshape/pkg/fact"
+	. "github.com/salsadigitalauorg/shipshape/pkg/fact/file"
+	"github.com/salsadigitalauorg/shipshape/pkg/internal"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFileFingerprintInit(t *testing.T) {
+	assert := assert.New(t)
+
+	factPlugin := fact.Manager().GetFactories()["file:fingerprint"]("testFileFingerprint")
+	assert.NotNil(factPlugin)
+	fingerprintFacter, ok := factPlugin.(*Fingerprint)
+	assert.True(ok)
+	assert.Equal("testFileFingerprint", fingerprintFacter.GetId())
+}
+
+func TestFileFingerprintPluginName(t *testing.T) {
+	fingerprint := NewFingerprint("testFileFingerprint")
+	assert.Equal(t, "file:fingerprint", fingerprint.GetName())
+}
+
+func TestFileFingerprintCollect(t *testing.T) {
+	tests := []internal.FactCollectTest{
+		{
+			Name: "testNoFrameworks",
+			FactFn: func() fact.Facter {
+				f := NewFingerprint("testNoFrameworks")
+				f.Path = "testdata/fingerprint/markers-only"
+				return f
+			},
+			ExpectedFormat: "",
+			ExpectedErrors: []error{ErrNoFrameworks},
+		},
+		{
+			Name: "testNoPath",
+			FactFn: func() fact.Facter {
+				f := NewFingerprint("testNoPath")
+				f.Frameworks = map[string]FrameworkSignature{
+					"drupal": {Markers: []string{"use Drupal\\Core\\DrupalKernel;"}},
+				}
+				return f
+			},
+			ExpectedFormat: "",
+			ExpectedErrors: []error{ErrNoPath},
+		},
+		{
+			Name: "testMarkersOnlyAboveThreshold",
+			FactFn: func() fact.Facter {
+				f := NewFingerprint("testMarkersOnlyAboveThreshold")
+				f.Path = "testdata/fingerprint/markers-only"
+				f.Threshold = 1
+				f.Frameworks = map[string]FrameworkSignature{
+					"drupal": {
+						Markers: []string{"use Drupal\\Core\\DrupalKernel;"},
+					},
+				}
+				return f
+			},
+			ExpectedFormat: data.FormatMapString,
+			ExpectedData: map[string]string{
+				"drupal": "5",
+			},
+			ExpectedErrors: []error{},
+		},
+		{
+			Name: "testMarkersOnlyBelowThreshold",
+			FactFn: func() fact.Facter {
+				f := NewFingerprint("testMarkersOnlyBelowThreshold")
+				f.Path = "testdata/fingerprint/markers-only"
+				f.Threshold = 10
+				f.Frameworks = map[string]FrameworkSignature{
+					"drupal": {
+						Markers: []string{"use Drupal\\Core\\DrupalKernel;"},
+					},
+				}
+				return f
+			},
+			ExpectedFormat: data.FormatMapString,
+			ExpectedData:   map[string]string{},
+			ExpectedErrors: []error{},
+		},
+		{
+			Name: "testDirsOnly",
+			FactFn: func() fact.Facter {
+				f := NewFingerprint("testDirsOnly")
+				f.Path = "testdata/fingerprint/dirs-only"
+				f.Threshold = 1
+				f.Frameworks = map[string]FrameworkSignature{
+					"drupal": {
+						Dirs: []string{"web", "docroot"},
+					},
+				}
+				return f
+			},
+			ExpectedFormat: data.FormatMapString,
+			ExpectedData: map[string]string{
+				"drupal": "5",
+			},
+			ExpectedErrors: []error{},
+		},
+		{
+			Name: "testMarkersAndDirsAccumulate",
+			FactFn: func() fact.Facter {
+				f := NewFingerprint("testMarkersAndDirsAccumulate")
+				f.Path = "testdata/fingerprint/combined"
+				f.Threshold = 1
+				f.Entrypoints = []string{"index.php"}
+				f.Frameworks = map[string]FrameworkSignature{
+					"drupal": {
+						Markers: []string{"use Drupal\\Core\\DrupalKernel;"},
+						Dirs:    []string{"web", "docroot"},
+					},
+				}
+				return f
+			},
+			ExpectedFormat: data.FormatMapString,
+			ExpectedData: map[string]string{
+				// markers: 1 marker * 1 entrypoint * weight 5 = 5
+				// dirs: 1 matching dir * weight 5 = 5
+				"drupal": "10",
+			},
+			ExpectedErrors: []error{},
+		},
+		{
+			Name: "testThresholdBoundaryExactlyAtThresholdDoesNotBreach",
+			FactFn: func() fact.Facter {
+				f := NewFingerprint("testThresholdBoundaryExactlyAtThresholdDoesNotBreach")
+				f.Path = "testdata/fingerprint/combined"
+				f.Threshold = 10
+				f.Entrypoints = []string{"index.php"}
+				f.Frameworks = map[string]FrameworkSignature{
+					"drupal": {
+						Markers: []string{"use Drupal\\Core\\DrupalKernel;"},
+						Dirs:    []string{"web", "docroot"},
+					},
+				}
+				return f
+			},
+			ExpectedFormat: data.FormatMapString,
+			ExpectedData:   map[string]string{},
+			ExpectedErrors: []error{},
+		},
+		{
+			Name: "testThresholdBoundaryJustOverThresholdBreaches",
+			FactFn: func() fact.Facter {
+				f := NewFingerprint("testThresholdBoundaryJustOverThresholdBreaches")
+				f.Path = "testdata/fingerprint/combined"
+				f.Threshold = 9
+				f.Entrypoints = []string{"index.php"}
+				f.Frameworks = map[string]FrameworkSignature{
+					"drupal": {
+						Markers: []string{"use Drupal\\Core\\DrupalKernel;"},
+						Dirs:    []string{"web", "docroot"},
+					},
+				}
+				return f
+			},
+			ExpectedFormat: data.FormatMapString,
+			ExpectedData: map[string]string{
+				"drupal": "10",
+			},
+			ExpectedErrors: []error{},
+		},
+		{
+			Name: "testCustomWeights",
+			FactFn: func() fact.Facter {
+				f := NewFingerprint("testCustomWeights")
+				f.Path = "testdata/fingerprint/combined"
+				f.Threshold = 1
+				f.Entrypoints = []string{"index.php"}
+				f.Weights = FingerprintWeights{Markers: 100, Dirs: 1}
+				f.Frameworks = map[string]FrameworkSignature{
+					"drupal": {
+						Markers: []string{"use Drupal\\Core\\DrupalKernel;"},
+						Dirs:    []string{"web", "docroot"},
+					},
+				}
+				return f
+			},
+			ExpectedFormat: data.FormatMapString,
+			ExpectedData: map[string]string{
+				// markers: 1 * 1 * 100 = 100; dirs: 1 * 1 = 1; total 101
+				"drupal": "101",
+			},
+			ExpectedErrors: []error{},
+		},
+		{
+			Name: "testMultiFramework",
+			FactFn: func() fact.Facter {
+				f := NewFingerprint("testMultiFramework")
+				f.Path = "testdata/fingerprint/multi-framework"
+				f.Threshold = 1
+				f.Entrypoints = []string{"index.php"}
+				f.Frameworks = map[string]FrameworkSignature{
+					"drupal": {
+						Markers: []string{"use Drupal\\Core\\DrupalKernel;"},
+						Dirs:    []string{"web", "docroot"},
+					},
+					"wordpress": {
+						Markers: []string{"require_once __DIR__ . '/wp-load.php';"},
+						Dirs:    []string{"wp-content"},
+					},
+					"symfony": {
+						Markers: []string{"this marker never matches"},
+						Dirs:    []string{"this-dir-never-matches"},
+					},
+				}
+				return f
+			},
+			ExpectedFormat: data.FormatMapString,
+			ExpectedData: map[string]string{
+				"drupal":    "10",
+				"wordpress": "10",
+			},
+			ExpectedErrors: []error{},
+		},
+		{
+			Name: "testMarkerContentNotLeakedIntoOutput",
+			FactFn: func() fact.Facter {
+				f := NewFingerprint("testMarkerContentNotLeakedIntoOutput")
+				f.Path = "testdata/fingerprint/markers-only"
+				f.Threshold = 1
+				f.Frameworks = map[string]FrameworkSignature{
+					"drupal": {
+						Markers: []string{"use Drupal\\Core\\DrupalKernel;"},
+					},
+				}
+				return f
+			},
+			ExpectedFormat: data.FormatMapString,
+			ExpectedData: map[string]string{
+				"drupal": "5",
+			},
+			ExpectedErrors: []error{},
+		},
+	}
+
+	config.ProjectDir = ""
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			internal.TestFactCollect(t, tt)
+		})
+	}
+}
+
+// TestFileFingerprintCollectDeterminism asserts that the emitted map is
+// built identically across repeated runs when multiple frameworks are
+// configured, since Go randomises map iteration and the fact must sort
+// framework names during scoring to avoid flaky behaviour (e.g. around
+// logging or any future short-circuiting).
+func TestFileFingerprintCollectDeterminism(t *testing.T) {
+	assert := assert.New(t)
+	config.ProjectDir = ""
+
+	var first map[string]string
+	for i := 0; i < 25; i++ {
+		f := NewFingerprint("testDeterminism")
+		f.Path = "testdata/fingerprint/multi-framework"
+		f.Threshold = 1
+		f.Entrypoints = []string{"index.php"}
+		f.Frameworks = map[string]FrameworkSignature{
+			"drupal": {
+				Markers: []string{"use Drupal\\Core\\DrupalKernel;"},
+				Dirs:    []string{"web", "docroot"},
+			},
+			"wordpress": {
+				Markers: []string{"require_once __DIR__ . '/wp-load.php';"},
+				Dirs:    []string{"wp-content"},
+			},
+		}
+
+		f.Collect()
+		assert.Empty(f.GetErrors())
+
+		got, ok := f.GetData().(map[string]string)
+		assert.True(ok)
+
+		if first == nil {
+			first = got
+			continue
+		}
+		assert.Equal(first, got, "fingerprint output changed between runs")
+	}
+
+	assert.Equal(map[string]string{
+		"drupal":    "10",
+		"wordpress": "10",
+	}, first)
+}
+
+// TestFileFingerprintUnreadableEntrypoint asserts that an entrypoint which
+// cannot be read is reported as a collection error rather than silently
+// skipped. Skipping it would lose any marker it might have matched and
+// under-score the framework, reporting a framework that is present as
+// absent - the worst failure mode for an audit tool, and a regression this
+// test locks down.
+//
+// The fixture is created at runtime with mode 0000 rather than committed,
+// since a permission-stripped file in testdata would not survive checkout
+// reliably.
+func TestFileFingerprintUnreadableEntrypoint(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: mode 0000 is still readable, cannot test unreadable file")
+	}
+
+	assert := assert.New(t)
+
+	dir := t.TempDir()
+	entrypoint := filepath.Join(dir, "index.php")
+	marker := "use Drupal\\Core\\DrupalKernel;"
+	if err := os.WriteFile(entrypoint, []byte("<?php\n"+marker+"\n"), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	if err := os.Chmod(entrypoint, 0o000); err != nil {
+		t.Fatalf("chmod fixture: %v", err)
+	}
+	t.Cleanup(func() {
+		// Restore permissions so t.TempDir cleanup can remove the file.
+		_ = os.Chmod(entrypoint, 0o644)
+	})
+
+	config.ProjectDir = ""
+
+	f := NewFingerprint("testUnreadableEntrypoint")
+	f.Path = dir
+	// Threshold 4 against a marker weight of 5: were the marker matched,
+	// this would score 5 and be emitted. The assertion below therefore
+	// distinguishes "error raised" from "silently scored zero".
+	f.Threshold = 4
+	f.Entrypoints = []string{"index.php"}
+	f.Frameworks = map[string]FrameworkSignature{
+		"drupal": {Markers: []string{marker}},
+	}
+
+	f.Collect()
+
+	assert.NotEmpty(f.GetErrors(), "unreadable entrypoint must raise a collection error")
+	assert.Empty(f.GetData(), "no data should be emitted when collection fails")
+}
+
+// TestFileFingerprintMarkerMatchingIgnoresCarriageReturns asserts that a
+// marker matches whole lines irrespective of LF vs CRLF line endings.
+// Markers are matched against lines split on \n, so without trimming the
+// trailing \r a config would silently stop matching against a file
+// committed with Windows line endings - and 0.x's bufio.Scanner-based
+// utils.FileContains stripped them, so not trimming would also be a
+// behavioural regression against the check this replaces.
+func TestFileFingerprintMarkerMatchingIgnoresCarriageReturns(t *testing.T) {
+	assert := assert.New(t)
+
+	marker := "use Drupal\\Core\\DrupalKernel;"
+
+	for _, tc := range []struct {
+		name    string
+		content string
+	}{
+		{name: "lf", content: "<?php\n" + marker + "\n"},
+		{name: "crlf", content: "<?php\r\n" + marker + "\r\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(
+				filepath.Join(dir, "index.php"), []byte(tc.content), 0o644); err != nil {
+				t.Fatalf("write fixture: %v", err)
+			}
+
+			config.ProjectDir = ""
+
+			f := NewFingerprint("testCRLF" + tc.name)
+			f.Path = dir
+			f.Threshold = 1
+			f.Entrypoints = []string{"index.php"}
+			f.Frameworks = map[string]FrameworkSignature{
+				"drupal": {Markers: []string{marker}},
+			}
+
+			f.Collect()
+
+			assert.Empty(f.GetErrors())
+			assert.Equal(map[string]string{"drupal": "5"}, f.GetData())
+		})
+	}
+}

--- a/pkg/fact/file/testdata/fingerprint/all-signals/composer.json
+++ b/pkg/fact/file/testdata/fingerprint/all-signals/composer.json
@@ -1,0 +1,6 @@
+{
+    "require": {
+        "php": "^8.1",
+        "drupal/core-recommended": "^10.2"
+    }
+}

--- a/pkg/fact/file/testdata/fingerprint/all-signals/web/index.php
+++ b/pkg/fact/file/testdata/fingerprint/all-signals/web/index.php
@@ -1,0 +1,6 @@
+<?php
+
+use Drupal\Core\DrupalKernel;
+
+$autoloader = require_once 'autoload.php';
+$kernel = new DrupalKernel('prod', $autoloader);

--- a/pkg/fact/file/testdata/fingerprint/combined/web/index.php
+++ b/pkg/fact/file/testdata/fingerprint/combined/web/index.php
@@ -1,0 +1,6 @@
+<?php
+
+use Drupal\Core\DrupalKernel;
+
+$autoloader = require_once 'autoload.php';
+$kernel = new DrupalKernel('prod', $autoloader);

--- a/pkg/fact/file/testdata/fingerprint/dependencies-only/composer.json
+++ b/pkg/fact/file/testdata/fingerprint/dependencies-only/composer.json
@@ -1,0 +1,9 @@
+{
+    "require": {
+        "php": "^8.1",
+        "drupal/core-recommended": "^10.2"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9.6"
+    }
+}

--- a/pkg/fact/file/testdata/fingerprint/dependencies-require-dev-only/composer.json
+++ b/pkg/fact/file/testdata/fingerprint/dependencies-require-dev-only/composer.json
@@ -1,0 +1,8 @@
+{
+    "require": {
+        "php": "^8.1"
+    },
+    "require-dev": {
+        "drupal/core-dev": "^10.2"
+    }
+}

--- a/pkg/fact/file/testdata/fingerprint/dirs-only/web/index.php
+++ b/pkg/fact/file/testdata/fingerprint/dirs-only/web/index.php
@@ -1,0 +1,4 @@
+<?php
+
+// Just an entrypoint; no marker content.
+echo "hello";

--- a/pkg/fact/file/testdata/fingerprint/malformed-manifest/composer.json
+++ b/pkg/fact/file/testdata/fingerprint/malformed-manifest/composer.json
@@ -1,0 +1,1 @@
+{ this is not valid json 

--- a/pkg/fact/file/testdata/fingerprint/markers-only/index.php
+++ b/pkg/fact/file/testdata/fingerprint/markers-only/index.php
@@ -1,0 +1,7 @@
+<?php
+
+use Drupal\Core\DrupalKernel;
+use Symfony\Component\HttpFoundation\Request;
+
+$autoloader = require_once 'autoload.php';
+$kernel = new DrupalKernel('prod', $autoloader);

--- a/pkg/fact/file/testdata/fingerprint/multi-framework/index.php
+++ b/pkg/fact/file/testdata/fingerprint/multi-framework/index.php
@@ -1,0 +1,3 @@
+<?php
+
+require_once __DIR__ . '/wp-load.php';

--- a/pkg/fact/file/testdata/fingerprint/multi-framework/web/index.php
+++ b/pkg/fact/file/testdata/fingerprint/multi-framework/web/index.php
@@ -1,0 +1,6 @@
+<?php
+
+use Drupal\Core\DrupalKernel;
+
+$autoloader = require_once 'autoload.php';
+$kernel = new DrupalKernel('prod', $autoloader);

--- a/pkg/fact/file/testdata/fingerprint/package-json-deps/package.json
+++ b/pkg/fact/file/testdata/fingerprint/package-json-deps/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "example",
+    "dependencies": {
+        "react": "^18.2.0"
+    },
+    "devDependencies": {
+        "jest": "^29.7.0"
+    }
+}

--- a/tests/e2e/examples_test.go
+++ b/tests/e2e/examples_test.go
@@ -137,6 +137,31 @@ func selfContainedCases() []selfContainedCase {
 				{name: "ci-placeholder-unsubstituted", status: "Fail", checkType: "drift", breachCount: 1},
 			},
 		},
+		{
+			name:         "app-type",
+			file:         "app-type.yml",
+			wantChecks:   4,
+			wantBreaches: 3,
+			wantSeverity: map[string]int{"high": 3},
+			// wantPolicies is intentionally omitted: all four checks share
+			// the detected plugin, and the policy IDs within a plugin are
+			// collected via Go map iteration (see shipshape.go), so their
+			// order is non-deterministic. checkResults asserts each check by
+			// name, which is order-independent.
+			//
+			// drupal/symfony/laravel each score markers+dirs+dependencies
+			// (5+5+10=20), over the threshold of 15, so they breach. The
+			// wordpress fixture only matches its own marker line (score 5,
+			// no dirs or dependencies signal fires for any configured
+			// framework) - 5 never exceeds 15, proving threshold filtering
+			// is exercised here, not just at the unit level.
+			checkResults: []wantResult{
+				{name: "drupal-project-frameworks", status: "Fail", checkType: "detected", breachCount: 1},
+				{name: "symfony-project-frameworks", status: "Fail", checkType: "detected", breachCount: 1},
+				{name: "laravel-project-frameworks", status: "Fail", checkType: "detected", breachCount: 1},
+				{name: "wordpress-project-frameworks", status: "Pass", checkType: "detected"},
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
## Summary
Closes the `sca:application_type` recipe gap in the 0.x→1.x catalogue by adding a `file:fingerprint` fact and a `detected` analyser:
| 0.x check | 1.x recipe | Example |
|---|---|---|
| [`sca:application_type`](docs/src/reference/checks/sca-application-type.md) | `file:fingerprint` + `detected` | `examples/app-type.yml` |
No new dependencies — `go.mod`/`go.sum` are unchanged in this range. The `dependencies` signal reuses `github.com/theory/jsonpath`, already a direct dependency introduced by the parent branch.
## New plugins
**`file:fingerprint` (fact)** — reproduces 0.x's *weighted-likelihood* model rather than simple presence matching, so ported configs score identically. Three signals, all with configurable weights and a threshold:
- `markers` — +5 per matching marker/entrypoint pair
- `dirs` — +5 per matching directory
- `dependencies` — manifest-based, scores **once only** per framework
Only labels scoring above the threshold are emitted; sub-threshold scores go to debug logs. Framework signatures are entirely operator config — no framework knowledge is baked into the binary, only the generic matching mechanism.
**`detected` (analyser)** — breaches once per entry in a `FormatMapString` input, emitting framework/likelihood key-value breaches. Any emitted label *is* the assertion failure, so like `drift` there is no inverse polarity to configure.
## Deliberate design decisions
- **Three intentional 0.x divergences**, documented on the struct: entrypoints match by **exact basename** rather than `utils.Glob`'s substring match (which would inflate scores via unintended file matches); an **unreadable entrypoint is a hard error**, not a skipped file (skipping would lose any marker it might have matched and report a framework that *is* present as absent — the worst failure mode for an audit tool); and marker lines are compared with **trailing carriage returns trimmed**, so a config keeps matching CRLF files as it did under 0.x's `bufio.Scanner`-based `utils.FileContains`.
- **`dependencies` fixes a 0.x bug.** `utils.HasComposerDependency` only ever checked `require`. The configurable `manifest` (default `composer.json`) and `dependency-paths` (default covers composer's `require`/`require-dev` and package.json's `dependencies`/`devDependencies`) close that gap, while a matched dependency still scores once only, reproducing 0.x's single bool-driven award.
- **Determinism.** `detected` sorts map keys before emitting breaches. Go randomises map iteration and `not:empty`'s existing `FormatMapString` path does not sort, so reusing it would make breach order — and any downstream assertion on it — non-deterministic for multi-label input.
- **Redaction by default.** Output carries only the label and score, never matched marker text, so a carelessly-written marker cannot echo file content into an audit report.
- **I/O proportional to entrypoint count.** Entrypoints are read once up front rather than re-opened per marker, which also reports an unreadable file once instead of once per marker.
- **Distinct sentinel errors** for missing, unreadable and malformed manifests, and for invalid `dependency-paths` expressions — rather than a panic or a silent zero score.
## Testing
- `pkg/fact/file/fingerprint_test.go` (622 lines) and `pkg/analyse/detected_test.go` (207 lines), with fixtures covering each signal in isolation (`markers-only`, `dirs-only`, `dependencies-only`, `dependencies-require-dev-only`, `package-json-deps`), combined (`all-signals`, `combined`), `multi-framework`, and `malformed-manifest`.
- `examples/app-type.yml` exercises the full composition across four framework fixtures (drupal, wordpress, symfony, laravel) lifted from `pkg/checks/sca/testdata/`. drupal/symfony/laravel each score markers+dirs+dependencies (5+5+10=20) over the threshold of 15 and breach; the **wordpress fixture deliberately scores 5 against a threshold of 15**, so threshold filtering is proven at the integration level, not only in unit tests.
- New `selfContainedCase` in `tests/e2e/examples_test.go` asserts per-check results by name. `wantPolicies` is intentionally omitted and the reason documented inline: all four checks share the `detected` plugin, and policy IDs within a plugin are collected via Go map iteration, so their order is non-deterministic.
## Docs
- `sca:application_type` moved to **Achievable now** in `docs/src/guide/gaps.md`, with a new `### Recipe: sca:application_type` section.
- Documents the two non-obvious footguns: `markers`/`dirs` accumulate per match while `dependencies` scores once only, and `deepMerge` **replaces** slices/scalars rather than unioning them when composing a shared signature library via repeated `-f` flags. Also covers the threshold zero-value caveat and the scope boundary (no expected-app-type checking without a future labels-only toggle).
- Sidebar stub added for `file:fingerprint`, alphabetically placed among the existing collect reference entries.