### PR TITLE
feat(fact): add http:crawl fact for site-wide broken-link auditing

### DIFF
--- a/docs/src/.vuepress/config.js
+++ b/docs/src/.vuepress/config.js
@@ -97,6 +97,7 @@ module.exports = {
                 ['/reference/collect/file-lookup', 'file:lookup'],
                 ['/reference/collect/file-read', 'file:read'],
                 ['/reference/collect/file-read-multiple', 'file:read:multiple'],
+                ['/reference/collect/http-crawl', 'http:crawl'],
                 ['/reference/collect/yaml-key', 'yaml:key'],
               ]
             },

--- a/docs/src/guide/gaps.md
+++ b/docs/src/guide/gaps.md
@@ -429,7 +429,7 @@ an offshore URL.
 | 0.x check | Status | 1.x plugin chain |
 |---|---|---|
 | [`docker:base_image`](../reference/checks/docker-base-image.md) | Achievable now | `docker:images` + `allowed:list` — see `examples/docker.yml` |
-| [`crawler`](../reference/checks/crawler.md) | Needs new capability | TBD |
+| [`crawler`](../reference/checks/crawler.md) | Achievable now | `http:crawl` + `not:empty` — see `examples/crawl.yml` |
 
 ### Recipe: docker:base_image
 
@@ -463,12 +463,74 @@ analyse:
 
 Source: `examples/docker.yml`
 
+### Recipe: crawler
+
+```yaml
+collect:
+  site-links:
+    http:crawl:
+      url: ${CRAWL_BASE_URL}
+      resolve-env: true
+      max-depth: 2
+
+analyse:
+  site-has-no-broken-links:
+    not:empty:
+      input: site-links
+      severity: high
+      description: "Site has no broken links"
+```
+
+Source: `examples/crawl.yml`
+
+**Migration notes from the 0.x `crawler` check:**
+
+| 0.x | 1.x |
+|---|---|
+| `domain` | `url` |
+| `extra_domains` | `include-domains` |
+| `include_urls` | `include-urls` |
+| `limit: 0` = unlimited | `limit` defaults to `100` — an unbounded crawl is no longer the default; opt into a wider budget explicitly |
+| no depth control | `max-depth` (default `3`) |
+| 203/204 misreported as errors (a bug in the underlying `colly` v1 library) | only non-2xx responses and transport errors are reported; 203/204 are correctly treated as success |
+| robots.txt always ignored | same — this is an audit tool crawling operator-owned/operator-approved targets, not a general-purpose spider |
+
+**Sovereignty note.** `http:crawl` performs outbound network I/O against
+the configured `url` (and any `include-domains` hosts) — this is the
+intended purpose of the plugin, not an incidental side effect like
+`file:fingerprint`'s signature-library composition. Scope is bounded to
+the root host plus explicitly allow-listed domains; no credentials are
+forwarded with requests; nothing is persisted beyond what an `output:`
+sink writes. For AU-sovereign audits, crawl targets should be
+operator-controlled or operator-approved infrastructure.
+
+**SSRF note.** `url` (and `include-domains`) must come from an explicitly
+configured, trusted value — e.g. a value set in a CI pipeline's own
+config, never a value influenced by end-user input. The domain allowlist
+bounds lateral scope: it is enforced on both discovered links and
+redirects — including every hop of a redirect chain, not only the initial
+request — so an attacker who fully controls the audited site's markup
+cannot make `http:crawl` fetch arbitrary third-party hosts either by
+linking to them directly or by redirecting to them. It does not protect
+against a malicious or attacker-influenced `url` itself; if the
+configured root redirects outside the allowlist, the crawl fails outright
+rather than silently auditing nothing (see the reference page's "Domain
+allowlist" section for the link-vs-redirect distinction and why a
+discovered link redirecting off-host is logged rather than treated as a
+broken link).
+
+**Privacy note (APP 11).** Crawled URLs, including any query strings,
+appear verbatim in breach output. An `output:` sink therefore inherits the
+same data classification as the URL structure of the audited site — treat
+accordingly if the site's URLs can embed identifiers or other information
+that should not be duplicated into a lower-classification results store.
+
 ## Summary
 
 | Status | Count |
 |---|---|
-| Achievable now | 16 |
+| Achievable now | 18 |
 | Achievable, undocumented | 0 |
-| Needs new capability | 2 |
+| Needs new capability | 0 |
 
 The plan for the remaining capabilities is on the [roadmap](roadmap.md) page.

--- a/docs/src/reference/collect/http-crawl.md
+++ b/docs/src/reference/collect/http-crawl.md
@@ -1,0 +1,88 @@
+# http:crawl
+
+The `http:crawl` collect plugin walks a site's link graph starting from a
+root url, following same-host links (plus any hosts in `include-domains`)
+up to a bounded depth and request count, and returns a map of every
+non-2xx response or transport error encountered along the way.
+
+It is a leaf collector (no `input`) - analogous to `http:fetch`, but for
+auditing a site's link graph rather than fetching a single resource, e.g.
+detecting broken links across a site.
+
+## Plugin fields
+
+| Field | Description | Required | Default |
+| --- | --- | :---: | :---: |
+| url | The root url to start crawling from. | Yes | "" |
+| include-domains | Extra hosts to follow links to, in addition to the root url's own host. | No | [] |
+| include-urls | Extra paths/urls to fetch regardless of whether they were discovered by crawling - useful for pages not reachable by any link. Resolved relative to `url`. | No | [] |
+| max-depth | How many link-following hops from the root url to traverse. The root url itself is depth 0. | No | 3 |
+| limit | Hard cap on the total number of requests issued across the whole crawl. | No | 100 |
+| timeout | Per-request timeout, as a Go duration string (e.g. `30s`). | No | 30s |
+| allow-insecure | Permits `http://` urls. Leave unset for production audits - see the ISM-1139 note below. | No | false |
+| resolve-env | Resolve `${VAR}` references in `url` from a `.env` file. See the caveat below. | No | false |
+| env-file | Path to the `.env` file used when `resolve-env` is true. | No | `<project-dir>/.env` |
+
+<Content :page-key="$site.pages.find(p => p.path === '/reference/common/collect.html').key"/>
+
+## HTTPS required by default
+
+`https://` is required unless `allow-insecure: true` is set. ISM-1139
+recommends encrypting data in transit, and defaulting to plain HTTP for an
+operator-supplied url risks silently auditing unencrypted traffic. Set
+`allow-insecure` only for local/CI use against a plain-http test server -
+never for a production audit target.
+
+## `resolve-env` reads a `.env` file, not the OS environment
+
+`resolve-env` (`pkg/env/envresolver.go`) reads **only** a `.env` file in
+the project directory (or the path given by `env-file`) via
+`godotenv.Read`. It never consults the shipshape process's own OS
+environment (`os.Environ()`). A variable exported in the shell that runs
+`shipshape run` will **not** be substituted into `url` - it must be
+written to a `.env` file instead. This is the single most likely source of
+confusion when parameterising the crawl root across environments.
+
+## Domain allowlist
+
+Only the root url's host, plus any hosts listed in `include-domains`, are
+followed - matched as an **exact host string**: subdomains and `www` vs
+apex variants of the same site are not implied, so a redirect from
+`www.example.gov.au` to `example.gov.au` needs the target added to
+`include-domains` explicitly if you want it crawled.
+
+- A **link** (`<a href>`) to a host outside the allowlist is skipped
+  entirely: not visited, not recorded, not even as a breach.
+- A **redirect** to a host outside the allowlist is refused before it is
+  ever issued, enforced on *every* hop of a redirect chain, not only the
+  initial request - so the allowlist cannot be bypassed by an on-allowlist
+  page redirecting elsewhere. A refusal on a discovered link is logged at
+  warning level and skipped - not recorded as a breach - because sites
+  commonly redirect off-host for legitimate reasons (SSO, `www`/apex
+  normalisation, link-tracking wrappers), and treating every such redirect
+  as a broken link would make this check impractical on real sites.
+- The one exception is the root `url` itself: if it redirects to a host
+  outside the allowlist, the crawl fails outright rather than silently
+  visiting nothing and reporting no broken links. Fix by pointing `url` at
+  the post-redirect host, or adding the target to `include-domains`.
+
+This keeps a compromised or malicious link (or redirect) on the audited
+site from causing shipshape to fetch arbitrary third-party infrastructure
+during an audit run.
+
+## Return format
+
+A map of url to status/error, containing **only** non-2xx responses and
+transport failures:
+
+| Key | Value |
+| --- | --- |
+| \<crawled url\> | The HTTP status code as a string (e.g. `"404"`), or `"error: <message>"` for a transport-level failure (DNS, connection refused, timeout). |
+
+2xx responses - including 203 and 204 - are never recorded. A site with no
+broken links emits an empty map. Pair the output with the `not:empty`
+analyser, which breaches whenever its input is non-empty.
+
+## Example
+
+<<< @/../examples/crawl.yml

--- a/examples/crawl.yml
+++ b/examples/crawl.yml
@@ -1,0 +1,52 @@
+# Audit a site for broken links by crawling it and flagging any non-2xx
+# response or transport error encountered along the way.
+#
+# `http:crawl` walks the link graph starting from `url`, following only
+# same-host links (plus any hosts in `include-domains`) up to `max-depth`
+# and a total request `limit`. It emits a map of url -> status/error for
+# every non-2xx response or failed request; 2xx responses (including 203
+# and 204) are not recorded. This pairs naturally with `not:empty`, which
+# breaches whenever its input is non-empty.
+#
+# `url` here is `${CRAWL_BASE_URL}`, resolved via `resolve-env`. Note this
+# reads a `.env` file in the project directory (see
+# pkg/env/envresolver.go) - it does NOT read the process's OS environment.
+# A real audit would point `url` directly at the site under test, e.g.
+# `https://www.example.gov.au`; this example uses an env var so the same
+# config can run against a disposable test server in CI (see
+# tests/e2e/crawl_test.go) as well as a real site locally.
+#
+# allow-insecure is set to true here only because the e2e test target
+# (tests/e2e/crawl_test.go) is a plain-http httptest server. A real audit
+# target should always be https (ISM-1139); omit allow-insecure entirely
+# when auditing production infrastructure so an accidental http:// url
+# fails loudly instead of being silently crawled unencrypted.
+collect:
+  site-links:
+    http:crawl:
+      url: ${CRAWL_BASE_URL}
+      resolve-env: true
+      allow-insecure: true
+      max-depth: 2
+
+  clean-links:
+    http:crawl:
+      url: ${CRAWL_BASE_URL}/clean
+      resolve-env: true
+      allow-insecure: true
+      max-depth: 2
+
+analyse:
+  # Breaches: the site links to a page that returns 404.
+  site-has-no-broken-links:
+    not:empty:
+      input: site-links
+      severity: high
+      description: "Site has no broken links"
+
+  # Passes: the /clean section is a closed subgraph of 2xx pages that never
+  # reaches the broken /missing link reachable from the site root.
+  clean-section-has-no-broken-links:
+    not:empty:
+      input: clean-links
+      description: "All crawled pages returned a 2xx response"

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/mysql v0.34.0
 	github.com/theory/jsonpath v0.12.0
 	github.com/vmware-labs/yaml-jsonpath v0.3.2
+	golang.org/x/net v0.51.0
 	golang.org/x/oauth2 v0.31.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -93,7 +94,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.38.0 // indirect
 	go.opentelemetry.io/otel/trace v1.38.0 // indirect
 	golang.org/x/crypto v0.48.0 // indirect
-	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/pkg/fact/http/crawl.go
+++ b/pkg/fact/http/crawl.go
@@ -1,0 +1,413 @@
+package http
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"golang.org/x/net/html"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/salsadigitalauorg/shipshape/pkg/data"
+	"github.com/salsadigitalauorg/shipshape/pkg/env"
+	"github.com/salsadigitalauorg/shipshape/pkg/fact"
+	"github.com/salsadigitalauorg/shipshape/pkg/plugin"
+)
+
+var (
+	// ErrNoCrawlUrl is returned when the plugin is configured without a url.
+	ErrNoCrawlUrl = errors.New("http:crawl requires a 'url'")
+	// ErrInvalidCrawlUrl is returned when the url cannot be parsed.
+	ErrInvalidCrawlUrl = errors.New(
+		"http:crawl requires a valid, absolute url")
+	// ErrCrawlSchemeNotAllowed is returned when the url scheme is not
+	// https, and allow-insecure has not been set.
+	ErrCrawlSchemeNotAllowed = errors.New(
+		"http:crawl requires an https url; set allow-insecure to permit http")
+	// ErrInvalidCrawlTimeout is returned when timeout cannot be parsed as a
+	// duration.
+	ErrInvalidCrawlTimeout = errors.New(
+		"http:crawl timeout must be a valid duration, e.g. '30s'")
+	// ErrInvalidCrawlLimit is returned when limit is negative.
+	ErrInvalidCrawlLimit = errors.New(
+		"http:crawl limit must be zero (for the default) or a positive number")
+	// ErrInvalidCrawlMaxDepth is returned when max-depth is negative.
+	ErrInvalidCrawlMaxDepth = errors.New(
+		"http:crawl max-depth must be zero (for the default) or a positive number")
+	// ErrOffAllowlistRedirect is returned when a response redirects to a
+	// host outside the root host + include-domains allowlist. The
+	// redirect is refused before it is issued - ISM-1288 / CWE-918: a
+	// compromised or malicious audited site must not be able to steer
+	// audit traffic at arbitrary third-party infrastructure. A refusal on
+	// a discovered link is logged and skipped, not recorded as a breach -
+	// many sites legitimately redirect off-host (SSO, www/apex
+	// normalisation, link-tracking wrappers). A refusal on the crawl root
+	// itself is a hard error - see ErrRootRedirectOffAllowlist.
+	ErrOffAllowlistRedirect = errors.New(
+		"http:crawl refused a redirect to a non-allow-listed host")
+	// ErrRootRedirectOffAllowlist is returned when the configured url
+	// itself redirects to a host outside the allowlist. Without this
+	// check the crawl would silently visit nothing and report success.
+	ErrRootRedirectOffAllowlist = errors.New(
+		"http:crawl url redirects to a host outside the allowlist; " +
+			"set url to the post-redirect host, or add the target to include-domains")
+)
+
+// defaultCrawlMaxDepth bounds link-following depth from the root url when
+// max-depth is not configured. The root url itself is depth 0.
+const defaultCrawlMaxDepth = 3
+
+// defaultCrawlLimit bounds the total number of requests issued when limit
+// is not configured. ISM-1288: an unbounded crawl of operator-supplied
+// infrastructure risks an unintentional denial of service against the
+// audited site; a crawl that needs a wider budget must opt in explicitly.
+const defaultCrawlLimit = 100
+
+// defaultCrawlTimeout is the per-request timeout used when timeout is not
+// configured, matching utils.fetchTimeout (pkg/utils/utils.go).
+const defaultCrawlTimeout = 30 * time.Second
+
+// maxCrawlResponseSize bounds the number of bytes read from each crawled
+// response body, matching utils.maxFetchResponseSize
+// (pkg/utils/utils.go), applied per-request rather than once since a crawl
+// issues many requests.
+const maxCrawlResponseSize = 10 * 1024 * 1024 // 10 MiB
+
+// maxCrawlRedirects caps the number of redirects followed per request,
+// matching net/http's unexported defaultCheckRedirect. Supplying a custom
+// CheckRedirect (required to enforce the domain allowlist on every hop)
+// replaces that default entirely, so the cap must be reimplemented here -
+// omitting it would trade the allowlist bypass this guards against for an
+// unbounded redirect loop.
+const maxCrawlRedirects = 10
+
+// Crawl walks a site starting from a root url, following same-site (or
+// explicitly allow-listed) links up to a bounded depth and request count,
+// and emits the HTTP status (or transport error) of every non-2xx or
+// failed request encountered. It is a leaf collector (no input), analogous
+// to http:fetch but for auditing a site's link graph rather than fetching
+// a single resource - e.g. detecting broken links across a site.
+//
+// HTTPS is required by default; ISM-1139 recommends encrypting data in
+// transit, and defaulting to plain HTTP for an operator-supplied url risks
+// silently auditing unencrypted traffic. Set AllowInsecure to opt out for
+// local/test scenarios.
+//
+// Only the root host, plus any hosts in IncludeDomains, are followed -
+// matched as an exact host string, so subdomains and www/apex variants of
+// the same site are not implied. A link to any other host is skipped
+// entirely: not visited, not recorded, not even as a breach. A redirect to
+// any other host is refused before it is issued - enforced on every hop,
+// not only the initial request - and is logged rather than recorded, since
+// sites commonly redirect off-host for legitimate reasons (SSO, www/apex
+// normalisation, link-tracking wrappers); add the target to IncludeDomains
+// to have it crawled instead. The one exception is Url itself: if the root
+// redirects off-allowlist the crawl fails outright
+// (ErrRootRedirectOffAllowlist), since silently visiting nothing and
+// reporting success would be worse than an explicit error.
+//
+// Traversal is sequential (single goroutine), which keeps runs
+// deterministic and avoids inadvertently load-testing the audited site.
+type Crawl struct {
+	fact.BaseFact       `yaml:",inline"`
+	env.BaseEnvResolver `yaml:",inline"`
+
+	// Plugin fields.
+	Url            string   `yaml:"url"`
+	IncludeDomains []string `yaml:"include-domains"`
+	IncludeUrls    []string `yaml:"include-urls"`
+	MaxDepth       int      `yaml:"max-depth"`
+	Limit          int      `yaml:"limit"`
+	Timeout        string   `yaml:"timeout"`
+	AllowInsecure  bool     `yaml:"allow-insecure"`
+}
+
+//go:generate go run ../../../cmd/gen.go fact-plugin --package=http
+
+func init() {
+	fact.Manager().RegisterFactory("http:crawl", func(n string) fact.Facter {
+		return NewCrawl(n)
+	})
+}
+
+func NewCrawl(id string) *Crawl {
+	return &Crawl{
+		BaseFact: fact.BaseFact{
+			BasePlugin: plugin.BasePlugin{
+				Id: id,
+			},
+		},
+	}
+}
+
+func (p *Crawl) GetName() string {
+	return "http:crawl"
+}
+
+// queueItem is one url pending a crawl request. isRoot marks the crawl's
+// original url (as opposed to an include-urls seed or a discovered link,
+// both of which also start at depth 0) - see the isRoot check in Collect
+// for why the distinction matters.
+type queueItem struct {
+	u      *url.URL
+	depth  int
+	isRoot bool
+}
+
+// normalizeCrawlURL returns a copy of u with its fragment cleared -
+// fragments are resolved client-side and never affect what the server
+// returns, so keeping them would visit the same resource under multiple
+// visited-set keys - and an empty path normalised to "/", so that
+// "http://host" and "http://host/" are treated as the same resource and
+// the root is never queued (and counted against limit) twice.
+func normalizeCrawlURL(u *url.URL) *url.URL {
+	c := *u
+	c.Fragment = ""
+	if c.Path == "" {
+		c.Path = "/"
+	}
+	return &c
+}
+
+func (p *Crawl) Collect() {
+	contextLogger := log.WithFields(log.Fields{
+		"fact-plugin": p.GetName(),
+		"fact":        p.GetId(),
+	})
+
+	envMap, err := p.GetEnvMap()
+	if err != nil {
+		p.AddErrors(err)
+		return
+	}
+
+	rawUrl, err := env.ResolveValue(envMap, p.Url)
+	if err != nil {
+		p.AddErrors(err)
+		return
+	}
+
+	if rawUrl == "" {
+		p.AddErrors(ErrNoCrawlUrl)
+		return
+	}
+
+	root, err := url.Parse(rawUrl)
+	if err != nil || root.Scheme == "" || root.Host == "" {
+		p.AddErrors(ErrInvalidCrawlUrl)
+		return
+	}
+	if root.Scheme != "https" && !p.AllowInsecure {
+		p.AddErrors(ErrCrawlSchemeNotAllowed)
+		return
+	}
+
+	timeout := defaultCrawlTimeout
+	if p.Timeout != "" {
+		timeout, err = time.ParseDuration(p.Timeout)
+		if err != nil {
+			p.AddErrors(ErrInvalidCrawlTimeout)
+			return
+		}
+	}
+
+	if p.MaxDepth < 0 {
+		p.AddErrors(ErrInvalidCrawlMaxDepth)
+		return
+	}
+	maxDepth := p.MaxDepth
+	if maxDepth == 0 {
+		maxDepth = defaultCrawlMaxDepth
+	}
+
+	if p.Limit < 0 {
+		p.AddErrors(ErrInvalidCrawlLimit)
+		return
+	}
+	limit := p.Limit
+	if limit == 0 {
+		limit = defaultCrawlLimit
+	}
+
+	allowedHosts := map[string]bool{root.Host: true}
+	for _, d := range p.IncludeDomains {
+		allowedHosts[d] = true
+	}
+
+	root = normalizeCrawlURL(root)
+
+	// A custom CheckRedirect is required to enforce the allowlist on every
+	// redirect hop, not just the initial request - net/http otherwise
+	// follows redirects (subject only to its own default 10-redirect cap,
+	// which is disabled the moment CheckRedirect is set, hence
+	// maxCrawlRedirects reimplementing it below) with no host check at all.
+	client := &http.Client{
+		Timeout: timeout,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if !allowedHosts[req.URL.Host] {
+				return fmt.Errorf("%w: %s", ErrOffAllowlistRedirect, req.URL.Host)
+			}
+			if len(via) >= maxCrawlRedirects {
+				return fmt.Errorf("stopped after %d redirects", maxCrawlRedirects)
+			}
+			return nil
+		},
+	}
+
+	visited := map[string]bool{}
+	var queue []queueItem
+	queue = append(queue, queueItem{u: root, depth: 0, isRoot: true})
+	visited[root.String()] = true
+
+	for _, raw := range p.IncludeUrls {
+		u, err := url.Parse(raw)
+		if err != nil {
+			contextLogger.WithField("url", raw).WithError(err).
+				Warn("skipping invalid include-urls entry")
+			continue
+		}
+		resolved := normalizeCrawlURL(root.ResolveReference(u))
+		if visited[resolved.String()] {
+			continue
+		}
+		visited[resolved.String()] = true
+		queue = append(queue, queueItem{u: resolved, depth: 0})
+	}
+
+	results := map[string]string{}
+	requests := 0
+
+	for len(queue) > 0 && requests < limit {
+		item := queue[0]
+		queue = queue[1:]
+		requests++
+
+		links, status, err := fetchAndExtractLinks(client, item.u)
+		if err != nil {
+			if errors.Is(err, ErrOffAllowlistRedirect) {
+				if item.isRoot {
+					p.AddErrors(fmt.Errorf("%w (%s)", ErrRootRedirectOffAllowlist, err))
+					return
+				}
+				contextLogger.WithField("from", item.u.String()).WithError(err).
+					Warn("refused redirect to non-allow-listed host; not followed, not recorded")
+				continue
+			}
+			contextLogger.WithField("url", item.u.String()).WithError(err).
+				Debug("crawl request failed")
+			results[item.u.String()] = "error: " + err.Error()
+			continue
+		}
+		if status < 200 || status >= 300 {
+			results[item.u.String()] = strconv.Itoa(status)
+		}
+		if status < 200 || status >= 300 || item.depth >= maxDepth {
+			continue
+		}
+
+		for _, link := range links {
+			resolved := normalizeCrawlURL(item.u.ResolveReference(link))
+			if resolved.Scheme != "http" && resolved.Scheme != "https" {
+				continue
+			}
+			if !allowedHosts[resolved.Host] {
+				continue
+			}
+			key := resolved.String()
+			if visited[key] {
+				continue
+			}
+			visited[key] = true
+			queue = append(queue, queueItem{u: resolved, depth: item.depth + 1})
+		}
+	}
+
+	p.Format = data.FormatMapString
+	p.SetData(results)
+}
+
+// fetchAndExtractLinks issues a single bounded GET request to u using the
+// given client and, if the response is 2xx HTML (or XHTML), extracts and
+// returns the raw href values of every anchor tag found. It returns the
+// response status code (or 0 if the request failed outright) and any
+// transport-level error. client is shared across the whole crawl so
+// connections are reused, and its CheckRedirect enforces the domain
+// allowlist and a redirect-count cap on every hop - see Collect.
+func fetchAndExtractLinks(client *http.Client, u *url.URL) ([]*url.URL, int, error) {
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	rsp, err := client.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rsp.Body.Close()
+
+	status := rsp.StatusCode
+	if status < 200 || status >= 300 {
+		return nil, status, nil
+	}
+
+	// mime.ParseMediaType lowercases the type and strips parameters (e.g.
+	// charset), so "TEXT/HTML" and "text/html; charset=utf-8" both match.
+	// Its error is deliberately discarded: for some malformed-but-still
+	// meaningful inputs (e.g. a trailing ";;") it returns a non-nil error
+	// alongside a perfectly usable mediatype, and an empty header also
+	// errors - gating on the error would silently drop pages a stricter
+	// check would still correctly classify.
+	mediaType, _, _ := mime.ParseMediaType(rsp.Header.Get("Content-Type"))
+	switch mediaType {
+	case "text/html", "application/xhtml+xml":
+	default:
+		return nil, status, nil
+	}
+
+	limited := io.LimitReader(rsp.Body, maxCrawlResponseSize+1)
+	links := extractLinks(limited)
+
+	return links, status, nil
+}
+
+// extractLinks scans r for anchor tags and returns the raw (unresolved)
+// href values found, in document order. Malformed HTML is tolerated -
+// html.Tokenizer stops at the first error/EOF and whatever was parsed up
+// to that point is returned, matching the resilience expected of an audit
+// tool crawling third-party markup it does not control.
+func extractLinks(r io.Reader) []*url.URL {
+	var links []*url.URL
+	z := html.NewTokenizer(r)
+
+	for {
+		tt := z.Next()
+		if tt == html.ErrorToken {
+			return links
+		}
+		if tt != html.StartTagToken && tt != html.SelfClosingTagToken {
+			continue
+		}
+
+		tok := z.Token()
+		if tok.Data != "a" {
+			continue
+		}
+
+		for _, attr := range tok.Attr {
+			if attr.Key != "href" || attr.Val == "" {
+				continue
+			}
+			href, err := url.Parse(attr.Val)
+			if err != nil {
+				continue
+			}
+			links = append(links, href)
+		}
+	}
+}

--- a/pkg/fact/http/crawl_test.go
+++ b/pkg/fact/http/crawl_test.go
@@ -1,0 +1,690 @@
+package http_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/salsadigitalauorg/shipshape/pkg/data"
+	"github.com/salsadigitalauorg/shipshape/pkg/fact"
+	. "github.com/salsadigitalauorg/shipshape/pkg/fact/http"
+)
+
+func TestCrawlInit(t *testing.T) {
+	assert := assert.New(t)
+
+	factPlugin := fact.Manager().GetFactories()["http:crawl"]("testCrawl")
+	assert.NotNil(factPlugin)
+	crawlFacter, ok := factPlugin.(*Crawl)
+	assert.True(ok)
+	assert.Equal("testCrawl", crawlFacter.GetId())
+}
+
+func TestCrawlPluginName(t *testing.T) {
+	assert.Equal(t, "http:crawl", NewCrawl("testCrawl").GetName())
+}
+
+func TestCrawlNoUrl(t *testing.T) {
+	c := NewCrawl("testCrawl")
+	c.AllowInsecure = true
+	c.Collect()
+	assert.Equal(t, []error{ErrNoCrawlUrl}, c.GetErrors())
+}
+
+func TestCrawlInvalidUrl(t *testing.T) {
+	c := NewCrawl("testCrawl")
+	c.Url = "not-a-url"
+	c.AllowInsecure = true
+	c.Collect()
+	assert.Equal(t, []error{ErrInvalidCrawlUrl}, c.GetErrors())
+}
+
+func TestCrawlInsecureSchemeRejectedByDefault(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("should not be fetched"))
+	}))
+	defer svr.Close()
+
+	c := NewCrawl("testCrawl")
+	c.Url = svr.URL // httptest.NewServer is plain http://
+	c.Collect()
+	assert.Equal(t, []error{ErrCrawlSchemeNotAllowed}, c.GetErrors())
+}
+
+func TestCrawlInvalidTimeout(t *testing.T) {
+	c := NewCrawl("testCrawl")
+	c.Url = "https://example.org"
+	c.Timeout = "not-a-duration"
+	c.Collect()
+	assert.Equal(t, []error{ErrInvalidCrawlTimeout}, c.GetErrors())
+}
+
+// TestCrawlStatusBoundaries is the regression guard for colly's
+// handleOnError treating StatusCode < 203 as success, which misreports 203
+// and 204 as errors (see docs/plans/2026-08-06-slice4-http-crawl.md §1).
+func TestCrawlStatusBoundaries(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`<a href="/no-content">no content</a>`))
+	})
+	mux.HandleFunc("/no-content", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent) // 204
+	})
+	svr := httptest.NewServer(mux)
+	defer svr.Close()
+
+	c := NewCrawl("testCrawl")
+	c.Url = svr.URL
+	c.AllowInsecure = true
+	c.Collect()
+
+	assert.Empty(t, c.GetErrors())
+	assert.Equal(t, data.FormatMapString, c.GetFormat())
+	assert.Empty(t, data.AsMapString(c.GetData()),
+		"204 must not be recorded as a breach")
+}
+
+// TestCrawl203NotRecorded asserts 203 is treated as success, not recorded
+// in the output - the same regression guard as TestCrawlStatusBoundaries's
+// 204 case, since colly's bug misclassifies both 203 and 204 as errors
+// (docs/plans/2026-08-06-slice4-http-crawl.md §1). 203 is a 2xx code; this
+// design reports only non-2xx statuses and transport errors.
+func TestCrawl203NotRecorded(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`<a href="/partial">partial</a>`))
+	})
+	mux.HandleFunc("/partial", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNonAuthoritativeInfo) // 203
+	})
+	svr := httptest.NewServer(mux)
+	defer svr.Close()
+
+	c := NewCrawl("testCrawl")
+	c.Url = svr.URL
+	c.AllowInsecure = true
+	c.Collect()
+
+	assert.Empty(t, c.GetErrors())
+	assert.Empty(t, data.AsMapString(c.GetData()),
+		"203 must not be recorded as a breach")
+}
+
+func TestCrawl404Recorded(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`<a href="/missing">missing</a>`))
+	})
+	mux.HandleFunc("/missing", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	svr := httptest.NewServer(mux)
+	defer svr.Close()
+
+	c := NewCrawl("testCrawl")
+	c.Url = svr.URL
+	c.AllowInsecure = true
+	c.Collect()
+
+	assert.Empty(t, c.GetErrors())
+	results := data.AsMapString(c.GetData())
+	assert.Equal(t, "404", results[svr.URL+"/missing"])
+	assert.Len(t, results, 1)
+}
+
+func TestCrawlHealthySiteEmitsEmptyMap(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`<a href="/about">about</a>`))
+	})
+	mux.HandleFunc("/about", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`no links here`))
+	})
+	svr := httptest.NewServer(mux)
+	defer svr.Close()
+
+	c := NewCrawl("testCrawl")
+	c.Url = svr.URL
+	c.AllowInsecure = true
+	c.Collect()
+
+	assert.Empty(t, c.GetErrors())
+	assert.Empty(t, data.AsMapString(c.GetData()))
+}
+
+// TestCrawlMaxDepthOffByOne asserts the root url is depth 0: with
+// max-depth: 1, links found on the root page are fetched (depth 1), but
+// links found on THOSE pages are not (would be depth 2).
+func TestCrawlMaxDepthOffByOne(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`<a href="/depth1">depth1</a>`))
+	})
+	mux.HandleFunc("/depth1", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`<a href="/missing">missing</a>`))
+	})
+	mux.HandleFunc("/missing", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	svr := httptest.NewServer(mux)
+	defer svr.Close()
+
+	c := NewCrawl("testCrawl")
+	c.Url = svr.URL
+	c.AllowInsecure = true
+	c.MaxDepth = 1
+	c.Collect()
+
+	assert.Empty(t, c.GetErrors())
+	results := data.AsMapString(c.GetData())
+	assert.Empty(t, results,
+		"/missing is at depth 2 and must not be reached when max-depth is 1")
+}
+
+func TestCrawlLimitBoundsTotalRequests(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`<a href="/a">a</a><a href="/b">b</a><a href="/c">c</a>`))
+	})
+	for _, path := range []string{"/a", "/b", "/c"} {
+		p := path
+		mux.HandleFunc(p, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		})
+	}
+	svr := httptest.NewServer(mux)
+	defer svr.Close()
+
+	c := NewCrawl("testCrawl")
+	c.Url = svr.URL
+	c.AllowInsecure = true
+	c.Limit = 2
+	c.Collect()
+
+	assert.Empty(t, c.GetErrors())
+	results := data.AsMapString(c.GetData())
+	assert.Len(t, results, 1,
+		"only 1 of the 3 linked pages fits within the root + limit=2 budget")
+}
+
+// TestCrawlAllowlistBypassSchemeRelative guards against a scheme-relative
+// href (//evil.example/x) being resolved to a host outside the allowlist
+// yet still followed because its Host looks unrelated to the check.
+func TestCrawlAllowlistBypassSchemeRelative(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`<a href="//evil.example/x">evil</a>`))
+	})
+	svr := httptest.NewServer(mux)
+	defer svr.Close()
+
+	c := NewCrawl("testCrawl")
+	c.Url = svr.URL
+	c.AllowInsecure = true
+	c.Collect()
+
+	assert.Empty(t, c.GetErrors())
+	assert.Empty(t, data.AsMapString(c.GetData()),
+		"scheme-relative link to a non-allow-listed host must not be followed")
+}
+
+// TestCrawlAllowlistBypassUserinfo guards against a link whose userinfo
+// component embeds the allowed host (http://ok.com@evil.com/) being
+// mistaken for the allowed host; url.URL.Host never includes userinfo, so
+// this is mostly a documentation-by-test of that guarantee.
+func TestCrawlAllowlistBypassUserinfo(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		host := r.Host
+		w.Write([]byte(`<a href="http://` + host + `@evil.example/x">evil</a>`))
+	})
+	svr := httptest.NewServer(mux)
+	defer svr.Close()
+
+	c := NewCrawl("testCrawl")
+	c.Url = svr.URL
+	c.AllowInsecure = true
+	c.Collect()
+
+	assert.Empty(t, c.GetErrors())
+	assert.Empty(t, data.AsMapString(c.GetData()),
+		"userinfo-embedded host must not bypass the allowlist")
+}
+
+func TestCrawlIncludeDomainsExtendsAllowlist(t *testing.T) {
+	mux2 := http.NewServeMux()
+	mux2.HandleFunc("/other", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	svr2 := httptest.NewServer(mux2)
+	defer svr2.Close()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`<a href="` + svr2.URL + `/other">other</a>`))
+	})
+	svr := httptest.NewServer(mux)
+	defer svr.Close()
+
+	c := NewCrawl("testCrawl")
+	c.Url = svr.URL
+	c.AllowInsecure = true
+	c.IncludeDomains = []string{strings.TrimPrefix(svr2.URL, "http://")}
+	c.Collect()
+
+	assert.Empty(t, c.GetErrors())
+	results := data.AsMapString(c.GetData())
+	assert.Equal(t, "404", results[svr2.URL+"/other"])
+}
+
+func TestCrawlIncludeUrlsSeededRegardlessOfDiscovery(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`no links here`))
+	})
+	mux.HandleFunc("/orphan", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	svr := httptest.NewServer(mux)
+	defer svr.Close()
+
+	c := NewCrawl("testCrawl")
+	c.Url = svr.URL
+	c.AllowInsecure = true
+	c.IncludeUrls = []string{"/orphan"}
+	c.Collect()
+
+	assert.Empty(t, c.GetErrors())
+	results := data.AsMapString(c.GetData())
+	assert.Equal(t, "404", results[svr.URL+"/orphan"])
+}
+
+func TestCrawlTransportErrorRecorded(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`<a href="http://127.0.0.1:1/unreachable">unreachable</a>`))
+	}))
+	defer svr.Close()
+
+	c := NewCrawl("testCrawl")
+	c.Url = svr.URL
+	c.AllowInsecure = true
+	c.IncludeDomains = []string{"127.0.0.1:1"}
+	c.Collect()
+
+	assert.Empty(t, c.GetErrors())
+	results := data.AsMapString(c.GetData())
+	found := false
+	for u, v := range results {
+		if strings.Contains(u, "127.0.0.1:1") {
+			found = true
+			assert.True(t, strings.HasPrefix(v, "error: "))
+		}
+	}
+	assert.True(t, found, "unreachable host must be recorded as an error")
+}
+
+func TestCrawlResolveEnvUsesDotEnvFile(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	svr := httptest.NewServer(mux)
+	defer svr.Close()
+
+	dir := t.TempDir()
+	envFile := dir + "/.env"
+	assert.NoError(t, os.WriteFile(envFile, []byte("CRAWL_BASE_URL="+svr.URL+"\n"), 0o600))
+
+	c := NewCrawl("testCrawl")
+	c.Url = "${CRAWL_BASE_URL}"
+	c.AllowInsecure = true
+	c.ResolveEnv = true
+	c.EnvFile = envFile
+	c.Collect()
+
+	assert.Empty(t, c.GetErrors())
+	results := data.AsMapString(c.GetData())
+	assert.Equal(t, "404", results[svr.URL+"/"])
+}
+
+// TestCrawlRefusesOffAllowlistRedirect is the key regression guard for the
+// allowlist-bypass-via-redirect vulnerability: an on-allowlist page
+// redirects to an off-allowlist host, and the offsite server must never be
+// contacted at all - not merely absent from output, which is how the
+// original bug passed review the first time.
+func TestCrawlRefusesOffAllowlistRedirect(t *testing.T) {
+	var offsiteHitMu sync.Mutex
+	var offsiteHit bool
+	offsite := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		offsiteHitMu.Lock()
+		offsiteHit = true
+		offsiteHitMu.Unlock()
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer offsite.Close()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`<a href="/redir">redir</a>`))
+	})
+	mux.HandleFunc("/redir", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, offsite.URL+"/exfil", http.StatusFound)
+	})
+	svr := httptest.NewServer(mux)
+	defer svr.Close()
+
+	c := NewCrawl("testCrawl")
+	c.Url = svr.URL
+	c.AllowInsecure = true
+	c.Collect()
+
+	offsiteHitMu.Lock()
+	hit := offsiteHit
+	offsiteHitMu.Unlock()
+	assert.False(t, hit, "off-allowlist redirect target must never be contacted")
+
+	assert.Empty(t, c.GetErrors(),
+		"a refused redirect on a discovered link is logged, not a fact-level error")
+	assert.Empty(t, data.AsMapString(c.GetData()),
+		"a refused redirect on a discovered link must not be recorded as a breach")
+}
+
+// TestCrawlFollowsSameHostRedirect guards against the allowlist enforcement
+// in TestCrawlRefusesOffAllowlistRedirect over-blocking: a same-host
+// redirect must still be followed, and links on the final page discovered.
+func TestCrawlFollowsSameHostRedirect(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`<a href="/hop">hop</a>`))
+	})
+	mux.HandleFunc("/hop", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/final", http.StatusFound)
+	})
+	mux.HandleFunc("/final", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`<a href="/missing">missing</a>`))
+	})
+	mux.HandleFunc("/missing", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	svr := httptest.NewServer(mux)
+	defer svr.Close()
+
+	c := NewCrawl("testCrawl")
+	c.Url = svr.URL
+	c.AllowInsecure = true
+	c.Collect()
+
+	assert.Empty(t, c.GetErrors())
+	results := data.AsMapString(c.GetData())
+	assert.Equal(t, "404", results[svr.URL+"/missing"],
+		"a same-host redirect must still be followed, and its final page's links discovered")
+}
+
+// TestCrawlRedirectToIncludeDomainAllowed guards against the allowlist
+// check itself, not just its default: a redirect to a host explicitly
+// added via include-domains must be followed.
+func TestCrawlRedirectToIncludeDomainAllowed(t *testing.T) {
+	other := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer other.Close()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`<a href="/redir">redir</a>`))
+	})
+	mux.HandleFunc("/redir", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, other.URL, http.StatusFound)
+	})
+	svr := httptest.NewServer(mux)
+	defer svr.Close()
+
+	c := NewCrawl("testCrawl")
+	c.Url = svr.URL
+	c.AllowInsecure = true
+	c.IncludeDomains = []string{strings.TrimPrefix(other.URL, "http://")}
+	c.Collect()
+
+	assert.Empty(t, c.GetErrors())
+	results := data.AsMapString(c.GetData())
+	assert.Equal(t, "404", results[svr.URL+"/redir"],
+		"a redirect to an include-domains host must be followed; the "+
+			"pre-redirect url is the recorded key, matching how "+
+			"transport-error results are keyed elsewhere in this file")
+}
+
+// TestCrawlRedirectLoopBounded is the regression guard for supplying
+// CheckRedirect disabling net/http's own default redirect cap: without
+// maxCrawlRedirects reimplementing that cap, a self-redirecting endpoint
+// would hang the crawl rather than erroring.
+func TestCrawlRedirectLoopBounded(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`<a href="/loop">loop</a>`))
+	})
+	mux.HandleFunc("/loop", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/loop", http.StatusFound)
+	})
+	svr := httptest.NewServer(mux)
+	defer svr.Close()
+
+	done := make(chan struct{})
+	c := NewCrawl("testCrawl")
+	c.Url = svr.URL
+	c.AllowInsecure = true
+	go func() {
+		c.Collect()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("crawl did not terminate - redirect loop was not bounded")
+	}
+
+	results := data.AsMapString(c.GetData())
+	assert.Contains(t, results[svr.URL+"/loop"], "redirect",
+		"a redirect loop must be recorded as an error, not silently dropped")
+}
+
+// TestCrawlRootRedirectOffAllowlistIsHardError guards against the crawl
+// root itself redirecting off-allowlist: unlike a discovered link (which is
+// skipped and logged), this must fail the fact outright. Silently visiting
+// nothing and letting not:empty pass would be a worse outcome than an
+// explicit, actionable error.
+func TestCrawlRootRedirectOffAllowlistIsHardError(t *testing.T) {
+	offsite := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer offsite.Close()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, offsite.URL, http.StatusFound)
+	})
+	svr := httptest.NewServer(mux)
+	defer svr.Close()
+
+	c := NewCrawl("testCrawl")
+	c.Url = svr.URL
+	c.AllowInsecure = true
+	c.Collect()
+
+	require.Len(t, c.GetErrors(), 1)
+	assert.ErrorIs(t, c.GetErrors()[0], ErrRootRedirectOffAllowlist)
+	assert.Nil(t, c.GetData(),
+		"a hard error must not also emit a (misleadingly empty, passing) result")
+}
+
+func TestCrawlNegativeLimitErrors(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	svr := httptest.NewServer(mux)
+	defer svr.Close()
+
+	c := NewCrawl("testCrawl")
+	c.Url = svr.URL
+	c.AllowInsecure = true
+	c.Limit = -5
+	c.Collect()
+
+	assert.Equal(t, []error{ErrInvalidCrawlLimit}, c.GetErrors())
+	assert.Nil(t, c.GetData(),
+		"a negative limit must not silently emit an empty, passing result")
+}
+
+func TestCrawlNegativeMaxDepthErrors(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	svr := httptest.NewServer(mux)
+	defer svr.Close()
+
+	c := NewCrawl("testCrawl")
+	c.Url = svr.URL
+	c.AllowInsecure = true
+	c.MaxDepth = -1
+	c.Collect()
+
+	assert.Equal(t, []error{ErrInvalidCrawlMaxDepth}, c.GetErrors())
+	assert.Nil(t, c.GetData(),
+		"a negative max-depth must not silently emit an empty, passing result")
+}
+
+// TestCrawlContentTypeCaseInsensitive is the regression guard for Warning
+// 2: HTTP media types are case-insensitive (RFC 9110), so a server sending
+// an uppercase Content-Type must still have its links discovered.
+func TestCrawlContentTypeCaseInsensitive(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "TEXT/HTML")
+		w.Write([]byte(`<a href="/missing">missing</a>`))
+	})
+	mux.HandleFunc("/missing", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	svr := httptest.NewServer(mux)
+	defer svr.Close()
+
+	c := NewCrawl("testCrawl")
+	c.Url = svr.URL
+	c.AllowInsecure = true
+	c.Collect()
+
+	assert.Empty(t, c.GetErrors())
+	results := data.AsMapString(c.GetData())
+	assert.Equal(t, "404", results[svr.URL+"/missing"],
+		"an uppercase Content-Type must still be parsed for links")
+}
+
+func TestCrawlContentTypeXhtml(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/xhtml+xml")
+		w.Write([]byte(`<a href="/missing">missing</a>`))
+	})
+	mux.HandleFunc("/missing", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	svr := httptest.NewServer(mux)
+	defer svr.Close()
+
+	c := NewCrawl("testCrawl")
+	c.Url = svr.URL
+	c.AllowInsecure = true
+	c.Collect()
+
+	assert.Empty(t, c.GetErrors())
+	results := data.AsMapString(c.GetData())
+	assert.Equal(t, "404", results[svr.URL+"/missing"],
+		"application/xhtml+xml must be parsed for links")
+}
+
+// TestCrawlNonHtmlContentTypeNotParsed guards against the content-type
+// switch in fetchAndExtractLinks being widened too far: a plain-text
+// response containing markup-shaped text must not have it parsed for links.
+func TestCrawlNonHtmlContentTypeNotParsed(t *testing.T) {
+	mux := http.NewServeMux()
+	var missingHit bool
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.Write([]byte(`<a href="/missing">missing</a>`))
+	})
+	mux.HandleFunc("/missing", func(w http.ResponseWriter, r *http.Request) {
+		missingHit = true
+		w.WriteHeader(http.StatusNotFound)
+	})
+	svr := httptest.NewServer(mux)
+	defer svr.Close()
+
+	c := NewCrawl("testCrawl")
+	c.Url = svr.URL
+	c.AllowInsecure = true
+	c.Collect()
+
+	assert.Empty(t, c.GetErrors())
+	assert.False(t, missingHit, "text/plain body must not be parsed for links")
+	assert.Empty(t, data.AsMapString(c.GetData()))
+}
+
+// TestCrawlRootNotFetchedTwice is the regression guard for Warning 4: a
+// root url given without a trailing slash ("http://host") and a discovered
+// href="/" ("http://host/") resolve to different url.URL.Path values and
+// must not be treated as two distinct pages. Asserted via a server-side
+// hit counter, since the duplicate is invisible in fact output.
+func TestCrawlRootNotFetchedTwice(t *testing.T) {
+	var hitsMu sync.Mutex
+	hits := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		hitsMu.Lock()
+		hits++
+		hitsMu.Unlock()
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`<a href="/">home</a>`))
+	})
+	svr := httptest.NewServer(mux)
+	defer svr.Close()
+
+	c := NewCrawl("testCrawl")
+	c.Url = svr.URL // no trailing slash
+	c.AllowInsecure = true
+	c.Collect()
+
+	hitsMu.Lock()
+	got := hits
+	hitsMu.Unlock()
+	assert.Equal(t, 1, got,
+		"root without a trailing slash and a discovered href=\"/\" must be the same visited-set entry")
+	assert.Empty(t, c.GetErrors())
+	assert.Empty(t, data.AsMapString(c.GetData()))
+}

--- a/tests/e2e/crawl_test.go
+++ b/tests/e2e/crawl_test.go
@@ -1,0 +1,88 @@
+package e2e
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCrawlExample exercises the http:crawl fact plugin end-to-end against
+// a disposable httptest server, since it needs a live target rather than a
+// static fixture tree.
+//
+// Server link graph:
+//
+//	/            -> 200, links to /missing, /clean, /no-content
+//	/missing     -> 404
+//	/no-content  -> 204, anti-regression guard for colly's <203
+//	                misclassification bug (must never appear in output)
+//	/clean       -> 200, links only to /clean/other
+//	/clean/other -> 200, links only back to /clean
+//
+// The /clean subgraph is closed: from /clean at depth 0, /clean/other is
+// depth 1 and links back to /clean which is already visited, so /missing
+// (only reachable from /) is never reached regardless of max-depth.
+//
+// This is also the first e2e coverage of resolve-env: examples/crawl.yml
+// sets `url: ${CRAWL_BASE_URL}` with `resolve-env: true`, and this test
+// seeds a `.env` file in the staged project directory rather than the OS
+// environment, matching pkg/env/envresolver.go's GetEnvMap contract.
+func TestCrawlExample(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`<a href="/missing">missing</a>` +
+			`<a href="/clean">clean</a>` +
+			`<a href="/no-content">no content</a>`))
+	})
+	mux.HandleFunc("/missing", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	mux.HandleFunc("/no-content", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/clean", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`<a href="/clean/other">other</a>`))
+	})
+	mux.HandleFunc("/clean/other", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`<a href="/clean">back</a>`))
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	project := stagedTestdata(t)
+	writeFile(t, filepath.Join(project, ".env"), "CRAWL_BASE_URL="+server.URL+"\n")
+
+	res := runShipshape(t, project,
+		"run", ".", "-f", examplePath("crawl.yml"), "-o", "json")
+	rl := res.DecodeJSON(t)
+
+	siteResult, ok := findResult(rl, "site-has-no-broken-links")
+	require.True(t, ok, "site-has-no-broken-links result not present")
+	assert.Equal(t, "Fail", siteResult.Status)
+	assert.Len(t, siteResult.Breaches, 1,
+		"only /missing should breach; /no-content (204) must not")
+
+	cleanResult, ok := findResult(rl, "clean-section-has-no-broken-links")
+	require.True(t, ok, "clean-section-has-no-broken-links result not present")
+	assert.Equal(t, "Pass", cleanResult.Status)
+	assert.Empty(t, cleanResult.Breaches)
+
+	assert.Equal(t, uint32(1), rl.TotalBreaches)
+
+	assert.Equal(t, 0, res.ExitCode, "no -e flag: exit code must be 0 despite the breach")
+
+	// site-has-no-broken-links is severity: high, so -e trips shipshape.Exit's
+	// os.Exit(1) path (pkg/shipshape/shipshape.go:206-208).
+	resErr := runShipshape(t, project,
+		"run", ".", "-f", examplePath("crawl.yml"), "-o", "json", "-e")
+	assert.Equal(t, 1, resErr.ExitCode, "-e flag: exit code must be 1 when a high-severity breach is found")
+}


### PR DESCRIPTION
Closes the 0.x `crawler` gap by composing a new http:crawl collect plugin with the existing not:empty analyser. Implemented on net/http + golang.org/x/net/html rather than colly: x/net was already an indirect dependency (now direct, version unchanged), so this adds no new module, and it avoids colly v1's abandoned module line and its handleOnError bug that misreports 203/204 as errors.

Sequential BFS from a root url, emitting non-2xx statuses and transport errors as data.FormatMapString. Bounded by default - max-depth 3, limit 100 requests, 30s per-request timeout, 10 MiB per-response cap - so an audit cannot unintentionally denial-of-service the site under test (ISM-1288). https is required unless allow-insecure is set (ISM-1139).

Traffic is confined to the root host plus include-domains, matched as an exact host string. Off-allowlist links are skipped; off-allowlist redirects are refused before being issued, enforced on every hop, so a compromised or malicious audited site cannot steer audit traffic at third-party infrastructure (CWE-918). Because supplying a custom CheckRedirect disables net/http's own redirect cap, that cap is reimplemented explicitly. A refused redirect on a discovered link is logged and skipped rather than breached - www/apex normalisation, SSO and link-tracking wrappers all redirect off-host legitimately - while the crawl root redirecting off-allowlist is a hard error, since silently visiting nothing would otherwise report success.

Includes examples/crawl.yml, e2e coverage (the first exercising resolve-env, which reads a .env file rather than the OS environment), a reference page, and the gaps.md recipe with 0.x migration notes.