### PR TITLE
feat(fact): add yaml:lint fact plugin, closing the yamllint gap

### DIFF
--- a/docs/src/.vuepress/config.js
+++ b/docs/src/.vuepress/config.js
@@ -103,6 +103,7 @@ module.exports = {
                 ['/reference/collect/json-key', 'json:key'],
                 ['/reference/collect/static-analysis', 'static-analysis'],
                 ['/reference/collect/yaml-key', 'yaml:key'],
+                ['/reference/collect/yaml-lint', 'yaml:lint'],
               ]
             },
             {

--- a/docs/src/guide/gaps.md
+++ b/docs/src/guide/gaps.md
@@ -128,7 +128,7 @@ Source: `examples/file-drift.yml`
 | 0.x check | Status | 1.x plugin chain |
 |---|---|---|
 | [`yaml`](../reference/checks/yaml.md) | Achievable now | `file:read` + `yaml:key` + `equals` / `allowed:list` — see `examples/drupal-config.yml` |
-| [`yamllint`](../reference/checks/yaml-lint.md) | Needs new capability | No equivalent — a YAML parse error aborts the run instead of breaching. See [below](#recipe-yamllint-not-yet-reproducible). |
+| [`yamllint`](../reference/checks/yaml-lint.md) | Achievable now | `file:lookup` + `yaml:lint` + `not:empty` — see `examples/yaml-lint.yml` |
 | [`json`](../reference/checks/json.md) | Achievable now | `file:read` + `json:key` + `equals` / `allowed:list` — see `examples/json-lookup.yml` |
 
 ### Recipe: yaml
@@ -157,44 +157,79 @@ analyse:
 
 Source: `examples/drupal-config.yml`
 
-### Recipe: yamllint (not yet reproducible)
+### Recipe: yamllint
 
 `yamllint` asserts only that files *parse*, reporting an undecodable file as a
-breach. 1.x cannot currently express this, because the two are structurally
-opposed: in 1.x a YAML parse failure is a **collect error**, and any collect
-error is fatal to the whole run —
+breach. Reproducing it needed a new building block, because the 0.x check and
+the 1.x pipeline were structurally opposed: in 1.x a YAML parse failure is a
+**collect error**, and any collect error is fatal to the whole run —
 `fact.Manager().CollectAllFacts()` is followed immediately by
-`log.Fatal("failed to collect facts")` (`pkg/shipshape/shipshape.go:171-173`).
+`log.Fatal("failed to collect facts")` (`pkg/shipshape/shipshape.go:171-174`).
+So the exact condition `yamllint` exists to report was the condition that
+prevented 1.x from reaching the analyse stage at all.
 
-So the exact condition `yamllint` exists to report is the condition that
-prevents 1.x from reaching the analyse stage at all:
+[`yaml:lint`](../reference/collect/yaml-lint.md) resolves this by inverting the
+relationship: it treats a parse failure as ordinary **data** — a
+filename-to-error map — rather than as a collection error. `not:empty` then
+breaches once per entry.
 
 ```yaml
-# Aborts with "failed to collect facts" — never produces a breach
 collect:
-  f:
-    file:read:
-      path: bad.yml
-  k:
-    yaml:key:
-      input: f
-      path: a
+  config-files:
+    file:lookup:
+      path: config/default
+      pattern: '.*\.yml$'
+      file-names-only: false   # emit contents (map-bytes), not names
+
+  invalid-yaml:
+    yaml:lint:
+      input: config-files
+
+analyse:
+  yaml-is-valid:
+    not:empty:
+      description: 'YAML files that do not parse'
+      input: invalid-yaml
+      severity: high
+      breach-format:
+        type: key-value
+        key-label: file
+        key: '{{ .Breach.Key }}'
+        value-label: 'YAML error'
+        value: '{{ .Breach.Value }}'
 ```
 
-```
-level=error msg="error looking up yaml path" error="yaml: line 2: mapping values
-  are not allowed in this context" fact=k fact-plugin="yaml:key"
-level=fatal msg="failed to collect facts"
-```
+Source: `examples/yaml-lint.yml`
 
-A fix needs a way to treat a fact's collection error as analysable data rather
-than a fatal condition — for example a `yaml:valid` analyser acting on a fact's
-error state, or an opt-in "tolerate collect errors" mode that lets the pipeline
-continue and surfaces the error to an analyser. `BaseAnalyser` already inspects
-`p.input.GetErrors()` (`pkg/analyse/base.go:92`), so the plumbing partly exists;
-the blocker is the unconditional `log.Fatal` upstream of it.
+File selection is delegated to `file:lookup`, so `path`, `pattern`,
+`exclude-pattern` and `skip-dirs` are inherited rather than reimplemented — but
+note `file-names-only: false` is required, since `yaml:lint` needs file contents
+rather than names.
 
-Until then, keep using the 0.x `yamllint` check. It remains fully supported.
+An alternative design — an opt-in "tolerate collect errors" mode surfacing the
+error via `BaseAnalyser`'s existing `p.input.GetErrors()` handling
+(`pkg/analyse/base.go:92`) — was rejected. A tolerated collect error is
+indistinguishable from genuine misconfiguration: a missing file, an unresolvable
+connection and a malformed document would all arrive as the same "input failure",
+so an operator could not tell the assertion they asked for from a broken config.
+It would also have changed run semantics for every fact, where `yaml:lint` is
+additive.
+
+Three differences from the 0.x check are worth knowing:
+
+- **Multi-document files are fully validated.** 0.x used a single
+  `yaml.Unmarshal`, which stops after the first document, so a file whose later
+  documents were malformed passed silently. `yaml:lint` validates every
+  document by default; set `all-documents: false` for 0.x parity.
+- **No per-file passes.** 0.x added `<file> has valid yaml.` for each valid
+  file. 1.x analysers only emit breaches, so a clean run is a single pass on the
+  analyser rather than one per file.
+- **A missing path is still fatal.** `file:lookup` requires a `pattern` and
+  errors on a nonexistent path, so there is no `ignore-missing` equivalent.
+
+Duplicate keys are reported (as `cannot decode yaml: …`, preserving the 0.x
+label for a `yaml.TypeError`), which is worth knowing because a duplicate key
+silently overrides the earlier value at runtime.
 
 ### Recipe: json
 
@@ -569,12 +604,13 @@ that should not be duplicated into a lower-classification results store.
 
 | Status | Count |
 |---|---|
-| Achievable now | 18 |
+| Achievable now | 19 |
 | Achievable, undocumented | 0 |
-| Needs new capability | 1 |
+| Needs new capability | 0 |
 
-19 rows, one per registered 0.x check type. The single remaining gap is
-[`yamllint`](#recipe-yamllint-not-yet-reproducible), which needs a way to treat a
-fact's collection error as analysable data rather than a fatal error.
+19 rows, one per registered 0.x check type. Every 0.x check now has a documented
+recipe and a working example in `examples/` — the last gap, `yamllint`, closed
+with the [`yaml:lint`](../reference/collect/yaml-lint.md) fact plugin.
 
-The plan for the remaining capabilities is on the [roadmap](roadmap.md) page.
+Remaining work is documentation quality rather than new capability; see the
+[roadmap](roadmap.md).

--- a/docs/src/guide/roadmap.md
+++ b/docs/src/guide/roadmap.md
@@ -30,19 +30,14 @@ documented in the reference and backed by a working file in `examples/`.
 
 The [gaps matrix](gaps.md) is the authoritative record of current status.
 
-## Current status: one capability gap remains
+## Current status: no capability gaps remain
 
-18 of the 19 registered 0.x checks have a documented recipe and a working example
-in `examples/`. The remaining gap is **`yamllint`**: it reports an undecodable
-YAML file as a breach, but in 1.x a parse failure is a collect error, and any
-collect error is fatal to the run (`pkg/shipshape/shipshape.go:171-173`) — so the
-pipeline never reaches the analyse stage where the breach would be raised.
-
-Closing it needs a way to treat a fact's collection error as analysable data
-rather than a fatal condition: either an analyser that acts on a fact's error
-state (`BaseAnalyser` already reads `p.input.GetErrors()`), or an opt-in
-"tolerate collect errors" mode. See
-[Recipe: yamllint](gaps.md#recipe-yamllint-not-yet-reproducible).
+All 19 registered 0.x checks have a documented recipe and a working example in
+`examples/`. The last gap, **`yamllint`**, closed with the `yaml:lint` fact
+plugin: it treats a YAML parse failure as analysable data rather than a collect
+error, so the pipeline reaches the analyse stage instead of aborting at
+`log.Fatal("failed to collect facts")` (`pkg/shipshape/shipshape.go:171-174`).
+See [Recipe: yamllint](gaps.md#recipe-yamllint).
 
 The capabilities that were previously deferred here have all landed:
 
@@ -52,6 +47,7 @@ The capabilities that were previously deferred here have all landed:
 | `filediff` | `file:drift` fact + `drift` analyser — placeholder-masking instead of template rendering |
 | `crawler` | `http:crawl` fact plugin |
 | `sca:application_type` | `file:fingerprint` fact + `detected` analyser |
+| `yamllint` | `yaml:lint` fact plugin — parse failures as data, not fatal errors |
 
 The Drush-based Drupal checks similarly all have worked examples now. They share
 the collect → assert composition pattern shown in the
@@ -60,9 +56,14 @@ the collect → assert composition pattern shown in the
 makes the assertion.
 
 Remaining work is therefore **reference documentation quality**, not new
-plugins — several `reference/collect/` and `reference/connection/` pages are
-still title-only stubs, and a few plugins (`http:fetch`, `json:key`, `drift`,
-`detected`) have no reference page at all.
+plugins. Ten pages are still title-only stubs: `database:search`,
+`docker:command`, `docker:images`, `file:fingerprint`, `file:lookup`,
+`file:read`, `file:read:multiple` and `yaml:key` under `reference/collect/`,
+plus `docker:exec` and `mysql` under `reference/connection/`.
+
+`file:lookup` is the highest-value of these, since several recipes now depend on
+its `file-names-only` field to select between emitting file names and file
+contents.
 
 ## Known plugin limitations to investigate
 

--- a/docs/src/reference/collect/yaml-lint.md
+++ b/docs/src/reference/collect/yaml-lint.md
@@ -1,0 +1,170 @@
+# yaml:lint
+
+The `yaml:lint` collect plugin reports which of its input files **fail to parse
+as YAML**. It makes no assertion about the *contents* of those files — that is
+[`yaml:key`](yaml-key.md)'s job. Use it as a cheap syntax gate over a directory
+of config.
+
+It is the 1.x replacement for the 0.x [`yamllint`](../checks/yaml-lint.md) check.
+
+## Why this plugin exists
+
+Everywhere else in the pipeline a YAML parse failure is a **collection error**,
+and any collection error is fatal — the run aborts with `failed to collect facts`
+before reaching the analyse stage. That makes the exact condition `yamllint`
+reports impossible to express by composing other plugins.
+
+`yaml:lint` inverts that relationship: a parse failure becomes ordinary **data**,
+so an analyser can act on it. This is why the plugin never raises a collection
+error for a malformed document — the only error it raises is genuine
+misconfiguration (an unusable input format), which should still be fatal.
+
+## Inputs
+
+`yaml:lint` accepts a single input in `map-bytes` format — a map of filename to
+file contents.
+
+| Accepted format | Typical source |
+| --- | --- |
+| `map-bytes` | [`file:lookup`](file-lookup.md) with `file-names-only: false` |
+
+File selection is deliberately delegated to `file:lookup`, so `path`, `pattern`,
+`exclude-pattern` and `skip-dirs` are inherited rather than reimplemented.
+
+::: warning `file-names-only` must be false
+`file:lookup` defaults to emitting file *names* (`list-string`). `yaml:lint`
+needs file *contents*, so set `file-names-only: false`. Leaving it at the
+default is rejected at input validation with
+`inputFormat 'list-string' not supported for 'yaml:lint'`.
+:::
+
+## Plugin fields
+
+| Field | Description | Required | Default |
+| --- | --- | :---: | :---: |
+| all-documents | Validate every document in a multi-document (`---`-separated) file rather than only the first. | No | `true` |
+
+<Content :page-key="$site.pages.find(p => p.path === '/reference/common/collect.html').key"/>
+
+## Return format
+
+`map-string` — a map of **filename to parse error**, containing only the files
+that failed. A tree with no invalid files emits an empty map (not nil), so
+[`not:empty`](../analyse/not-empty.md) sees a supported format and simply finds
+nothing to report.
+
+Pair it with `not:empty`, which breaches once per entry.
+
+## Example
+
+```yaml
+collect:
+  config-files:
+    file:lookup:
+      path: config/default
+      pattern: '.*\.yml$'
+      file-names-only: false
+
+  invalid-yaml:
+    yaml:lint:
+      input: config-files
+
+analyse:
+  yaml-is-valid:
+    not:empty:
+      description: 'YAML files that do not parse'
+      input: invalid-yaml
+      severity: high
+      breach-format:
+        type: key-value
+        key-label: file
+        key: '{{ .Breach.Key }}'
+        value-label: 'YAML error'
+        value: '{{ .Breach.Value }}'
+```
+
+Source: `examples/yaml-lint.yml` — see also the
+[`yamllint` recipe](../../guide/gaps.md#recipe-yamllint).
+
+## Error classification
+
+Two message shapes are distinguished, preserving the 0.x breach labels:
+
+| Condition | Message |
+| --- | --- |
+| A `yaml.TypeError` — the document parsed but contained conflicts, e.g. a duplicate key | `cannot decode yaml: <details>` |
+| Any other parse failure — typically a syntax error | The parser message verbatim, e.g. `yaml: line 3: did not find expected ',' or ']'` |
+
+A `TypeError` can aggregate several complaints; all are joined with `; ` rather
+than discarding any.
+
+::: tip Duplicate keys are reported
+`a: 1` followed by `a: 2` is a `TypeError`, not silently accepted. This is worth
+knowing because a duplicate key silently overrides the earlier value at runtime
+— a real defect that is easy to miss in review.
+:::
+
+## Multi-document files
+
+`all-documents` defaults to `true`, which is a **deliberate improvement on 0.x**.
+The 0.x check used a single `yaml.Unmarshal`, which stops after the first
+document — so a file whose *later* documents were malformed passed silently.
+That matters for Kubernetes manifests and any `---`-separated config.
+
+Set `all-documents: false` for bug-for-bug 0.x parity.
+
+::: warning Reported line numbers can be one line early
+Messages come verbatim from `gopkg.in/yaml.v3`, which for an unterminated
+construct reports the line where that construct **opened**, not where parsing
+gave up. An unclosed `[` on line 4 is reported as line 3. This is the library's
+own behaviour — identical between `Unmarshal` and the decoder — and is passed
+through unaltered rather than second-guessed. The 0.x check reported the same
+positions.
+:::
+
+## Errors
+
+| Condition | Behaviour |
+| --- | --- |
+| A file does not parse | **Not an error** — reported as data, which is the point of the plugin |
+| Input format is not `map-bytes` | Rejected at input validation, before collection |
+| Input path does not exist | A `file:lookup` collection error (fatal) — there is no `ignore-missing` equivalent |
+| `pattern` matches zero files | **Passes.** `file:lookup` emits an empty `map-bytes`, so `yaml:lint` emits an empty `map-string`, so `not:empty` finds nothing to breach on |
+
+::: warning A typo'd pattern reports green, not "nothing was checked"
+This is a regression from 0.x, which explicitly breached when `pattern` matched
+no files (`no matching yaml files found`). In 1.x, an existing path with a
+`pattern` that matches nothing is indistinguishable from a directory that is
+genuinely all valid YAML — both produce a passing `not:empty` result. A typo in
+`pattern`, or a directory that has been restructured so the pattern no longer
+matches anything, silently audits zero files rather than surfacing that as a
+problem.
+
+Only the *zero-match* case is affected. A `path` that does not exist at all is
+still a `file:lookup` collection error and remains fatal (see the row above).
+
+If validating that something was checked matters for your use case, assert on
+the underlying `file:lookup` fact directly. There is no generic "list must be
+non-empty" analyser, but if the expected filenames are known in advance,
+`allowed:list` with a `required:` list against `file:lookup`'s `list-string`
+output (`file-names-only` left at its default `true`) breaches
+`required value not found` for any filename absent from the match — including
+when nothing matched at all.
+:::
+
+## Differences from 0.x `yamllint`
+
+| Aspect | 0.x | 1.x |
+| --- | --- | --- |
+| Multi-document files | First document only | All documents by default |
+| Per-file passes | Adds `<file> has valid yaml.` per valid file | Only failures are reported; a clean run is a single pass on the analyser |
+| File selection | `path`/`file`/`files`/`pattern`, plus `ignore-missing` | Delegated to `file:lookup`; `pattern` is required and a missing path is fatal |
+| Zero files matched | Breaches — `no matching yaml files found` | **Passes** — see the warning above |
+
+## Data classification
+
+Breach output carries **file paths and parser messages**, and a parser message
+can quote document content — a duplicate key's name, for example. If the linted
+files hold sensitive configuration, any `output:` sink inherits that
+classification. Treat accordingly where results are written to a lower
+classification store than the audited files.

--- a/examples/testdata/yaml-lint/broken-syntax.yml
+++ b/examples/testdata/yaml-lint/broken-syntax.yml
@@ -1,0 +1,6 @@
+langcode: en
+status: true
+dependencies:
+  module: [node, user
+id: broken_syntax
+label: 'An unclosed flow sequence above makes this file unparseable'

--- a/examples/testdata/yaml-lint/duplicate-keys.yml
+++ b/examples/testdata/yaml-lint/duplicate-keys.yml
@@ -1,0 +1,5 @@
+langcode: en
+status: true
+id: duplicate_keys
+label: 'The status key below is defined twice, silently overriding the first'
+status: false

--- a/examples/testdata/yaml-lint/multi-document.yml
+++ b/examples/testdata/yaml-lint/multi-document.yml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: first-document-is-fine
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: second-document-is-broken
+data:
+  values: [a, b

--- a/examples/testdata/yaml-lint/valid.yml
+++ b/examples/testdata/yaml-lint/valid.yml
@@ -1,0 +1,8 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - user
+id: valid_example
+label: 'A well-formed config file'

--- a/examples/yaml-lint.yml
+++ b/examples/yaml-lint.yml
@@ -1,0 +1,32 @@
+# Assert that YAML files parse - the 1.x equivalent of the 0.x `yamllint` check.
+#
+# `yaml:lint` exists because everywhere else in the pipeline a YAML parse
+# failure is a *collection error*, and any collection error aborts the run
+# before the analyse stage. This plugin treats a parse failure as data
+# instead, so `not:empty` can report it as a breach.
+#
+# File selection is delegated to `file:lookup` with `file-names-only: false`,
+# which emits file contents (map-bytes) rather than names.
+collect:
+  config-files:
+    file:lookup:
+      path: yaml-lint
+      pattern: '.*\.yml$'
+      file-names-only: false
+
+  invalid-yaml:
+    yaml:lint:
+      input: config-files
+
+analyse:
+  yaml-is-valid:
+    not:empty:
+      description: 'YAML files that do not parse'
+      input: invalid-yaml
+      severity: high
+      breach-format:
+        type: key-value
+        key-label: file
+        key: '{{ .Breach.Key }}'
+        value-label: 'YAML error'
+        value: '{{ .Breach.Value }}'

--- a/pkg/fact/yaml/lint.go
+++ b/pkg/fact/yaml/lint.go
@@ -1,0 +1,187 @@
+package yaml
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
+
+	"github.com/salsadigitalauorg/shipshape/pkg/data"
+	"github.com/salsadigitalauorg/shipshape/pkg/fact"
+	"github.com/salsadigitalauorg/shipshape/pkg/plugin"
+)
+
+// typeErrorPrefix labels a *yaml.TypeError, distinguishing a document that
+// parsed but contained conflicting/duplicate entries from an outright syntax
+// error. It mirrors the two breach shapes the 0.x yamllint check reported
+// (pkg/checks/yaml/yamllintcheck.go), which are preserved here so migrated
+// configs surface a recognisable message.
+const typeErrorPrefix = "cannot decode yaml: "
+
+// Lint reports which of its input files fail to parse as YAML.
+//
+// It inverts the usual fact/error relationship: everywhere else in the
+// pipeline a YAML parse failure is a *collection error*, and any collection
+// error is fatal to the run (pkg/shipshape/shipshape.go), so the pipeline
+// never reaches an analyser. That makes the exact condition the 0.x yamllint
+// check exists to report unreachable in 1.x. yaml:lint therefore treats a
+// parse failure as ordinary *data* - a file->message map - so an analyser can
+// act on it. That inversion is the whole point of the plugin, and it is why
+// Collect never calls AddErrors for a malformed document; the only errors it
+// raises are genuine misconfiguration (an unusable input format), which
+// should stay fatal.
+//
+// Emits FormatMapString containing only the failures, so an entirely valid
+// tree emits an empty map. Pairs with the not:empty analyser, which breaches
+// once per entry.
+type Lint struct {
+	fact.BaseFact `yaml:",inline"`
+
+	// AllDocuments validates every document in a multi-document
+	// ('---'-separated) file rather than only the first. Defaults to true,
+	// which is a deliberate improvement on 0.x: that check used a single
+	// yaml.Unmarshal, which stops after the first document and so silently
+	// passed a file whose later documents were malformed. Set false for
+	// bug-for-bug 0.x parity.
+	//
+	// A pointer so an operator explicitly setting 'false' is
+	// distinguishable from the field being absent, matching how
+	// IgnoreMissing is handled on the 0.x yaml checks.
+	AllDocuments *bool `yaml:"all-documents"`
+}
+
+//go:generate go run ../../../cmd/gen.go fact-plugin --package=yaml
+
+func init() {
+	fact.Manager().RegisterFactory("yaml:lint", func(n string) fact.Facter {
+		return NewLint(n)
+	})
+}
+
+func NewLint(id string) *Lint {
+	allDocuments := true
+	return &Lint{
+		BaseFact: fact.BaseFact{
+			BasePlugin: plugin.BasePlugin{
+				Id: id,
+			},
+		},
+		AllDocuments: &allDocuments,
+	}
+}
+
+func (p *Lint) GetName() string {
+	return "yaml:lint"
+}
+
+// SupportedInputFormats accepts only FormatMapBytes, the format emitted by
+// file:lookup with 'file-names-only: false'. Delegating file selection to
+// file:lookup means yaml:lint inherits path/pattern/exclude-pattern/skip-dirs
+// rather than reimplementing them.
+func (p *Lint) SupportedInputFormats() (plugin.SupportLevel, []data.DataFormat) {
+	return plugin.SupportRequired, []data.DataFormat{data.FormatMapBytes}
+}
+
+// allDocuments resolves the AllDocuments setting, defaulting to true when the
+// field is absent. A Lint built by yaml.Unmarshal rather than NewLint (as the
+// fact manager does when a config omits the key) leaves the pointer nil.
+func (p *Lint) allDocuments() bool {
+	return p.AllDocuments == nil || *p.AllDocuments
+}
+
+func (p *Lint) Collect() {
+	contextLogger := log.WithFields(log.Fields{
+		"fact-plugin": p.GetName(),
+		"fact":        p.GetId(),
+	})
+
+	contextLogger.WithFields(log.Fields{
+		"input":         p.GetInputName(),
+		"input-plugin":  p.GetInput().GetName(),
+		"input-format":  p.GetInput().GetFormat(),
+		"all-documents": p.allDocuments(),
+	}).Debug("collecting data")
+
+	switch p.GetInput().GetFormat() {
+	case data.FormatMapBytes:
+		inputData := data.AsMapBytes(p.GetInput().GetData())
+
+		// Always emit map-string, even for no input or an all-valid tree, so
+		// not:empty sees a supported (empty) format rather than logging an
+		// unsupported-format error.
+		invalid := map[string]string{}
+		for f, src := range inputData {
+			if msg, ok := p.validate(src); !ok {
+				invalid[f] = msg
+			}
+		}
+
+		contextLogger.WithFields(log.Fields{
+			"files-checked": len(inputData),
+			"files-invalid": len(invalid),
+		}).Debug("linted yaml")
+
+		p.Format = data.FormatMapString
+		p.SetData(invalid)
+
+	default:
+		contextLogger.WithField("format", p.GetInput().GetFormat()).
+			Error("unsupported input format")
+		p.AddErrors(fmt.Errorf("unsupported input format %s", p.GetInput().GetFormat()))
+	}
+}
+
+// validate reports whether src parses as YAML, returning a formatted message
+// if not. Decoding into interface{} keeps this a pure syntax gate, making no
+// assertion about the document's contents - that is yaml:key's job.
+//
+// Returns ok=false with the message when src is invalid.
+//
+// Note on line numbers: the message comes verbatim from gopkg.in/yaml.v3,
+// which for an unterminated construct reports the line where that construct
+// *opened* rather than where parsing gave up. An unclosed '[' on line 4 of a
+// 6-line file is reported as line 3. This is the library's behaviour and is
+// identical between Unmarshal and Decoder (verified), so it is passed through
+// unaltered rather than "corrected" - second-guessing the parser's own
+// position would be guesswork, and the message is still enough to locate the
+// fault. The 0.x check passed the same messages through.
+func (p *Lint) validate(src []byte) (string, bool) {
+	if !p.allDocuments() {
+		var ifc interface{}
+		if err := yaml.Unmarshal(src, &ifc); err != nil {
+			return formatErr(err), false
+		}
+		return "", true
+	}
+
+	// A decoder loop reaches every document in a '---'-separated file.
+	// yaml.Unmarshal would return after the first, so a malformed later
+	// document would go unreported.
+	dec := yaml.NewDecoder(bytes.NewReader(src))
+	for {
+		var ifc interface{}
+		err := dec.Decode(&ifc)
+		if errors.Is(err, io.EOF) {
+			return "", true
+		}
+		if err != nil {
+			return formatErr(err), false
+		}
+	}
+}
+
+// formatErr renders a parse error as a single-line message, preserving the
+// 0.x distinction between a type error and any other parse failure. A
+// *yaml.TypeError aggregates several messages, which are joined rather than
+// dropped so every conflict in the document is reported.
+func formatErr(err error) string {
+	var typeErr *yaml.TypeError
+	if errors.As(err, &typeErr) {
+		return typeErrorPrefix + strings.Join(typeErr.Errors, "; ")
+	}
+	return err.Error()
+}

--- a/pkg/fact/yaml/lint_test.go
+++ b/pkg/fact/yaml/lint_test.go
@@ -1,0 +1,351 @@
+package yaml_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/salsadigitalauorg/shipshape/pkg/data"
+	"github.com/salsadigitalauorg/shipshape/pkg/fact"
+	. "github.com/salsadigitalauorg/shipshape/pkg/fact/yaml"
+	"github.com/salsadigitalauorg/shipshape/pkg/internal"
+	"github.com/salsadigitalauorg/shipshape/pkg/plugin"
+)
+
+func TestLintInit(t *testing.T) {
+	assert := assert.New(t)
+
+	// Test that the yaml:lint plugin is registered.
+	factPlugin := fact.Manager().GetFactories()["yaml:lint"]("testLintYaml")
+	assert.NotNil(factPlugin)
+	lintFacter, ok := factPlugin.(*Lint)
+	assert.True(ok)
+	assert.Equal("testLintYaml", lintFacter.GetId())
+}
+
+func TestLintPluginName(t *testing.T) {
+	lint := NewLint("testLintYaml")
+	assert.Equal(t, "yaml:lint", lint.GetName())
+}
+
+func TestLintSupportedConnections(t *testing.T) {
+	lint := NewLint("testLintYaml")
+	supportLevel, connections := lint.SupportedConnections()
+	assert.Equal(t, plugin.SupportNone, supportLevel)
+	assert.Empty(t, connections)
+}
+
+func TestLintSupportedInputFormats(t *testing.T) {
+	lint := NewLint("testLintYaml")
+	supportLevel, inputFormats := lint.SupportedInputFormats()
+	assert.Equal(t, plugin.SupportRequired, supportLevel)
+	assert.ElementsMatch(t, []data.DataFormat{data.FormatMapBytes}, inputFormats)
+}
+
+// TestLintAllDocumentsDefault asserts the constructor opts in to
+// multi-document validation, since that is the documented default and the
+// behaviour that diverges from 0.x.
+func TestLintAllDocumentsDefault(t *testing.T) {
+	lint := NewLint("testLintYaml")
+	assert.NotNil(t, lint.AllDocuments)
+	assert.True(t, *lint.AllDocuments)
+}
+
+func TestLintCollect(t *testing.T) {
+	tests := []internal.FactCollectTest{
+		{
+			Name:               "noInput",
+			Facter:             NewLint("invalid-yaml"),
+			ExpectedInputError: &plugin.ErrSupportRequired{SupportType: "input"},
+		},
+		{
+			Name: "noInput/nameProvided",
+			FactFn: func() fact.Facter {
+				f := NewLint("invalid-yaml")
+				f.SetInputName("test-input")
+				return f
+			},
+			ExpectedInputError: &plugin.ErrSupportRequired{SupportType: "input"},
+		},
+		// An unsupported format is rejected by ValidateInput before Collect
+		// runs (pkg/fact/base.go:173-184), so the plugin's own default branch
+		// is defensive only. Asserting the input error here documents where
+		// the rejection actually happens.
+		{
+			Name: "inputFormat/unsupported",
+			FactFn: func() fact.Facter {
+				f := NewLint("invalid-yaml")
+				f.SetInputName("test-input")
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatRaw, Data: []byte("foo: bar")},
+			ExpectedInputError: &plugin.ErrSupportNone{
+				Plugin:        "yaml:lint",
+				SupportType:   "inputFormat",
+				SupportPlugin: string(data.FormatRaw)},
+		},
+
+		// A valid tree emits an empty map rather than nil, so not:empty sees a
+		// supported format and simply finds nothing to breach on.
+		{
+			Name: "allValid",
+			FactFn: func() fact.Facter {
+				f := NewLint("invalid-yaml")
+				f.SetInputName("test-input")
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatMapBytes,
+				Data: map[string][]byte{
+					"a.yml": []byte("foo: bar\n"),
+					"b.yml": []byte("baz:\n  - one\n  - two\n"),
+				},
+			},
+			ExpectedFormat: data.FormatMapString,
+			ExpectedData:   map[string]string{},
+		},
+		{
+			Name: "emptyInput",
+			FactFn: func() fact.Facter {
+				f := NewLint("invalid-yaml")
+				f.SetInputName("test-input")
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatMapBytes,
+				Data:       map[string][]byte{},
+			},
+			ExpectedFormat: data.FormatMapString,
+			ExpectedData:   map[string]string{},
+		},
+		// An empty file is valid YAML (decodes to nil), matching 0.x.
+		{
+			Name: "emptyFileIsValid",
+			FactFn: func() fact.Facter {
+				f := NewLint("invalid-yaml")
+				f.SetInputName("test-input")
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatMapBytes,
+				Data:       map[string][]byte{"empty.yml": []byte("")},
+			},
+			ExpectedFormat: data.FormatMapString,
+			ExpectedData:   map[string]string{},
+		},
+
+		// A parse failure must be data, never a collection error - otherwise
+		// the run would abort before reaching the analyse stage, which is the
+		// gap this plugin exists to close.
+		{
+			Name: "syntaxError",
+			FactFn: func() fact.Facter {
+				f := NewLint("invalid-yaml")
+				f.SetInputName("test-input")
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatMapBytes,
+				Data: map[string][]byte{
+					"good.yml": []byte("foo: bar\n"),
+					"bad.yml":  []byte("foo: [unclosed\n"),
+				},
+			},
+			ExpectedFormat: data.FormatMapString,
+			ExpectedData: map[string]string{
+				"bad.yml": "yaml: line 1: did not find expected ',' or ']'",
+			},
+		},
+		{
+			Name: "mappingValuesNotAllowed",
+			FactFn: func() fact.Facter {
+				f := NewLint("invalid-yaml")
+				f.SetInputName("test-input")
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatMapBytes,
+				Data:       map[string][]byte{"bad.yml": []byte("a: b: c\n")},
+			},
+			ExpectedFormat: data.FormatMapString,
+			ExpectedData: map[string]string{
+				"bad.yml": "yaml: mapping values are not allowed in this context",
+			},
+		},
+		// Duplicate keys surface as *yaml.TypeError, which carries the 0.x
+		// "cannot decode yaml: " prefix rather than the bare parser message.
+		{
+			Name: "duplicateKeysAreTypeError",
+			FactFn: func() fact.Facter {
+				f := NewLint("invalid-yaml")
+				f.SetInputName("test-input")
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatMapBytes,
+				Data:       map[string][]byte{"dupe.yml": []byte("a: 1\na: 2\n")},
+			},
+			ExpectedFormat: data.FormatMapString,
+			ExpectedData: map[string]string{
+				"dupe.yml": `cannot decode yaml: line 2: mapping key "a" already defined at line 1`,
+			},
+		},
+		{
+			Name: "multipleInvalidFiles",
+			FactFn: func() fact.Facter {
+				f := NewLint("invalid-yaml")
+				f.SetInputName("test-input")
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatMapBytes,
+				Data: map[string][]byte{
+					"ok.yml":  []byte("foo: bar\n"),
+					"one.yml": []byte("foo: [unclosed\n"),
+					"two.yml": []byte("a: 1\na: 2\n"),
+					"tab.yml": []byte("a:\n\tb: 1\n"),
+				},
+			},
+			ExpectedFormat: data.FormatMapString,
+			ExpectedData: map[string]string{
+				"one.yml": "yaml: line 1: did not find expected ',' or ']'",
+				"two.yml": `cannot decode yaml: line 2: mapping key "a" already defined at line 1`,
+				"tab.yml": "yaml: line 2: found character that cannot start any token",
+			},
+		},
+
+		// Multi-document handling: the error is in the SECOND document, so
+		// only the decoder loop finds it. This is the deliberate divergence
+		// from 0.x's single yaml.Unmarshal.
+		//
+		// The reported line (2) is one less than the file line (3): yaml.v3
+		// reports where the unclosed '[' opened. Asserted verbatim so a
+		// change in the library's positions is caught rather than masked.
+		{
+			Name: "multiDocument/lateErrorCaughtByDefault",
+			FactFn: func() fact.Facter {
+				f := NewLint("invalid-yaml")
+				f.SetInputName("test-input")
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatMapBytes,
+				Data: map[string][]byte{
+					"multi.yml": []byte("a: 1\n---\nb: [unclosed\n"),
+				},
+			},
+			ExpectedFormat: data.FormatMapString,
+			ExpectedData: map[string]string{
+				"multi.yml": "yaml: line 2: did not find expected ',' or ']'",
+			},
+		},
+		{
+			Name: "multiDocument/lateErrorMissedWhenDisabled",
+			FactFn: func() fact.Facter {
+				f := NewLint("invalid-yaml")
+				f.SetInputName("test-input")
+				allDocs := false
+				f.AllDocuments = &allDocs
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatMapBytes,
+				Data: map[string][]byte{
+					"multi.yml": []byte("a: 1\n---\nb: [unclosed\n"),
+				},
+			},
+			ExpectedFormat: data.FormatMapString,
+			ExpectedData:   map[string]string{},
+		},
+		{
+			Name: "multiDocument/allValid",
+			FactFn: func() fact.Facter {
+				f := NewLint("invalid-yaml")
+				f.SetInputName("test-input")
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatMapBytes,
+				Data: map[string][]byte{
+					"multi.yml": []byte("a: 1\n---\nb: 2\n---\nc: 3\n"),
+				},
+			},
+			ExpectedFormat: data.FormatMapString,
+			ExpectedData:   map[string]string{},
+		},
+		// An error in the FIRST document is found regardless of the
+		// all-documents setting; the pair below asserts both paths agree.
+		{
+			Name: "multiDocument/firstDocError",
+			FactFn: func() fact.Facter {
+				f := NewLint("invalid-yaml")
+				f.SetInputName("test-input")
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatMapBytes,
+				Data: map[string][]byte{
+					"multi.yml": []byte("a: [unclosed\n---\nb: 2\n"),
+				},
+			},
+			ExpectedFormat: data.FormatMapString,
+			ExpectedData: map[string]string{
+				"multi.yml": "yaml: line 1: did not find expected ',' or ']'",
+			},
+		},
+		// An error in the first document is found either way.
+		{
+			Name: "multiDocument/earlyErrorFoundWhenDisabled",
+			FactFn: func() fact.Facter {
+				f := NewLint("invalid-yaml")
+				f.SetInputName("test-input")
+				allDocs := false
+				f.AllDocuments = &allDocs
+				return f
+			},
+			TestInput: internal.FactInputTest{
+				DataFormat: data.FormatMapBytes,
+				Data: map[string][]byte{
+					"multi.yml": []byte("a: [unclosed\n---\nb: 2\n"),
+				},
+			},
+			ExpectedFormat: data.FormatMapString,
+			ExpectedData: map[string]string{
+				"multi.yml": "yaml: line 1: did not find expected ',' or ']'",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			internal.TestFactCollect(t, tt)
+		})
+	}
+}
+
+// TestLintAllDocumentsNilDefaultsTrue covers a Lint built by the fact
+// manager's yaml.Unmarshal path rather than NewLint: a config that omits
+// 'all-documents' leaves the pointer nil, which must still validate every
+// document.
+func TestLintAllDocumentsNilDefaultsTrue(t *testing.T) {
+	internal.TestFactCollect(t, internal.FactCollectTest{
+		Name: "allDocumentsNil",
+		FactFn: func() fact.Facter {
+			f := NewLint("invalid-yaml")
+			f.SetInputName("test-input")
+			f.AllDocuments = nil
+			return f
+		},
+		TestInput: internal.FactInputTest{
+			DataFormat: data.FormatMapBytes,
+			Data: map[string][]byte{
+				"multi.yml": []byte("a: 1\n---\nb: [unclosed\n"),
+			},
+		},
+		ExpectedFormat: data.FormatMapString,
+		ExpectedData: map[string]string{
+			"multi.yml": "yaml: line 2: did not find expected ',' or ']'",
+		},
+	})
+}

--- a/tests/e2e/examples_test.go
+++ b/tests/e2e/examples_test.go
@@ -162,6 +162,33 @@ func selfContainedCases() []selfContainedCase {
 				{name: "wordpress-project-frameworks", status: "Pass", checkType: "detected"},
 			},
 		},
+		{
+			name:         "yaml-lint",
+			file:         "yaml-lint.yml",
+			wantChecks:   1,
+			wantBreaches: 3,
+			wantSeverity: map[string]int{"high": 3},
+			wantPolicies: map[string][]string{"not:empty": {"yaml-is-valid"}},
+			// The decisive assertion for this example is that the run
+			// COMPLETES and reports breaches at all. A YAML parse failure is a
+			// collection error everywhere else in the pipeline, and collection
+			// errors are fatal (pkg/shipshape/shipshape.go), so before
+			// yaml:lint existed this config would have aborted with "failed to
+			// collect facts" and produced no JSON to decode.
+			//
+			// Three of the four fixtures breach: broken-syntax.yml (unclosed
+			// flow sequence), duplicate-keys.yml (a *yaml.TypeError, hence the
+			// "cannot decode yaml:" prefix) and multi-document.yml, whose
+			// error is in its SECOND document - caught only because
+			// all-documents defaults to true. valid.yml does not breach.
+			//
+			// Breach order is not asserted: not:empty iterates its input map
+			// without sorting, so the order of the three breaches varies
+			// between runs.
+			checkResults: []wantResult{
+				{name: "yaml-is-valid", status: "Fail", checkType: "not:empty", breachCount: 3},
+			},
+		},
 	}
 }
 
@@ -246,4 +273,48 @@ func TestSelfContainedExitCodes(t *testing.T) {
 // do not cause a non-zero exit under the default configuration.
 func hasHighSeverityBreach(tc selfContainedCase) bool {
 	return tc.wantSeverity["high"] > 0
+}
+
+// TestYamlLintReportsInsteadOfAborting asserts the specific behaviour the
+// yaml:lint plugin exists to provide, which the aggregate assertions in
+// TestSelfContainedExamples cannot express on their own:
+//
+//  1. The run does NOT abort. Malformed YAML is a fatal collection error
+//     everywhere else in the pipeline, so the regression this guards against is
+//     a return to "failed to collect facts" with no results at all.
+//  2. The RIGHT files are reported - in particular multi-document.yml, whose
+//     syntax error is in its second document and is therefore invisible to a
+//     single yaml.Unmarshal (what 0.x yamllint did).
+//  3. valid.yml is NOT reported, so the plugin is not simply failing everything.
+func TestYamlLintReportsInsteadOfAborting(t *testing.T) {
+	t.Parallel()
+
+	res := runExample(t, stagedTestdata(t), "yaml-lint.yml", "json")
+
+	require.NotContains(t, string(res.Stderr), "failed to collect facts",
+		"malformed YAML must be analysable data, not a fatal collect error")
+
+	rl := res.DecodeJSON(t)
+	got, ok := findResult(rl, "yaml-is-valid")
+	require.True(t, ok, "yaml-is-valid result not found")
+
+	reported := map[string]string{}
+	for _, b := range got.Breaches {
+		key, _ := b["key"].(string)
+		value, _ := b["value"].(string)
+		reported[key] = value
+	}
+
+	assert.Contains(t, reported, "yaml-lint/broken-syntax.yml")
+	assert.Contains(t, reported, "yaml-lint/duplicate-keys.yml")
+	assert.Contains(t, reported, "yaml-lint/multi-document.yml",
+		"an error in a later document must be caught: all-documents defaults to true")
+	assert.NotContains(t, reported, "yaml-lint/valid.yml",
+		"a well-formed file must not be reported")
+
+	// A *yaml.TypeError keeps the 0.x "cannot decode yaml:" prefix, which
+	// distinguishes it from a plain syntax error.
+	assert.Contains(t, reported["yaml-lint/duplicate-keys.yml"], "cannot decode yaml:")
+	assert.Contains(t, reported["yaml-lint/duplicate-keys.yml"], `mapping key "status" already defined`)
+	assert.NotContains(t, reported["yaml-lint/broken-syntax.yml"], "cannot decode yaml:")
 }


### PR DESCRIPTION
A YAML parse failure is a collect error everywhere else in the pipeline, and any collect error is fatal - so the exact condition the 0.x yamllint check reports was previously unreachable in 1.x. yaml:lint inverts that: a parse failure becomes analysable data (a filename->error map) instead of aborting the run, so not:empty can breach on it.

Validates every document in a multi-document file by default (gated behind all-documents), fixing a silent 0.x gap where a single yaml.Unmarshal only checked the first document.

Also documents a known regression versus 0.x: a pattern matching zero files now passes rather than breaching, since file:lookup delegates file selection.