### PR TITLE
docs: fix drift between docs/src and current code, add missing reference pages

### DIFF
--- a/docs/src/.vuepress/config.js
+++ b/docs/src/.vuepress/config.js
@@ -93,11 +93,15 @@ module.exports = {
                 ['/reference/collect/database-search', 'database:search'],
                 ['/reference/collect/docker-command', 'docker:command'],
                 ['/reference/collect/docker-images', 'docker:images'],
+                ['/reference/collect/file-drift', 'file:drift'],
                 ['/reference/collect/file-fingerprint', 'file:fingerprint'],
                 ['/reference/collect/file-lookup', 'file:lookup'],
                 ['/reference/collect/file-read', 'file:read'],
                 ['/reference/collect/file-read-multiple', 'file:read:multiple'],
                 ['/reference/collect/http-crawl', 'http:crawl'],
+                ['/reference/collect/http-fetch', 'http:fetch'],
+                ['/reference/collect/json-key', 'json:key'],
+                ['/reference/collect/static-analysis', 'static-analysis'],
                 ['/reference/collect/yaml-key', 'yaml:key'],
               ]
             },
@@ -107,11 +111,14 @@ module.exports = {
               collapsable: false,
               children: [
                 ['/reference/analyse/allowed-list', 'allowed:list'],
+                ['/reference/analyse/detected', 'detected'],
+                ['/reference/analyse/drift', 'drift'],
                 ['/reference/analyse/equals', 'equals'],
                 ['/reference/analyse/not-empty', 'not:empty'],
                 ['/reference/analyse/not-equals', 'not:equals'],
                 ['/reference/analyse/regex-match', 'regex:match'],
                 ['/reference/analyse/regex-not-match', 'regex:not-match'],
+                ['/reference/analyse/static-analysis', 'static-analysis:breaches'],
               ]
             },
             {
@@ -128,8 +135,9 @@ module.exports = {
               collapsable: false,
               children: [
                 ['/reference/checks/file', 'file'],
-                ['/reference/checks/file-diff', 'file:diff'],
+                ['/reference/checks/file-diff', 'filediff'],
                 ['/reference/checks/yaml', 'yaml'],
+                ['/reference/checks/yaml-lint', 'yamllint'],
                 ['/reference/checks/json', 'json'],
                 ['/reference/checks/drupal-drush-yaml', 'drush-yaml'],
                 ['/reference/checks/drupal-file-module', 'drupal-file-module'],

--- a/docs/src/guide/0.x.md
+++ b/docs/src/guide/0.x.md
@@ -25,10 +25,12 @@ checks:
       # ... check-specific fields
 ```
 
-The binary auto-detects the format. If `checks:` is the only top-level key,
-the 0.x runner is used. If any of `connections`, `collect`, `analyse`, or
-`output` are present, the 1.x runner is used instead. See
-[Config versions](versions.md#how-the-binary-picks-a-format) for the exact rule.
+The binary auto-detects the format. The 1.x runner is used when a non-empty
+top-level `collect:` key is present; otherwise the 0.x runner is used. Note that
+`analyse:` or `output:` alone do **not** select 1.x. See
+[Config versions](versions.md#how-the-binary-picks-a-format) for the exact rule,
+and [Mixing formats](versions.md#mixing-formats-across-files) — passing a 0.x
+and a 1.x file to the same run is an error, not a merge.
 
 ## Common fields
 
@@ -65,13 +67,14 @@ full reference page.
 | Type | What it does |
 |---|---|
 | [`file`](../reference/checks/file.md) | Assert files matching a pattern are absent |
-| [`file:diff`](../reference/checks/file-diff.md) | Assert a file matches a reference template |
+| [`filediff`](../reference/checks/file-diff.md) | Assert a file matches a reference template |
 
 ### YAML / JSON checks
 
 | Type | What it does |
 |---|---|
 | [`yaml`](../reference/checks/yaml.md) | Assert key-value pairs in YAML files |
+| [`yamllint`](../reference/checks/yaml-lint.md) | Assert files parse as valid YAML (syntax only) |
 | [`json`](../reference/checks/json.md) | Assert key-value pairs in JSON files |
 
 ### Drupal checks

--- a/docs/src/guide/README.md
+++ b/docs/src/guide/README.md
@@ -119,14 +119,18 @@ Flags:
                                                  problems to API (env: LAGOON_API_BASE_URL)
       --lagoon-api-token string                  Lagoon API token when pushing problems
                                                  to API (env: LAGOON_API_TOKEN)
+      --lagoon-environment string                The Lagoon environment name (env: LAGOON_ENVIRONMENT)
       --lagoon-insights-remote-endpoint string   Insights Remote Problems endpoint
                                                   (default "http://lagoon-remote-insights-remote.lagoon.svc/problems")
+      --lagoon-project string                    The Lagoon project name (env: LAGOON_PROJECT)
       --lagoon-push-problems-to-insights         Push audit facts to Lagoon via Insights Remote
-  -o, --output-format string                     Output format for stdout [pretty|table|json|junit]
-                                                 (overrides config file)
-      --output-file string                       File to write output to
-      --output-file-format string                Format for file output [pretty|table|json|junit]
-                                                 (defaults to stdout format)
+      --lagoon-source string                     Source to use for Problems pushed to Lagoon (default "Shipshape")
+      --output-file string                       Path to output file
+                                                 (env: SHIPSHAPE_OUTPUT_FILE)
+      --output-file-format string                Format for the output file [pretty|table|json|junit]
+                                                 (env: SHIPSHAPE_OUTPUT_FILE_FORMAT)
+  -o, --output-format string                     Output format [pretty|table|json|junit]
+                                                 (env: SHIPSHAPE_OUTPUT_FORMAT) (default "pretty")
   -r, --remediate                                Run remediation for supported checks
 
 Global Flags:

--- a/docs/src/guide/gaps.md
+++ b/docs/src/guide/gaps.md
@@ -51,20 +51,20 @@ Source: `examples/files.yml`
 0.x `file:diff` rendered a Jinja template with an operator-supplied vars map
 and diffed the result against an on-disk file. 1.x deliberately does **not**
 reproduce that: `file:drift` instead masks placeholder-shaped substrings
-(default `{{ VAR }}`) out of both sides before diffing, so the same config
-runs unmodified across every project provisioned from a template — no
-per-project vars map required. It also detects a placeholder that was never
+(default <code v-pre>{{ VAR }}</code>) out of both sides before diffing, so the
+same config runs unmodified across every project provisioned from a template —
+no per-project vars map required. It also detects a placeholder that was never
 substituted, which rendering cannot.
 
 Template rendering was rejected in favour of drift matching for several
 reasons: a per-project vars map does not scale across many provisioned
-projects; `${{ VAR }}`-style placeholders collide with GitHub Actions'
-`${{ secrets.* }}` syntax when the template is a workflow file; rendering
-silently substitutes undefined variables rather than surfacing them;
-rendering cannot detect a placeholder that was never substituted, because
-there is nothing left to compare once it is rendered away; and a rendering
-engine (e.g. gonja) pulls in dozens of transitive dependencies where RE2
-(already in the standard library) needs none.
+projects; <code v-pre>${{ VAR }}</code>-style placeholders collide with GitHub
+Actions' <code v-pre>${{ secrets.* }}</code> syntax when the template is a
+workflow file; rendering silently substitutes undefined variables rather than
+surfacing them; rendering cannot detect a placeholder that was never
+substituted, because there is nothing left to compare once it is rendered
+away; and a rendering engine (e.g. gonja) pulls in dozens of transitive
+dependencies where RE2 (already in the standard library) needs none.
 
 ```yaml
 collect:
@@ -100,20 +100,20 @@ placeholder's position, not that the surrounding line is otherwise identical
 in structure. In particular:
 
 - A placeholder capture can absorb adjacent genuine drift on the same line —
-  e.g. template `image: {{ IMG }}:v1` against current
+  e.g. template <code v-pre>image: {{ IMG }}:v1</code> against current
   `image: evil/malware:latest:v1` reports no drift, because the wildcard
   swallows everything up to the literal `:v1` suffix. Keep placeholders on
   their own line, or as the entire value, where the drift you care about
   could plausibly appear.
 - The same placeholder name used twice on one line (e.g.
-  `a: {{ X }} b: {{ X }}`) is **not** checked for consistency between the two
-  captured values — RE2 has no backreferences, so `file:drift` cannot express
-  "these two captures must match". A current line of `a: one b: two` reports
-  no drift even though the two `X` values differ.
+  <code v-pre>a: {{ X }} b: {{ X }}</code>) is **not** checked for consistency
+  between the two captured values — RE2 has no backreferences, so `file:drift`
+  cannot express "these two captures must match". A current line of
+  `a: one b: two` reports no drift even though the two `X` values differ.
 - An empty substitution (the current file has nothing where the template has
-  `{{ VAR }}`) counts as substituted, not as drift. Only a placeholder that is
-  still **literally present** in the current file — the common
-  copy-paste-and-forgot-to-fill-in bug — is flagged as unsubstituted.
+  <code v-pre>{{ VAR }}</code>) counts as substituted, not as drift. Only a
+  placeholder that is still **literally present** in the current file — the
+  common copy-paste-and-forgot-to-fill-in bug — is flagged as unsubstituted.
 
 None of these are considered blocking for the initial recipe: they are
 inherent to wildcard-based matching without a rendering/vars step, and are
@@ -128,6 +128,7 @@ Source: `examples/file-drift.yml`
 | 0.x check | Status | 1.x plugin chain |
 |---|---|---|
 | [`yaml`](../reference/checks/yaml.md) | Achievable now | `file:read` + `yaml:key` + `equals` / `allowed:list` — see `examples/drupal-config.yml` |
+| [`yamllint`](../reference/checks/yaml-lint.md) | Needs new capability | No equivalent — a YAML parse error aborts the run instead of breaching. See [below](#recipe-yamllint-not-yet-reproducible). |
 | [`json`](../reference/checks/json.md) | Achievable now | `file:read` + `json:key` + `equals` / `allowed:list` — see `examples/json-lookup.yml` |
 
 ### Recipe: yaml
@@ -155,6 +156,45 @@ analyse:
 ```
 
 Source: `examples/drupal-config.yml`
+
+### Recipe: yamllint (not yet reproducible)
+
+`yamllint` asserts only that files *parse*, reporting an undecodable file as a
+breach. 1.x cannot currently express this, because the two are structurally
+opposed: in 1.x a YAML parse failure is a **collect error**, and any collect
+error is fatal to the whole run —
+`fact.Manager().CollectAllFacts()` is followed immediately by
+`log.Fatal("failed to collect facts")` (`pkg/shipshape/shipshape.go:171-173`).
+
+So the exact condition `yamllint` exists to report is the condition that
+prevents 1.x from reaching the analyse stage at all:
+
+```yaml
+# Aborts with "failed to collect facts" — never produces a breach
+collect:
+  f:
+    file:read:
+      path: bad.yml
+  k:
+    yaml:key:
+      input: f
+      path: a
+```
+
+```
+level=error msg="error looking up yaml path" error="yaml: line 2: mapping values
+  are not allowed in this context" fact=k fact-plugin="yaml:key"
+level=fatal msg="failed to collect facts"
+```
+
+A fix needs a way to treat a fact's collection error as analysable data rather
+than a fatal condition — for example a `yaml:valid` analyser acting on a fact's
+error state, or an opt-in "tolerate collect errors" mode that lets the pipeline
+continue and surfaces the error to an analyser. `BaseAnalyser` already inspects
+`p.input.GetErrors()` (`pkg/analyse/base.go:92`), so the plumbing partly exists;
+the blocker is the unconditional `log.Fatal` upstream of it.
+
+Until then, keep using the 0.x `yamllint` check. It remains fully supported.
 
 ### Recipe: json
 
@@ -531,6 +571,10 @@ that should not be duplicated into a lower-classification results store.
 |---|---|
 | Achievable now | 18 |
 | Achievable, undocumented | 0 |
-| Needs new capability | 0 |
+| Needs new capability | 1 |
+
+19 rows, one per registered 0.x check type. The single remaining gap is
+[`yamllint`](#recipe-yamllint-not-yet-reproducible), which needs a way to treat a
+fact's collection error as analysable data rather than a fatal error.
 
 The plan for the remaining capabilities is on the [roadmap](roadmap.md) page.

--- a/docs/src/guide/roadmap.md
+++ b/docs/src/guide/roadmap.md
@@ -30,56 +30,56 @@ documented in the reference and backed by a working file in `examples/`.
 
 The [gaps matrix](gaps.md) is the authoritative record of current status.
 
-## Recipes to document
+## Current status: one capability gap remains
 
-The Drush-based Drupal checks that were previously **Achievable, undocumented**
-now each have a worked example in `examples/` and are marked **Achievable now**
-on the gaps matrix:
+18 of the 19 registered 0.x checks have a documented recipe and a working example
+in `examples/`. The remaining gap is **`yamllint`**: it reports an undecodable
+YAML file as a breach, but in 1.x a parse failure is a collect error, and any
+collect error is fatal to the run (`pkg/shipshape/shipshape.go:171-173`) — so the
+pipeline never reaches the analyse stage where the breach would be raised.
 
-| 0.x check | Example |
+Closing it needs a way to treat a fact's collection error as analysable data
+rather than a fatal condition: either an analyser that acts on a fact's error
+state (`BaseAnalyser` already reads `p.input.GetErrors()`), or an opt-in
+"tolerate collect errors" mode. See
+[Recipe: yamllint](gaps.md#recipe-yamllint-not-yet-reproducible).
+
+The capabilities that were previously deferred here have all landed:
+
+| 0.x check | Capability added |
 |---|---|
-| `drupal-db-module` | `examples/drupal-db-module.yml` |
-| `drupal-db-permissions` | `examples/drupal-db-permissions.yml` |
-| `drupal-db-user-tfa` | `examples/drupal-db-user-tfa.yml` |
-| `drupal-admin-user` | `examples/drupal-admin-user.yml` |
-| `drupal-user-forbidden` | `examples/drupal-user-forbidden.yml` |
-| `drupal-role-permissions` | `examples/drupal-role-permissions.yml` |
-| `drupal-user-role` | `examples/drupal-user-role.yml` |
-| `drupal-tracking-code` | `examples/drupal-tracking-code.yml` |
+| `json` | `json:key` fact plugin (RFC 9535 JSONPath) |
+| `filediff` | `file:drift` fact + `drift` analyser — placeholder-masking instead of template rendering |
+| `crawler` | `http:crawl` fact plugin |
+| `sca:application_type` | `file:fingerprint` fact + `detected` analyser |
 
-They all share the collect → assert composition pattern shown in the
+The Drush-based Drupal checks similarly all have worked examples now. They share
+the collect → assert composition pattern shown in the
 [Drush composition recipe](gaps.md#recipe-the-drush-composition-pattern): a
 `command` fact emits data one item per line, and `allowed:list` / `equals`
 makes the assertion.
 
-## New general-purpose capabilities (deferred)
-
-These checks have no existing plugin that can collect the data they need
-(status **Needs new capability** on the gaps matrix). The intended direction is
-to add a **general-purpose, reusable** collect plugin — not a check-specific
-one — so that the new capability serves future recipes too. The exact approach
-for each is **to be determined (TBD)**.
-
-| 0.x check | Missing capability | Direction |
-|---|---|---|
-| `json` | Parse JSON files and extract keys/values | Add a general-purpose `json:key` fact plugin (analogous to `yaml:key`) |
-| `file:diff` | Compare a file against a rendered template and surface the difference | TBD |
-| `crawler` | Crawl a site and collect non-200 responses | TBD |
-| `sca:application_type` | Scan a codebase for framework markers and dependencies | TBD |
-
-These are deferred with no committed timeline.
+Remaining work is therefore **reference documentation quality**, not new
+plugins — several `reference/collect/` and `reference/connection/` pages are
+still title-only stubs, and a few plugins (`http:fetch`, `json:key`, `drift`,
+`detected`) have no reference page at all.
 
 ## Known plugin limitations to investigate
 
-These are defects and gaps found while validating the bundled examples against
-1.x. They are tracked here so the affected examples can be simplified or
-completed once the underlying plugin work lands.
+These are defects found while validating the bundled examples against 1.x. They
+are tracked here so the affected examples can be simplified once the underlying
+plugin work lands.
+
+::: danger Both are panics, not errors
+Each item below crashes the process on operator-supplied config rather than
+reporting a collection error. A malformed or merely unusual config file should
+never panic — these are correctness bugs, not cosmetic ones.
+:::
 
 | Area | Symptom | Direction |
 |---|---|---|
-| `examples/docker.yml` — `base-images` | `docker:images` with `additional-inputs: [buildargs]` fails at collect with `inputFormat required for 'yaml:key'`. | Investigate whether the example needs an explicit `input-format` on the additional input, or whether `docker:images` additional-input handling regressed. The `base-images` block is currently commented/omitted from a runnable path. |
-| `yaml:key` — empty sequence | A role/config file with an empty YAML list (e.g. `permissions: []`) panics in `YamlLookup.ProcessNodes` (index out of range). | Guard the `SequenceNode` case against empty `Content`. |
-| `allowed:list` — multi-file input | `yaml:key` output over a `file:lookup` (map of file → list) produces `map-nested-string` when any file has an empty map, which `allowed:list` does not support; when all files have lists, `allowed:list`'s `map-list-string` branch panics in `AsMapListString` (the fact data is `map[string]interface{}`, not `map[string][]string`). | Make `allowed:list` accept the actual multi-file `yaml:key` data shape (and `map-nested-string`), so a "disallowed permission across all roles" assertion can be expressed without per-role single-file reads. This is why `examples/drupal-config.yml` asserts permissions per-role rather than across all roles at once. |
+| `yaml:key` — empty sequence | A config file with an empty YAML list (e.g. `permissions: []`) panics with `index out of range`. The `SequenceNode` branch indexes `Content[0]` without a length check in **four** places: `YamlLookup.ProcessNodes` (`pkg/fact/yaml/yaml.go:106`, `:122`) and `AliasNodeToData` (`:238`, `:254`). | Guard every `SequenceNode` case against empty `Content`, and emit an empty list rather than panicking. All four sites need the guard, not just the one reached first. |
+| `allowed:list` — multi-file input | `yaml:key` output over a `file:lookup` (map of file → list) panics in `AsMapListString` (`pkg/data/data.go:94`) with `interface conversion: map[string]interface{}, not map[string][]string`, via `allowedlist.go:178`. When any file has an empty map the format instead becomes `map-nested-string`, which `allowed:list` does not handle. | Make `allowed:list` accept the actual multi-file `yaml:key` data shape (and `map-nested-string`), so a "disallowed permission across all roles" assertion can be expressed without per-role single-file reads. This is why `examples/drupal-config.yml` asserts permissions per-role rather than across all roles at once. |
 
 ## How to contribute
 

--- a/docs/src/guide/roadmap.md
+++ b/docs/src/guide/roadmap.md
@@ -81,6 +81,23 @@ never panic — these are correctness bugs, not cosmetic ones.
 | `yaml:key` — empty sequence | A config file with an empty YAML list (e.g. `permissions: []`) panics with `index out of range`. The `SequenceNode` branch indexes `Content[0]` without a length check in **four** places: `YamlLookup.ProcessNodes` (`pkg/fact/yaml/yaml.go:106`, `:122`) and `AliasNodeToData` (`:238`, `:254`). | Guard every `SequenceNode` case against empty `Content`, and emit an empty list rather than panicking. All four sites need the guard, not just the one reached first. |
 | `allowed:list` — multi-file input | `yaml:key` output over a `file:lookup` (map of file → list) panics in `AsMapListString` (`pkg/data/data.go:94`) with `interface conversion: map[string]interface{}, not map[string][]string`, via `allowedlist.go:178`. When any file has an empty map the format instead becomes `map-nested-string`, which `allowed:list` does not handle. | Make `allowed:list` accept the actual multi-file `yaml:key` data shape (and `map-nested-string`), so a "disallowed permission across all roles" assertion can be expressed without per-role single-file reads. This is why `examples/drupal-config.yml` asserts permissions per-role rather than across all roles at once. |
 
+## Candidate composability improvements (unscheduled)
+
+These came out of a review of every bundled example. Unlike the defects above,
+none is a bug — each is an ergonomics improvement where the current composition
+works but reads more verbosely than it should. They are recorded for
+prioritisation and are **not** scheduled.
+
+| Candidate                             | Pain point                                                                                                                                                                                  | Direction                                                                                                                                                                                                                                |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `command` stdout ergonomics           | Nine examples repeat the `bash -c` + `set -o pipefail` + `jq` dance, and eight then need `key: stdout` to select stdout out of a map — an unintuitive extra hop.                            | A `command` option (or thin `command:lines` fact) emitting stdout directly as `FormatListString`, split per line. Highest reuse: it simplifies every Drush recipe at once.                                                               |
+| Collapse `file:read` → `*:key` chains | `required-values.yml`, `regex-match.yml`, `yaml-lookup.yml` and `json-lookup.yml` each wire a `file:read` fact whose only job is to feed `yaml:key`/`json:key`.                             | Let `yaml:key`/`json:key` read a file directly, collapsing two nodes into one. **Note:** `yaml:key` already uses `path:` for the key path within the document (`pkg/fact/yaml/key.go:22`), so this needs a different key (e.g. `file:`). |
+| `string:transform` helper             | `docker.yml` repeats `yaml:key` over `compose-services-nodes` four times and strips image tags with a hard-to-read regex (`package-match: '^(.[^:@]*)?[:@]?([^ latest$]*)'`).               | A small transform helper (strip suffix, split on `:`) so the very common `image:tag` split doesn't need a fragile regex.                                                                                                                 |
+| Named `breach-format` presets         | `domain-in-db-tables.yml` needs a large inline `breach-format` template for readable output. `webforms-tokenised-email-handlers.yml` already works around the repetition with YAML anchors. | A library of named presets (e.g. `key-value-table`). Lowest urgency — YAML anchors already mitigate it.                                                                                                                                  |
+
+The first item is the highest-value, lowest-risk of the four and the natural next
+increment. The remaining three are held pending demonstrated demand.
+
 ## How to contribute
 
 The [gaps matrix](gaps.md) is the source of truth for what remains open.

--- a/docs/src/guide/versions.md
+++ b/docs/src/guide/versions.md
@@ -23,11 +23,22 @@ Not sure if 1.x covers everything you need? Check the
 
 ## How the binary picks a format
 
-When Shipshape reads a config file it tries to parse it as a 1.x config first.
-If any of the top-level 1.x keys (`connections`, `collect`, `analyse`,
-`output`) are present, the file is treated as 1.x and the pipeline runner is
-used. If none of those keys are found, the file is treated as 0.x and the
-checks runner is used.
+The deciding key is **`collect:`**. When Shipshape reads a config file it tries
+to parse it as a 1.x config first: if a **non-empty top-level `collect:` block**
+is present, the file is treated as 1.x and the pipeline runner is used.
+Otherwise the file is treated as 0.x and the checks runner is used.
+
+::: warning `collect:` is the only key that selects 1.x
+`connections:`, `analyse:` and `output:` do **not** on their own make a file
+1.x. A file containing only `analyse:` (or only `output:`) falls through to the
+0.x runner, which finds no `checks:` block and runs zero checks — exiting `0`
+as though everything passed.
+
+Those three keys matter only once a run is already 1.x, where they are used to
+reject a 0.x file passed alongside a 1.x one (see
+[Mixing formats](#mixing-formats-across-files) below). An empty `collect:` block
+does not count either — it must contain at least one fact.
+:::
 
 The distinguishing key is the top-level block name:
 
@@ -41,7 +52,7 @@ checks:
 ```
 
 ```yaml
-# 1.x — identified by any of: connections, collect, analyse, output
+# 1.x — identified by a non-empty top-level "collect:" key
 collect:
   disallowed-php-scripts:
     file:lookup:
@@ -56,14 +67,30 @@ analyse:
       severity: high
 ```
 
-If a file contains both a `checks:` key and a 1.x key, the 1.x runner takes
-precedence.
+If a single file contains both a `checks:` key and a non-empty `collect:` key,
+the 1.x runner takes precedence and the `checks:` block is ignored.
+
+## Mixing formats across files
+
+Passing a 0.x file and a 1.x file to the same run with `-f` is **an error, not a
+merge**:
+
+```sh
+$ shipshape run . -f pipeline.yml -f legacy-checks.yml
+config file "legacy-checks.yml" is not v2-compatible but was provided
+alongside a v2 config; mixing v1 and v2 config files is not supported
+```
+
+Once any file in the run declares a non-empty `collect:`, every other file must
+contain at least one of `connections`, `collect`, `analyse` or `output`. A file
+with none of them is reported rather than silently discarded. Run the two
+formats as separate invocations instead.
 
 ## Format overview
 
 | | 0.x | 1.x |
 |---|---|---|
-| Top-level key | `checks:` | `collect:` / `analyse:` / `output:` |
+| Top-level key | `checks:` | `collect:` (the deciding key) |
 | Config struct | `Config` | `ConfigV2` |
 | Runner | `RunConfig` | `RunV2` |
 | Model | One check per concern — collection, evaluation, and optional remediation bundled together | Composable pipeline — collect data with one plugin, analyse it with another |

--- a/docs/src/reference/README.md
+++ b/docs/src/reference/README.md
@@ -1,29 +1,39 @@
 # Overview
 
+Every plugin registered in the 1.x pipeline is listed below. Pages marked
+*(stub)* exist but are not yet written up — the plugin works, the documentation
+is the gap. Entries with no link have no page yet at all.
 
 ## Connection plugins
 
 The following Connection plugins are available:
-  - [mysql](../reference/connection/mysql)
-  - [docker:exec](../reference/connection/docker-exec)
+  - [mysql](../reference/connection/mysql) *(stub)*
+  - [docker:exec](../reference/connection/docker-exec) *(stub)*
 
 ## Collect plugins
 
 The following Collect/Fact plugins are available:
   - [command](../reference/collect/command)
-  - [database:search](../reference/collect/database-search)
-  - [docker:command](../reference/collect/docker-command)
-  - [docker:images](../reference/collect/docker-images)
-  - [file:lookup](../reference/collect/file-lookup)
-  - [file:read](../reference/collect/file-read)
-  - [file:read:multiple](../reference/collect/file-read-multiple)
+  - [database:search](../reference/collect/database-search) *(stub)*
+  - [docker:command](../reference/collect/docker-command) *(stub)*
+  - [docker:images](../reference/collect/docker-images) *(stub)*
+  - [file:drift](../reference/collect/file-drift) — see also the [`filediff` recipe](../guide/gaps.md#recipe-file-diff)
+  - [file:fingerprint](../reference/collect/file-fingerprint) *(stub)*
+  - [file:lookup](../reference/collect/file-lookup) *(stub)*
+  - [file:read](../reference/collect/file-read) *(stub)*
+  - [file:read:multiple](../reference/collect/file-read-multiple) *(stub)*
+  - [http:crawl](../reference/collect/http-crawl)
+  - [http:fetch](../reference/collect/http-fetch)
+  - [json:key](../reference/collect/json-key) — see also the [`json` recipe](../guide/gaps.md#recipe-json)
   - [static-analysis](../reference/collect/static-analysis)
-  - [yaml:key](../reference/collect/yaml-key)
+  - [yaml:key](../reference/collect/yaml-key) *(stub)*
 
 ## Analyse plugins
 
 The following Analyse plugins are available:
   - [allowed:list](../reference/analyse/allowed-list)
+  - [detected](../reference/analyse/detected) — see also the [`sca:application_type` recipe](../guide/gaps.md#recipe-sca-application-type)
+  - [drift](../reference/analyse/drift) — see also the [`filediff` recipe](../guide/gaps.md#recipe-file-diff)
   - [equals](../reference/analyse/equals)
   - [not:empty](../reference/analyse/not-empty)
   - [not:equals](../reference/analyse/not-equals)
@@ -35,3 +45,9 @@ The following Analyse plugins are available:
 
 The following Remediation plugins are available:
   - [command](../reference/remediate/command)
+
+## Checks (0.x)
+
+The legacy `checks:` format is documented in the
+[Checks reference](../reference/checks/) and the
+[0.x config guide](../guide/0.x.md).

--- a/docs/src/reference/analyse/detected.md
+++ b/docs/src/reference/analyse/detected.md
@@ -1,0 +1,45 @@
+# detected
+
+The `detected` analyser breaches **once per entry** in a map-shaped input,
+whenever that entry is present. It is designed to pair with the
+[`file:fingerprint`](../collect/file-fingerprint.md) fact, where each map entry is
+a detected framework and its likelihood score.
+
+## Plugin fields
+
+`detected` has no plugin-specific fields — there is nothing to configure beyond
+the common ones below.
+
+::: tip No inverse polarity
+Like [`drift`](drift.md), `detected` has no toggle to invert the assertion. The
+presence of an entry is itself the assertion failure, so an empty input passes.
+:::
+
+<Content :page-key="$site.pages.find(p => p.path === '/reference/common/analyse.html').key"/>
+
+## Input format
+
+Requires `map-string` (framework label → score). An empty map produces no
+breaches. Other formats are treated as a no-op.
+
+## Breach output
+
+One `KeyValueBreach` per map entry, labelled `framework` / `likelihood`.
+
+Map keys are **sorted** before breaches are emitted. Go randomises map iteration
+order, and this analyser is typically used with multi-label input (several
+detected frameworks), so without sorting the breach order — and any test
+asserting on it — would be non-deterministic.
+
+## Example
+
+```yaml
+analyse:
+  application-type:
+    detected:
+      description: Detected application frameworks
+      input: app-fingerprint
+```
+
+Source: `examples/app-type.yml` — see also the
+[`sca:application_type` recipe](../../guide/gaps.md#recipe-sca-application-type).

--- a/docs/src/reference/analyse/drift.md
+++ b/docs/src/reference/analyse/drift.md
@@ -1,0 +1,36 @@
+# drift
+
+The `drift` analyser breaches whenever its input is non-empty. It is designed to
+pair with the [`file:drift`](../collect/file-drift.md) fact: any drift content at
+all is itself the assertion failure.
+
+## Plugin fields
+
+`drift` has no plugin-specific fields — there is nothing to configure beyond the
+common ones below.
+
+::: tip No inverse polarity
+Unlike `allowed:list` or `regex:match`, `drift` has no toggle to invert the
+assertion. Drift always means breach.
+:::
+
+<Content :page-key="$site.pages.find(p => p.path === '/reference/common/analyse.html').key"/>
+
+## Example
+
+```yaml
+analyse:
+  ci-matches-template:
+    drift:
+      description: CI workflow has not drifted from the project template
+      input: ci-drift
+```
+
+Source: `examples/file-drift.yml` — see also the
+[`filediff` recipe](../../guide/gaps.md#recipe-file-diff).
+
+## Breach output
+
+Breaches carry the full unified diff via `KeyValuesBreach`, legible in the
+`pretty`, `json` and `junit` renderers. The `table` renderer does **not** wrap
+multi-line breach values, so avoid it for drift checks.

--- a/docs/src/reference/checks/README.md
+++ b/docs/src/reference/checks/README.md
@@ -1,0 +1,53 @@
+---
+title: Checks (0.x)
+---
+# Checks (0.x) reference
+
+These pages document the check types available in the legacy 0.x `checks:`
+format. The format is **fully supported** and continues to run without changes —
+see [Config versions](../../guide/0.x.md) for the format itself.
+
+For new configurations, prefer the 1.x pipeline. The
+[recipe catalogue](../../guide/gaps.md) shows the `collect` + `analyse` chain
+that reproduces each check below.
+
+::: warning Unrecognised check keys are silently ignored
+An unknown key under `checks:` is discarded without warning — the run reports
+zero checks and still exits `0`, which is indistinguishable from a passing build.
+Copy the **Check type** value from each page exactly. Note in particular that
+[`filediff`](file-diff.md) has no colon.
+:::
+
+## File checks
+
+- [`file`](file.md) — assert files matching a pattern are absent
+- [`filediff`](file-diff.md) — assert a file matches a reference template
+
+## YAML / JSON checks
+
+- [`yaml`](yaml.md) — assert key-value pairs in YAML files
+- [`yamllint`](yaml-lint.md) — assert files parse as valid YAML
+- [`json`](json.md) — assert key-value pairs in JSON files
+
+## Drupal checks
+
+- [`drush-yaml`](drupal-drush-yaml.md) — assert Drupal config via Drush
+- [`drupal-file-module`](drupal-file-module.md) — assert modules via filesystem
+- [`drupal-db-module`](drupal-db-module.md) — assert modules via database
+- [`drupal-admin-user`](drupal-admin-user.md) — assert UID 1 roles
+- [`drupal-db-permissions`](drupal-db-permissions.md) — assert role permissions
+- [`drupal-db-user-tfa`](drupal-db-user-tfa.md) — assert users have TFA
+- [`drupal-user-forbidden`](drupal-user-forbidden.md) — assert an account absent
+- [`drupal-role-permissions`](drupal-role-permissions.md) — assert role permissions
+- [`drupal-user-role`](drupal-user-role.md) — assert role holders are allow-listed
+- [`drupal-tracking-code`](drupal-tracking-code.md) — assert tracking code present
+
+## Code quality checks
+
+- [`phpstan`](phpstan.md) — run PHPStan and report issues
+- [`sca:application_type`](sca-application-type.md) — detect application framework
+
+## Infrastructure checks
+
+- [`docker:base_image`](docker-base-image.md) — assert approved base images
+- [`crawler`](crawler.md) — assert pages return HTTP 200

--- a/docs/src/reference/checks/file-diff.md
+++ b/docs/src/reference/checks/file-diff.md
@@ -1,10 +1,17 @@
-# file:diff
+# filediff
 
 Compares a file on disk against a reference template and reports any
 differences. Use this to ensure configuration files have not drifted from a
 known-good baseline.
 
-**Check type:** `file:diff`
+**Check type:** `filediff`
+
+::: warning The check key has no colon
+The registered check type is `filediff`, not `file:diff`. An unrecognised key
+under `checks:` is **silently ignored** — a config written as `file:diff` runs
+zero checks and still exits `0`, which is indistinguishable from a passing
+build. If this check appears to do nothing, verify the key first.
+:::
 
 ## Fields
 
@@ -22,7 +29,7 @@ known-good baseline.
 
 ```yaml
 checks:
-  file:diff:
+  filediff:
     - name: Nginx config matches template
       target: /etc/nginx/nginx.conf
       source: templates/nginx.conf.j2

--- a/docs/src/reference/checks/yaml-lint.md
+++ b/docs/src/reference/checks/yaml-lint.md
@@ -1,0 +1,66 @@
+# yamllint
+
+Asserts that files parse as valid YAML. Unlike [`yaml`](yaml.md), it makes no
+assertions about the *contents* — it only reports files that cannot be decoded.
+Use it as a cheap syntax gate over a directory of config before other checks try
+to read it.
+
+**Check type:** `yamllint`
+
+## Fields
+
+`yamllint` accepts the same file-selection fields as [`yaml`](yaml.md), since it
+embeds the same check:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Label shown in output |
+| `severity` | string | no | `low`, `normal`, `high`, or `critical` (default: `normal`) |
+| `path` | string | one of path/file/files/pattern | Directory to search in |
+| `file` | string | one of path/file/files/pattern | Single file name |
+| `files` | list | one of path/file/files/pattern | Explicit list of file names |
+| `pattern` | string | one of path/file/files/pattern | Regex pattern to match file names |
+| `exclude-pattern` | string | no | Regex pattern — matching files are skipped |
+| `ignore-missing` | bool | no | If `true`, pass instead of failing when a file or path does not exist |
+
+A `values:` list, if supplied, is ignored — this check does not evaluate
+assertions.
+
+## Example
+
+```yaml
+checks:
+  yamllint:
+    - name: Exported config is valid YAML
+      path: config/default
+      pattern: '.*\.yml$'
+```
+
+A single file:
+
+```yaml
+checks:
+  yamllint:
+    - name: CI workflow parses
+      file: .github/workflows/ci.yml
+```
+
+## Behaviour
+
+Each selected file is unmarshalled with `gopkg.in/yaml.v3` into a generic
+`interface{}`. A file that decodes cleanly adds a pass
+(`<file> has valid yaml.`); a file that fails adds a breach. Two breach shapes
+are distinguished:
+
+- **`cannot decode yaml: <file>`** — a `yaml.TypeError`, meaning the document
+  parsed but contained type conflicts. All reported type errors are joined into
+  the breach value.
+- **`yaml error: <file>`** — any other unmarshal error, typically a syntax
+  error. The underlying parser message is the breach value.
+
+The check passes when no file produced a breach.
+
+## Remediation
+
+This check does not support automatic remediation. Fix the reported YAML
+manually.

--- a/docs/src/reference/checks/yaml.md
+++ b/docs/src/reference/checks/yaml.md
@@ -16,9 +16,17 @@ needing a running Drupal instance.
 | `file` | string | one of path/file/files/pattern | Single file name |
 | `files` | list | one of path/file/files/pattern | Explicit list of file names |
 | `pattern` | string | one of path/file/files/pattern | Regex pattern to match file names |
-| `config-name` | string | no | Drupal config name (used with `path` to locate `<config-name>.yml`) |
 | `exclude-pattern` | string | no | Regex pattern — matching files are skipped |
+| `ignore-missing` | bool | no | If `true`, pass instead of failing when a file or path does not exist |
 | `values` | list of [KeyValue](#keyvalue-fields) | yes | Assertions to evaluate |
+
+::: warning `config-name` is not supported by this check
+`config-name` belongs to the Drush-based Drupal checks
+([`drush-yaml`](drupal-drush-yaml.md) and friends), **not** to `yaml`. Setting it
+here has no effect: unknown YAML fields are ignored, so a `yaml` check with only
+`config-name` and `path` resolves no file at all and breaches with
+`no file provided`. Use `file:` (or `files:` / `pattern:`) to name the target.
+:::
 
 ## KeyValue fields
 
@@ -40,14 +48,12 @@ Each entry in `values` supports:
 checks:
   yaml:
     - name: File config check
-      config-name: update.settings
       path: config/default
+      file: update.settings.yml
       values:
         - key: check.interval_days
           value: "7"
 ```
-
-Source: `pkg/config/testdata/shipshape.yml`
 
 Multiple assertions in one check:
 
@@ -56,7 +62,7 @@ checks:
   yaml:
     - name: Cron and update settings
       path: config/default
-      config-name: automated_cron.settings
+      file: automated_cron.settings.yml
       values:
         - key: interval
           value: "10800"
@@ -64,14 +70,30 @@ checks:
           truthy: true
 ```
 
+Across many files by pattern:
+
+```yaml
+checks:
+  yaml:
+    - name: No disallowed permissions on any role
+      path: config/default
+      pattern: '^user\.role\..*\.yml$'
+      values:
+        - key: permissions
+          is-list: true
+          disallowed:
+            - administer site configuration
+```
+
 ## Behaviour
 
 Shipshape locates the target file(s) using the supplied path/file/files/pattern
-fields. For each file, it parses the YAML and evaluates every `values` entry.
+fields, in that precedence order — `file` wins over `files`, which wins over
+`pattern`. For each file it parses the YAML and evaluates every `values` entry.
 Any assertion that fails is reported as a breach.
 
-When `config-name` is set alongside `path`, Shipshape looks for
-`<path>/<config-name>.yml`.
+If none of `file`, `files` or `pattern` is set, the check breaches with
+`no file provided` rather than scanning `path` wholesale.
 
 ## Remediation
 

--- a/docs/src/reference/collect/file-drift.md
+++ b/docs/src/reference/collect/file-drift.md
@@ -1,0 +1,100 @@
+# file:drift
+
+The `file:drift` collect plugin compares a **template** against a **current
+file** and emits the lines that differ, as a unified diff. Placeholder-shaped
+substrings are masked out of both sides before comparing, so the same config runs
+unmodified across every project provisioned from a shared template — no
+per-project variables map required.
+
+It is the 1.x replacement for the 0.x [`filediff`](../checks/file-diff.md) check.
+Unlike `filediff` it does **not** render the template: see
+[why rendering was rejected](../../guide/gaps.md#recipe-file-diff).
+
+## Inputs
+
+`file:drift` is unusual in taking **two** inputs:
+
+| Input | Role | Accepted formats |
+| --- | --- | --- |
+| `input` | The template (the known-good baseline) | `raw`, `string` |
+| `additional-inputs` | The current file being checked — exactly one | `raw`, `string` |
+
+Both typically come from [`file:read`](file-read.md) or
+[`http:fetch`](http-fetch.md).
+
+::: warning Exactly one additional input, and its format is checked
+Supplying zero or more than one `additional-inputs` is a collection error.
+Pointing it at a multi-file fact (e.g. `file:lookup`, which emits `map-bytes`)
+is also rejected rather than silently producing an empty "current" side — which
+would otherwise breach claiming the whole template had been deleted, the worst
+failure mode for an audit tool.
+:::
+
+## Plugin fields
+
+| Field | Description | Required | Default |
+| --- | --- | :---: | :---: |
+| placeholder-pattern | Regex matching placeholders to mask before diffing. | No | <code v-pre>{{\s*(\w+)\s*}}</code> |
+
+<Content :page-key="$site.pages.find(p => p.path === '/reference/common/collect.html').key"/>
+
+## Return format
+
+`list-string` — the unified diff lines (3 lines of context), empty when there is
+no drift. Pair it with the [`drift`](../analyse/drift.md) analyser, which
+breaches whenever the list is non-empty.
+
+## Example
+
+```yaml
+collect:
+  template:
+    http:fetch:
+      url: https://raw.githubusercontent.com/client/project-template/main/.github/workflows/ci.yml
+
+  current:
+    file:read:
+      path: .github/workflows/ci.yml
+
+  ci-drift:
+    file:drift:
+      input: template
+      additional-inputs: [current]
+
+analyse:
+  ci-matches-template:
+    drift:
+      description: CI workflow has not drifted from the project template
+      input: ci-drift
+```
+
+Source: `examples/file-drift.yml`
+
+## Placeholder matching is a wildcard, not a value check
+
+Each placeholder is matched against the current line with a non-greedy `(.*?)`
+capture. `file:drift` therefore confirms that *something* occupies the
+placeholder's position — not that the rest of the line is otherwise identical in
+structure. Consequences worth knowing:
+
+- **A capture can absorb adjacent genuine drift on the same line.** Template
+  <code v-pre>image: {{ IMG }}:v1</code> against current
+  `image: evil/malware:latest:v1` reports no drift, because the wildcard
+  swallows everything up to the literal `:v1`. Keep placeholders on their own
+  line, or as an entire value, wherever the drift you care about could
+  plausibly appear.
+- **A repeated placeholder is not checked for consistency.** RE2 has no
+  backreferences, so <code v-pre>a: {{ X }} b: {{ X }}</code> cannot express
+  "these two captures must match" — current `a: one b: two` reports no drift.
+- **An empty substitution counts as substituted**, not as drift. Only a
+  placeholder still *literally present* in the current file — the
+  copy-paste-and-forgot-to-fill-in bug — is flagged as unsubstituted.
+
+These are inherent to wildcard matching without a rendering step, and are the
+accepted trade-off against a per-project variables map.
+
+## Output rendering
+
+Drift breaches carry a full unified diff via `KeyValuesBreach`, legible in the
+`pretty`, `json` and `junit` renderers. The `table` renderer does **not** wrap
+multi-line breach values, so it is unsuitable for drift checks.

--- a/docs/src/reference/collect/http-fetch.md
+++ b/docs/src/reference/collect/http-fetch.md
@@ -1,0 +1,81 @@
+# http:fetch
+
+The `http:fetch` collect plugin retrieves the content of a remote URL over HTTPS
+and emits it as raw bytes. It is a leaf collector (no `input`) — analogous to
+[`file:read`](file-read.md) but for remote sources, e.g. fetching a template file
+from a public repository to compare against a provisioned project's copy with
+[`file:drift`](file-drift.md).
+
+For crawling a site's link graph rather than fetching a single resource, use
+[`http:crawl`](http-crawl.md).
+
+## Plugin fields
+
+| Field | Description | Required | Default |
+| --- | --- | :---: | :---: |
+| url | The absolute url to fetch. Must include a scheme and host. | Yes | "" |
+| allow-insecure | Permits `http://` urls. Leave unset for production audits — see the ISM-1139 note below. | No | false |
+
+<Content :page-key="$site.pages.find(p => p.path === '/reference/common/collect.html').key"/>
+
+## Return format
+
+`raw` — the response body as bytes. Suitable as input to `file:drift`,
+`yaml:key`, or `json:key`.
+
+## HTTPS required by default
+
+`https://` is required unless `allow-insecure: true` is set. ISM-1139 recommends
+encrypting data in transit, and defaulting to plain HTTP for an
+operator-supplied url risks silently sending audit traffic unencrypted. Set
+`allow-insecure` only for local or CI use against a plain-http test server —
+never for a production target.
+
+## Only unauthenticated URLs are supported
+
+`http:fetch` sends no credentials. Fetching a file from a **private** repository
+is not supported — clone it locally and use [`file:read`](file-read.md) instead.
+
+The error message for a failed fetch says so explicitly, because GitHub returns
+`404` (not `401`/`403`) for an unauthorised private repository, which otherwise
+looks like a wrong path rather than a permissions problem.
+
+## Example
+
+```yaml
+collect:
+  template:
+    http:fetch:
+      url: https://raw.githubusercontent.com/client/project-template/main/.github/workflows/ci.yml
+
+  current:
+    file:read:
+      path: .github/workflows/ci.yml
+
+  ci-drift:
+    file:drift:
+      input: template
+      additional-inputs: [current]
+
+analyse:
+  ci-matches-template:
+    drift:
+      description: CI workflow has not drifted from the project template
+      input: ci-drift
+```
+
+Source: `examples/file-drift.yml`
+
+## Errors
+
+| Condition | Behaviour |
+| --- | --- |
+| `url` not set | Collection error — `http:fetch requires a valid, absolute url` |
+| `url` has no scheme or host | Collection error — same as above |
+| Scheme is not `https` and `allow-insecure` is unset | Collection error — `http:fetch requires an https url; set allow-insecure to permit http` |
+| Non-2xx response or transport failure | Collection error, including the private-repository hint |
+
+::: warning A collection error aborts the run
+Any fact error is fatal — the pipeline never reaches the analyse stage. An
+unreachable url therefore stops the run rather than producing a breach.
+:::

--- a/docs/src/reference/collect/json-key.md
+++ b/docs/src/reference/collect/json-key.md
@@ -1,0 +1,94 @@
+# json:key
+
+The `json:key` collect plugin evaluates an
+[RFC 9535](https://www.rfc-editor.org/rfc/rfc9535.html) JSONPath expression
+against JSON input and emits the matched values. It is the JSON counterpart to
+[`yaml:key`](yaml-key.md), using the JSONPath query language rather than a
+dotted-path lookup.
+
+It takes raw JSON as input — typically from [`file:read`](file-read.md) or
+[`http:fetch`](http-fetch.md).
+
+## Plugin fields
+
+| Field | Description | Required | Default |
+| --- | --- | :---: | :---: |
+| expression | The RFC 9535 JSONPath expression to evaluate against the input. | Yes | "" |
+
+<Content :page-key="$site.pages.find(p => p.path === '/reference/common/collect.html').key"/>
+
+## Return format
+
+The emitted format is derived from the **shape of the match**, mirroring
+`yaml:key`:
+
+| Match | Emitted format |
+| --- | --- |
+| A single scalar | `string` |
+| Multiple scalars | `list-string` |
+| An object | `map-string` |
+| Multiple objects | `list-map-string` |
+| No match | `nil` |
+
+Because a non-match emits nil rather than erroring, `not:empty` can be used to
+assert the *absence* of a value.
+
+This matters when choosing an analyser: `$.name` on a typical `package.json`
+emits a string, so the scalar analysers (`equals`, `not:equals`) apply, whereas
+`$.scripts.*` emits a list and needs `allowed:list` or `not:empty`.
+
+## Expression syntax
+
+`json:key` implements RFC 9535 in full, including:
+
+- Wildcards — `$.scripts.*`
+- Index and slice — `$.items[0]`, `$.items[1:3]`
+- Filters — `$.deps[?@.name=='x'].version` (the RFC form) and the
+  parenthesised `[?(@.name=='x')]`
+- Functions — `length()`, `count()`, `match()`, `search()`
+
+::: tip Dialect differs from `yaml:key`
+`yaml:key` uses an older pre-RFC dialect. It accepts only the parenthesised
+filter form and supports none of the RFC functions. An expression written for
+`json:key` will not necessarily work on `yaml:key` and vice versa.
+:::
+
+## Example
+
+```yaml
+collect:
+  pkg-file:
+    file:read:
+      path: package.json
+
+  script-commands:
+    json:key:
+      input: pkg-file
+      expression: "$.scripts.*"
+
+analyse:
+  approved-script-tooling:
+    allowed:list:
+      description: A script uses an unapproved build tool
+      input: script-commands
+      allowed:
+        - eslint .
+        - vite build
+        - vitest run
+```
+
+Source: `examples/json-lookup.yml` — see also the
+[`json` recipe](../../guide/gaps.md#recipe-json).
+
+## Errors
+
+| Condition | Behaviour |
+| --- | --- |
+| `expression` not set | Collection error — `json:key requires an 'expression'` |
+| Expression is not valid RFC 9535 | Collection error — `invalid JSONPath expression` |
+| Input cannot be decoded as JSON | Collection error — `invalid JSON input` |
+
+::: warning A collection error aborts the run
+Any fact error is fatal — the pipeline never reaches the analyse stage. Malformed
+JSON therefore stops the run rather than producing a breach.
+:::


### PR DESCRIPTION
## Summary
Documentation-only pass over `docs/src` to bring it back in line with the current
1.x code, plus the reference pages that were never written for recently landed
plugins. No Go code is touched.
Base branch: `feature/http-crawl` (stacks on the `http:crawl` fact).
Every behavioural claim in these pages was re-verified against the code — by
targeted `shipshape run` reproductions and by reading the registering source —
rather than trusted from the existing prose. Several of the corrections below are
cases where the docs described behaviour that never existed.
## Corrections to incorrect documentation
- **`filediff` check key.** The docs said `file:diff`. That key is not
  registered, so a config using it is silently ignored and the run executes zero
  checks with no error. Fixed in `reference/checks/file-diff.md`, `guide/0.x.md`
  and the sidebar.
- **1.x/0.x format detection.** `versions.md` and `0.x.md` claimed any of
  `connections:`/`collect:`/`analyse:`/`output:` selects the 1.x format. In fact
  a **non-empty `collect:`** is the only key that does. The mixed-version error is
  now documented.
- **`yaml` check `config-name` field.** `reference/checks/yaml.md` documented a
  `config-name` field that does not exist on the `yaml` check — it belongs to the
  Drush checks. The page's own worked example failed with `no file provided` if
  copied verbatim.
- **Plugin index.** `reference/README.md` was rebuilt from the actual
  `RegisterFactory` calls, adding **6 missing entries**.
- **Stale CLI output.** Regenerated the `run -h` block in `guide/README.md`.
## Stale roadmap claims removed
`roadmap.md` carried two tables claiming `json`, `filediff`, `crawler` and
`sca:application_type` were still deferred with no timeline. All four have
shipped (`json:key`, `file:drift` + `drift`, `http:crawl`, `file:fingerprint` +
`detected`) and are already **Achievable now** on the gaps matrix. The
known-limitations table also still listed the `docker.yml` `base-images` defect,
which is fixed.
The roadmap now states the real position: **18 of 19 registered 0.x checks have a
documented recipe and working example**, and remaining work is reference-doc
quality, not new plugins.
## The one remaining capability gap
`yamllint` is now documented as the single **Needs new capability** gap. It
reports an undecodable YAML file as a breach, but in 1.x a parse failure is a
collect error and any collect error is fatal to the run
(`pkg/shipshape/shipshape.go:171-173`) — so the pipeline never reaches the
analyse stage where the breach would be raised. No 1.x recipe can express it
today. Closing it needs either an analyser that acts on a fact's error state
(`BaseAnalyser` already reads `p.input.GetErrors()`) or an opt-in
"tolerate collect errors" mode.
## Sharpened defect descriptions
The two still-live plugin limitations are now described precisely, and flagged
for what they are — **panics on operator-supplied config, not errors**:
- **`yaml:key` empty sequence.** The `SequenceNode` branch indexes `Content[0]`
  without a length check in **four** places, not the one previously documented:
  `YamlLookup.ProcessNodes` (`pkg/fact/yaml/yaml.go:106`, `:122`) and
  `AliasNodeToData` (`:238`, `:254`). All four need the guard.
- **`allowed:list` multi-file input.** Exact failure mode recorded:
  `interface conversion: map[string]interface{}, not map[string][]string` in
  `AsMapListString` (`pkg/data/data.go:94`) via `allowedlist.go:178`.
## New reference pages
Added pages for plugins that had none: `file:drift`, `http:fetch`, `json:key`,
`detected`, `drift`, and the `yamllint` check — plus a `reference/checks/` index.
## Roadmap: candidate composability improvements
Extracted the pain-point review of every bundled example into a permanent
roadmap section (counts and citations corrected against the current codebase).
These are ergonomics candidates, explicitly **not bugs and not scheduled**:
| Candidate | Why |
|---|---|
| `command` stdout ergonomics | 9 examples repeat the `bash -c` + `pipefail` + `jq` dance; 8 then need `key: stdout`. Highest reuse — simplifies every Drush recipe at once. |
| Collapse `file:read` → `*:key` chains | 4 examples wire a `file:read` whose only job is feeding `yaml:key`/`json:key`. |
| `string:transform` helper | `docker.yml` splits `image:tag` with a fragile regex. |
| Named `breach-format` presets | Lowest urgency — YAML anchors already mitigate. |
## Build fix
`gaps.md` had a pre-existing VuePress build break: unescaped `{{ VAR }}` in prose
is parsed as a Vue template interpolation. Wrapped with `<code v-pre>` in
`gaps.md` and the new `file-drift.md`.
## Verification
- `npm ci && npx vuepress build src` from a clean install — exit 0, 66 pages.
- Targeted `shipshape run` reproductions of every behavioural claim (silent
  no-op on `file:diff`, format-detection selection, `yaml.md` example failure,
  both panics).
## Review notes
Reviewers most usefully check the **behavioural** corrections rather than prose:
the `filediff` key, the format-detection rule in `versions.md`, and the
`yamllint` gap rationale. Those three are where the previous docs were actively
misleading.